### PR TITLE
feat(rop): add macro for concatenating ROP chains to buffer

### DIFF
--- a/src/rop.rs
+++ b/src/rop.rs
@@ -28,6 +28,19 @@ macro_rules! create_rop_chain_to_buffer {
     }};
 }
 
+#[macro_export]
+macro_rules! concat_rop_chain_to_buffer {
+    ($buffer:expr, $($chain:expr),+ $(,)?) => {{
+        let mut total_offset = 0;b
+        $(
+            let chain_bytes = $chain;
+            $buffer[total_offset..total_offset + chain_bytes.len()].copy_from_slice(&chain_bytes);
+            total_offset += chain_bytes.len();
+        )*
+        total_offset // Return total bytes written
+    }};
+}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ImageFileHeader {


### PR DESCRIPTION
- Introduced `concat_rop_chain_to_buffer` macro to efficiently combine multiple ROP chains into a single buffer
- Allows flexible concatenation of ROP chains with automatic offset tracking and copying