### PR TITLE
ci: integrate Miri for undefined behavior detection

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,34 @@
+# Miri: Rust undefined behavior detector
+# Runs tests under the Miri interpreter to catch UB, invalid memory access,
+# and unsafe code issues that normal test runs cannot detect.
+
+name: Miri
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  workflow_dispatch:
+
+jobs:
+  miri:
+    name: Miri
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: microsoft/setup-msbuild@v3
+      - uses: glslang/setup-masm@v1.2
+        with:
+          vs-architecture: x64
+      - name: Install nightly Rust with Miri
+        run: |
+          rustup toolchain install nightly --component miri,rust-src
+          rustup override set nightly
+      - name: Setup Miri sysroot
+        run: cargo miri setup
+      - name: Run Miri
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-ignore-leaks"
+        run: cargo miri test --verbose

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -12,6 +12,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   miri:
     name: Miri

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -325,6 +325,7 @@ impl<'a> Breakpoint<'a> {
 mod tests {
     use super::*;
 
+    #[cfg(not(miri))]
     #[test]
     fn test_create_debug_engine() {
         // Create new debug engine instance


### PR DESCRIPTION
Add a Miri GitHub Actions workflow that runs the test suite under the
Miri interpreter on nightly Rust to catch UB and unsafe code issues.
Mark the debug engine test with #[cfg(not(miri))] since it invokes
Windows COM FFI which Miri cannot execute.

https://claude.ai/code/session_0161bMcXJJu5pWtxdX8Xtzjv