### PR TITLE
chore(deps): bump windows and dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ shellcode_fallback = []
 
 [dependencies]
 byte-strings = "0.3.1"
-goblin = "0.9.2"
+goblin = "0.9.3"
 hex = "0.4.3"
-thiserror = "2.0.8"
-windows-core = "0.59.0"
-windows-strings = "0.3.0"
+thiserror = "2.0.12"
+windows-core = "0.60.1"
+windows-strings = "0.3.1"
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",


### PR DESCRIPTION
- Updated goblin from 0.9.2 to 0.9.3
- Updated thiserror from 2.0.8 to 2.0.12
- Updated windows-core from 0.59.0 to 0.60.1
- Updated windows-strings from 0.3.0 to 0.3.1
- Updated windows crate from 0.59.0 to 0.60.0