### PR TITLE
style: rustfmt dbgeng.rs (fix cargo fmt --check on main)

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -5,10 +5,11 @@ use windows::core::{IUnknown, Interface, PCSTR, PCWSTR, PWSTR};
 // Import the necessary Windows Debug Engine interfaces
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
     DEBUG_ANY_ID, DEBUG_ATTACH_KERNEL_CONNECTION, DEBUG_ATTACH_LOCAL_KERNEL, DEBUG_BREAKPOINT_CODE,
-    DEBUG_BREAKPOINT_ENABLED, DEBUG_CLASS_KERNEL, DEBUG_ENGOPT_INITIAL_BREAK, DEBUG_EVENT_BREAKPOINT,
-    DEBUG_EXECUTE_ECHO, DEBUG_KERNEL_SMALL_DUMP, DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL,
-    DEBUG_STATUS_NO_DEBUGGEE, IDebugBreakpoint, IDebugBreakpoint2, IDebugClient6, IDebugControl4,
-    IDebugDataSpaces4, IDebugEventContextCallbacks, IDebugOutputCallbacks, IDebugSymbols3,
+    DEBUG_BREAKPOINT_ENABLED, DEBUG_CLASS_KERNEL, DEBUG_ENGOPT_INITIAL_BREAK,
+    DEBUG_EVENT_BREAKPOINT, DEBUG_EXECUTE_ECHO, DEBUG_KERNEL_SMALL_DUMP, DEBUG_OUTCTL_THIS_CLIENT,
+    DEBUG_OUTPUT_NORMAL, DEBUG_STATUS_NO_DEBUGGEE, IDebugBreakpoint, IDebugBreakpoint2,
+    IDebugClient6, IDebugControl4, IDebugDataSpaces4, IDebugEventContextCallbacks,
+    IDebugOutputCallbacks, IDebugSymbols3,
 };
 
 /// Callback type for breakpoint events that receives the breakpoint, context, and flags
@@ -44,7 +45,9 @@ pub enum DbgEngError {
     #[error("Invalid command string (contains interior NUL)")]
     InvalidCommand,
 
-    #[error("No active debuggee — attach to a target, launch a process, or open a dump/trace first")]
+    #[error(
+        "No active debuggee — attach to a target, launch a process, or open a dump/trace first"
+    )]
     NoDebuggee,
 
     #[error("Operation failed: {0}")]
@@ -226,7 +229,8 @@ impl DebugEngine {
     /// Returns an error rather than panicking when the connection string is invalid or
     /// the attach fails (e.g. the transport/port is already owned by another debugger).
     pub fn attach_kernel(&self, connection_string: &str) -> Result<(), DbgEngError> {
-        let connection = CString::new(connection_string).map_err(|_| DbgEngError::InvalidCommand)?;
+        let connection =
+            CString::new(connection_string).map_err(|_| DbgEngError::InvalidCommand)?;
 
         self.request_initial_break()?;
         unsafe {
@@ -318,7 +322,8 @@ impl DebugEngine {
         // debuggee can push DbgEng into an access violation — a structured exception
         // that Rust's `catch_unwind` cannot trap, which tears down the whole process.
         // Refuse up front when there is nothing to run, returning a clean error.
-        let status = unsafe { self.control.GetExecutionStatus() }.map_err(DbgEngError::CommandFailed)?;
+        let status =
+            unsafe { self.control.GetExecutionStatus() }.map_err(DbgEngError::CommandFailed)?;
         if status == DEBUG_STATUS_NO_DEBUGGEE {
             return Err(DbgEngError::NoDebuggee);
         }


### PR DESCRIPTION
`cargo fmt --check` currently fails on `main` after the live-kernel attach fix (`0c4dd18`): the edited import block and the new helper functions in `src/dbgeng.rs` weren't rustfmt-formatted.

This reformats only the affected regions. **No functional change** — `cargo build --all-targets` passes and the live-kernel attach/break/breakpoint/resume flow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Internal code formatting improvements to enhance readability and maintainability across core modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->