### PR TITLE
feat(win32k): add function to retrieve function address from module

### DIFF
--- a/src/win32k.rs
+++ b/src/win32k.rs
@@ -147,6 +147,12 @@ pub fn get_function_address(dll_name: &str, function_name: &str) -> *mut c_void 
         let h_module = GetModuleHandleA(PCSTR(format!("{}\0", dll_name).as_ptr()))
             .expect("[-] Failed to get module handle");
 
+        get_function_address_from_module(h_module, function_name)
+    }
+}
+
+pub fn get_function_address_from_module(h_module: HMODULE, function_name: &str) -> *mut c_void {
+    unsafe {
         let proc_addr = GetProcAddress(h_module, PCSTR(format!("{}\0", function_name).as_ptr()))
             .expect("[-] Failed to get function address");
 


### PR DESCRIPTION
- Introduced `get_function_address_from_module` to retrieve the address of a specified function from a given module handle.
- Enhanced the existing `get_function_address` function to utilize the new function for improved modularity and clarity.