### PR TITLE
ci: add Cargo fmt step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: glslang/setup-masm@v1
       - name: Install Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Cargo fmt
+        run: |
+          rustup component add rustfmt
+          cargo fmt --all -- --check
       - name: Build
         run: cargo build --verbose
       - name: Test


### PR DESCRIPTION
- Introduce a new step in the CI workflow to format Rust code using `cargo fmt`.
- Ensure that the Rust formatting tool is installed as part of the CI process.