### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `.github/workflows/ci.yml` and `.github/workflows/coverage.yml`
- Resolves open CodeQL `actions/missing-workflow-permissions` alerts ([#4](https://github.com/glslang/win-kexp/security/code-scanning/4), [#5](https://github.com/glslang/win-kexp/security/code-scanning/5))
- Matches the existing pattern already used in `miri.yml`

## Test plan
- [ ] CI workflow runs successfully on PR
- [ ] CodeQL scan closes alerts #4 and #5 after merge


Made with [Cursor](https://cursor.com)