### PR TITLE
ci: cache cargo registry and use pre-built nextest binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
           vs-architecture: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
       - name: Install Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}-${{ matrix.toolchain }}
       - name: Cargo fmt
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
       - name: Cargo update
         run: cargo update
-      - name: Install cargo-nextest
-        run: cargo install cargo-nextest --locked
+      - uses: taiki-e/install-action@nextest
       - name: Build
         run: |
           echo "=== Starting Rust build ==="


### PR DESCRIPTION
Replace `cargo install cargo-nextest --locked` with taiki-e/install-action
which downloads a pre-built nextest binary instead of compiling from source.
Add Swatinem/rust-cache to cache the cargo registry and build artifacts
across runs.

https://claude.ai/code/session_01EVGjCzKRDTgPEw6dJBekwJ