### PR TITLE
dbgeng: bound the live-kernel WaitForEvent so the engine thread can't hang

### DIFF
--- a/examples/kdtest.rs
+++ b/examples/kdtest.rs
@@ -8,13 +8,22 @@ use std::time::Instant;
 
 use win_kexp::dbgeng::DebugEngine;
 
-fn run(e: &DebugEngine, cmd: &str) {
+/// Runs a command, prints its output, and reports whether it succeeded so callers can
+/// stop early instead of validating bounded-wait behaviour from a broken state.
+fn run(e: &DebugEngine, cmd: &str) -> bool {
     println!("--- {cmd} ---");
-    match e.execute_command(cmd) {
-        Ok(out) => print!("{out}"),
-        Err(err) => println!("ERR: {err}"),
-    }
+    let ok = match e.execute_command(cmd) {
+        Ok(out) => {
+            print!("{out}");
+            true
+        }
+        Err(err) => {
+            println!("ERR: {err}");
+            false
+        }
+    };
     println!();
+    ok
 }
 
 fn main() {
@@ -30,8 +39,10 @@ fn main() {
         }
     }
 
-    run(&e, "bp nt!NtCreateFile");
-    run(&e, "bl");
+    if !run(&e, "bp nt!NtCreateFile") || !run(&e, "bl") {
+        eprintln!("failed to set/list the breakpoint; aborting");
+        return;
+    }
 
     println!("=== g (expect Breakpoint 0 hit at nt!NtCreateFile) ===");
     let t = Instant::now();
@@ -44,7 +55,10 @@ fn main() {
 
     // Now clear the bp and `go` with NO breakpoint: the bounded wait must force a return
     // around the 5s timeout instead of hanging the engine thread forever.
-    run(&e, "bc *");
+    if !run(&e, "bc *") {
+        eprintln!("failed to clear breakpoints; aborting");
+        return;
+    }
     println!("=== g with no breakpoint (expect a bounded return ~5s, NOT a hang) ===");
     let t = Instant::now();
     match e.execute_and_wait("g", 5_000) {
@@ -54,7 +68,11 @@ fn main() {
     println!("[bounded g returned in {:.1}s]", t.elapsed().as_secs_f32());
 
     // Leave the target running; detach.
-    let _ = e.execute_command("g");
-    let _ = e.end_session();
-    println!("done");
+    if let Err(err) = e.execute_command("g") {
+        eprintln!("resume before detach failed: {err}");
+    }
+    match e.end_session() {
+        Ok(()) => println!("done"),
+        Err(err) => eprintln!("end_session failed: {err}"),
+    }
 }

--- a/examples/kdtest.rs
+++ b/examples/kdtest.rs
@@ -1,0 +1,60 @@
+//! Scratch experiment (not part of the public API): exercise the win-kexp DebugEngine
+//! live-kernel path — attach+break, set a breakpoint, resume to it, and verify a `go`
+//! with no breakpoint returns within its bound instead of hanging the engine thread.
+//!
+//! Run: cargo run --example kdtest -- "net:port=50000,key=w.x.y.z"
+
+use std::time::Instant;
+
+use win_kexp::dbgeng::DebugEngine;
+
+fn run(e: &DebugEngine, cmd: &str) {
+    println!("--- {cmd} ---");
+    match e.execute_command(cmd) {
+        Ok(out) => print!("{out}"),
+        Err(err) => println!("ERR: {err}"),
+    }
+    println!();
+}
+
+fn main() {
+    let conn = std::env::args().nth(1).expect("usage: kdtest <conn>");
+    let e = DebugEngine::new();
+
+    let t = Instant::now();
+    match e.attach_kernel(&conn) {
+        Ok(()) => println!("attach_kernel OK in {:.1}s", t.elapsed().as_secs_f32()),
+        Err(err) => {
+            println!("attach_kernel ERR: {err}");
+            return;
+        }
+    }
+
+    run(&e, "bp nt!NtCreateFile");
+    run(&e, "bl");
+
+    println!("=== g (expect Breakpoint 0 hit at nt!NtCreateFile) ===");
+    let t = Instant::now();
+    match e.execute_and_wait("g", 60_000) {
+        Ok(out) => print!("{out}"),
+        Err(err) => println!("ERR: {err}"),
+    }
+    println!("[g returned in {:.1}s]", t.elapsed().as_secs_f32());
+    run(&e, "r");
+
+    // Now clear the bp and `go` with NO breakpoint: the bounded wait must force a return
+    // around the 5s timeout instead of hanging the engine thread forever.
+    run(&e, "bc *");
+    println!("=== g with no breakpoint (expect a bounded return ~5s, NOT a hang) ===");
+    let t = Instant::now();
+    match e.execute_and_wait("g", 5_000) {
+        Ok(out) => print!("[ok] {out}"),
+        Err(err) => println!("[err] {err}"),
+    }
+    println!("[bounded g returned in {:.1}s]", t.elapsed().as_secs_f32());
+
+    // Leave the target running; detach.
+    let _ = e.execute_command("g");
+    let _ = e.end_session();
+    println!("done");
+}

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -272,14 +272,17 @@ impl DebugEngine {
     /// [`DbgEngError::KernelBreakTimeout`] if the target never broke in within the bound
     /// (e.g. unreachable or not in debug mode), rather than reporting a false success.
     fn wait_for_kernel_break_in(&self) -> Result<(), DbgEngError> {
-        let waited = self.wait_for_event_bounded(KERNEL_ATTACH_WAIT_MS);
+        let (waited, timed_out) = self.wait_for_event_bounded(KERNEL_ATTACH_WAIT_MS);
         self.clear_initial_break();
         waited.map_err(DbgEngError::CommandFailed)?;
-        // The watchdog may have forced the wait to return without an actual break (no
-        // current process/thread); detect that instead of leaving a half-attached engine.
+        // If the watchdog forced the wait to return, the target never reached its
+        // INITIAL_BREAK on its own within the bound — the stop (if any) is a forced
+        // Ctrl+Break, not the clean break-in. Report a timeout and skip the absorb (there
+        // is no INITIAL_BREAK artifact to consume). Also treat a wait that returned with
+        // no debuggee as a timeout, defensively.
         let status =
             unsafe { self.control.GetExecutionStatus() }.map_err(DbgEngError::CommandFailed)?;
-        if status == DEBUG_STATUS_NO_DEBUGGEE {
+        if timed_out || status == DEBUG_STATUS_NO_DEBUGGEE {
             return Err(DbgEngError::KernelBreakTimeout);
         }
         self.absorb_initial_break_artifact();
@@ -348,15 +351,21 @@ impl DebugEngine {
     /// after `timeout_ms` a watchdog thread Ctrl+Breaks the target via `SetInterrupt`
     /// (the one DbgEng call safe from another thread) so the wait returns instead of
     /// hanging the single engine thread forever — e.g. a `go`/step that never hits a
-    /// breakpoint, or an attach whose target is reachable but won't break in. Returns the
-    /// raw `WaitForEvent` result so callers can tell a real stop from a forced one.
+    /// breakpoint, or an attach whose target is reachable but won't break in.
+    ///
+    /// Returns the raw `WaitForEvent` result **and** a `bool` that is `true` when the
+    /// watchdog had to force the return — in that case the stop is a forced Ctrl+Break,
+    /// not the event the caller was waiting for, so callers must not treat it as a normal
+    /// completion (e.g. an attach should report a timeout rather than a clean break-in).
     ///
     /// Limitation: `SetInterrupt` can only unblock a wait once the target is *connected*.
     /// A wait still establishing the KDNET link (e.g. an unreachable target) cannot be
     /// cancelled this way and will block like `kd` itself does on a dead connection.
-    fn wait_for_event_bounded(&self, timeout_ms: u32) -> windows::core::Result<()> {
+    fn wait_for_event_bounded(&self, timeout_ms: u32) -> (windows::core::Result<()>, bool) {
         let done = Arc::new(AtomicBool::new(false));
+        let fired = Arc::new(AtomicBool::new(false));
         let done_watch = Arc::clone(&done);
+        let fired_watch = Arc::clone(&fired);
         let handle = InterruptHandle(self.control.as_raw());
         let deadline = Duration::from_millis(timeout_ms as u64);
         let watchdog = thread::spawn(move || {
@@ -372,6 +381,7 @@ impl DebugEngine {
                     // Ctrl+Break a connected target so the engine thread's WaitForEvent
                     // returns with a stop. Repeat in case a busy target ignores one.
                     let _ = unsafe { ctl.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) };
+                    fired_watch.store(true, Ordering::SeqCst);
                 }
                 thread::sleep(Duration::from_millis(300));
             }
@@ -379,7 +389,7 @@ impl DebugEngine {
         let result = unsafe { self.control.WaitForEvent(0, WAIT_INFINITE) };
         done.store(true, Ordering::SeqCst);
         let _ = watchdog.join();
-        result
+        (result, fired.load(Ordering::SeqCst))
     }
 
     /// Issues an execution-control command (`g`, `t`, `p`, `g-`, `t-`, `p-`, …) and
@@ -427,7 +437,9 @@ impl DebugEngine {
         };
         let waited = if exec.is_ok() {
             if live_kernel {
-                self.wait_for_event_bounded(timeout_ms)
+                // A forced break at the bound is a fine outcome for go/step (the target
+                // simply hadn't stopped yet), so ignore the watchdog-fired flag here.
+                self.wait_for_event_bounded(timeout_ms).0
             } else {
                 unsafe { self.control.WaitForEvent(0, timeout_ms) }
             }

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1,4 +1,9 @@
 use std::ffi::CString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
 use thiserror::Error;
 use windows::core::{IUnknown, Interface, PCSTR, PCWSTR, PWSTR};
 
@@ -6,10 +11,10 @@ use windows::core::{IUnknown, Interface, PCSTR, PCWSTR, PWSTR};
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
     DEBUG_ANY_ID, DEBUG_ATTACH_KERNEL_CONNECTION, DEBUG_ATTACH_LOCAL_KERNEL, DEBUG_BREAKPOINT_CODE,
     DEBUG_BREAKPOINT_ENABLED, DEBUG_CLASS_KERNEL, DEBUG_ENGOPT_INITIAL_BREAK,
-    DEBUG_EVENT_BREAKPOINT, DEBUG_EXECUTE_ECHO, DEBUG_KERNEL_SMALL_DUMP, DEBUG_OUTCTL_THIS_CLIENT,
-    DEBUG_OUTPUT_NORMAL, DEBUG_STATUS_NO_DEBUGGEE, IDebugBreakpoint, IDebugBreakpoint2,
-    IDebugClient6, IDebugControl4, IDebugDataSpaces4, IDebugEventContextCallbacks,
-    IDebugOutputCallbacks, IDebugSymbols3,
+    DEBUG_EVENT_BREAKPOINT, DEBUG_EXECUTE_ECHO, DEBUG_INTERRUPT_ACTIVE, DEBUG_KERNEL_SMALL_DUMP,
+    DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL, DEBUG_STATUS_NO_DEBUGGEE, IDebugBreakpoint,
+    IDebugBreakpoint2, IDebugClient6, IDebugControl4, IDebugDataSpaces4,
+    IDebugEventContextCallbacks, IDebugOutputCallbacks, IDebugSymbols3,
 };
 
 /// Callback type for breakpoint events that receives the breakpoint, context, and flags
@@ -50,6 +55,11 @@ pub enum DbgEngError {
     )]
     NoDebuggee,
 
+    #[error(
+        "kernel target did not break in within the attach timeout — is it reachable and in debug mode?"
+    )]
+    KernelBreakTimeout,
+
     #[error("Operation failed: {0}")]
     OperationFailed(windows::core::Error),
 }
@@ -71,6 +81,18 @@ const LIVE_WAIT_MS: u32 = 30_000;
 /// a finite timeout on a live kernel connection returns `E_NOTIMPL` (the engine never
 /// drives the connection). See [`DebugEngine::is_live_kernel`].
 const WAIT_INFINITE: u32 = u32::MAX;
+/// Upper bound (ms) on a live-kernel break-in wait. The wait itself must be INFINITE
+/// (a finite `WaitForEvent` returns `E_NOTIMPL` on a live kernel), so a watchdog forces
+/// it to return after this long — the single engine thread must not hang forever on an
+/// unreachable/unresponsive target. Generous, to allow a KDNET resync (~25s observed).
+const KERNEL_ATTACH_WAIT_MS: u32 = 60_000;
+
+/// Carries a raw `IDebugControl` pointer to a watchdog thread solely to call
+/// `SetInterrupt`, which DbgEng documents as safe to call from any thread (the rest of
+/// the engine is single-thread-affine). Not otherwise dereferenced off-thread.
+struct InterruptHandle(*mut core::ffi::c_void);
+// SAFETY: only used to invoke SetInterrupt, the one cross-thread-safe DbgEng call.
+unsafe impl Send for InterruptHandle {}
 
 /// Encodes a `&str` as a NUL-terminated UTF-16 buffer for the `*Wide` DbgEng APIs.
 fn to_wide(s: &str) -> Vec<u16> {
@@ -185,7 +207,9 @@ impl DebugEngine {
     /// here — resume once and let it re-break — so the target is left cleanly halted and
     /// the caller's first real `go`/step runs to an actual breakpoint. Best-effort.
     fn absorb_initial_break_artifact(&self) {
-        let _ = self.execute_and_wait("g", WAIT_INFINITE);
+        // The spurious re-break fires immediately on resume; a short bound keeps this
+        // from hanging if (unexpectedly) it doesn't.
+        let _ = self.execute_and_wait("g", 5_000);
     }
 
     /// Whether the current target is a *live* kernel connection (net/1394/serial/local/
@@ -213,14 +237,10 @@ impl DebugEngine {
                 .AttachKernel(DEBUG_ATTACH_LOCAL_KERNEL, None)
                 .map_err(DbgEngError::AttachFailed)?;
         }
-        // A live kernel target requires an INFINITE WaitForEvent (a finite timeout
-        // returns E_NOTIMPL); INITIAL_BREAK makes this stop at the first event.
-        let waited = self.wait_for_event(WAIT_INFINITE);
-        self.clear_initial_break();
-        if waited.is_ok() {
-            self.absorb_initial_break_artifact();
-        }
-        waited
+        // A live kernel needs an INFINITE WaitForEvent (a finite timeout returns
+        // E_NOTIMPL); INITIAL_BREAK makes it stop at the first event. Bound it so an
+        // unresponsive target can't hang the engine thread forever.
+        self.wait_for_kernel_break_in()
     }
 
     /// Attaches to a kernel over a connection string (e.g. `net:port=50000,key=...`)
@@ -242,13 +262,28 @@ impl DebugEngine {
                 .map_err(DbgEngError::AttachFailed)?;
         }
         // Live kernel: INFINITE wait is mandatory (finite → E_NOTIMPL). INITIAL_BREAK
-        // above makes the engine stop once the KDNET link establishes.
-        let waited = self.wait_for_event(WAIT_INFINITE);
+        // above makes the engine stop once the KDNET link establishes. Bound it so an
+        // unreachable target can't hang the engine thread forever.
+        self.wait_for_kernel_break_in()
+    }
+
+    /// Shared tail of the kernel attach paths: wait (bounded) for the INITIAL_BREAK stop,
+    /// clear the option, and absorb the one spurious re-break it leaves. Returns
+    /// [`DbgEngError::KernelBreakTimeout`] if the target never broke in within the bound
+    /// (e.g. unreachable or not in debug mode), rather than reporting a false success.
+    fn wait_for_kernel_break_in(&self) -> Result<(), DbgEngError> {
+        let waited = self.wait_for_event_bounded(KERNEL_ATTACH_WAIT_MS);
         self.clear_initial_break();
-        if waited.is_ok() {
-            self.absorb_initial_break_artifact();
+        waited.map_err(DbgEngError::CommandFailed)?;
+        // The watchdog may have forced the wait to return without an actual break (no
+        // current process/thread); detect that instead of leaving a half-attached engine.
+        let status =
+            unsafe { self.control.GetExecutionStatus() }.map_err(DbgEngError::CommandFailed)?;
+        if status == DEBUG_STATUS_NO_DEBUGGEE {
+            return Err(DbgEngError::KernelBreakTimeout);
         }
-        waited
+        self.absorb_initial_break_artifact();
+        Ok(())
     }
 
     /// Sets the symbol path
@@ -309,6 +344,44 @@ impl DebugEngine {
         Ok(())
     }
 
+    /// `WaitForEvent` with the INFINITE timeout a live kernel requires, but **bounded**:
+    /// after `timeout_ms` a watchdog thread Ctrl+Breaks the target via `SetInterrupt`
+    /// (the one DbgEng call safe from another thread) so the wait returns instead of
+    /// hanging the single engine thread forever — e.g. a `go`/step that never hits a
+    /// breakpoint, or an attach whose target is reachable but won't break in. Returns the
+    /// raw `WaitForEvent` result so callers can tell a real stop from a forced one.
+    ///
+    /// Limitation: `SetInterrupt` can only unblock a wait once the target is *connected*.
+    /// A wait still establishing the KDNET link (e.g. an unreachable target) cannot be
+    /// cancelled this way and will block like `kd` itself does on a dead connection.
+    fn wait_for_event_bounded(&self, timeout_ms: u32) -> windows::core::Result<()> {
+        let done = Arc::new(AtomicBool::new(false));
+        let done_watch = Arc::clone(&done);
+        let handle = InterruptHandle(self.control.as_raw());
+        let deadline = Duration::from_millis(timeout_ms as u64);
+        let watchdog = thread::spawn(move || {
+            let handle = handle; // capture the whole (Send) handle, not just the raw field
+            let start = Instant::now();
+            loop {
+                if done_watch.load(Ordering::SeqCst) {
+                    return;
+                }
+                if start.elapsed() >= deadline
+                    && let Some(ctl) = unsafe { IDebugControl4::from_raw_borrowed(&handle.0) }
+                {
+                    // Ctrl+Break a connected target so the engine thread's WaitForEvent
+                    // returns with a stop. Repeat in case a busy target ignores one.
+                    let _ = unsafe { ctl.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) };
+                }
+                thread::sleep(Duration::from_millis(300));
+            }
+        });
+        let result = unsafe { self.control.WaitForEvent(0, WAIT_INFINITE) };
+        done.store(true, Ordering::SeqCst);
+        let _ = watchdog.join();
+        result
+    }
+
     /// Issues an execution-control command (`g`, `t`, `p`, `g-`, `t-`, `p-`, …) and
     /// drives it to the next stop.
     ///
@@ -329,13 +402,10 @@ impl DebugEngine {
         }
 
         // A live kernel target requires an INFINITE WaitForEvent timeout; a finite one
-        // returns E_NOTIMPL, so go/step would never advance. Dumps/TTD/user-mode keep
-        // the caller's timeout.
-        let timeout_ms = if self.is_live_kernel() {
-            WAIT_INFINITE
-        } else {
-            timeout_ms
-        };
+        // returns E_NOTIMPL, so go/step would never advance. We instead wait INFINITE but
+        // bound it with a watchdog (below), so `timeout_ms` still caps the wait without
+        // hanging the engine thread. Dumps/TTD/user-mode use the timeout directly.
+        let live_kernel = self.is_live_kernel();
 
         let cmd_c = CString::new(command).map_err(|_| DbgEngError::InvalidCommand)?;
         let cmd = PCSTR::from_raw(cmd_c.as_ptr() as *const u8);
@@ -356,7 +426,11 @@ impl DebugEngine {
                 .Execute(DEBUG_OUTCTL_THIS_CLIENT, cmd, DEBUG_EXECUTE_ECHO)
         };
         let waited = if exec.is_ok() {
-            unsafe { self.control.WaitForEvent(0, timeout_ms) }
+            if live_kernel {
+                self.wait_for_event_bounded(timeout_ms)
+            } else {
+                unsafe { self.control.WaitForEvent(0, timeout_ms) }
+            }
         } else {
             Ok(())
         };


### PR DESCRIPTION
## Summary

Addresses a robustness gap in the live-kernel path (flagged in review of windbg-mcp#16): a live kernel requires an **INFINITE** `WaitForEvent` (a finite one returns `E_NOTIMPL`), so attach break-in and `go`/step could block the **single** DbgEng worker thread forever — wedging every later call until restart.

### Fix
`wait_for_event_bounded(timeout_ms)`: waits `INFINITE`, but a watchdog thread Ctrl+Breaks the target via `SetInterrupt` (the one DbgEng call documented as cross-thread-safe) after `timeout_ms`, so the wait returns instead of hanging.
- **attach** (`attach_kernel`/`attach_local_kernel`): bounded at 60s; returns the new `DbgEngError::KernelBreakTimeout` if the target never broke in.
- **go/step** (`execute_and_wait` on a live kernel): bounded at the caller's timeout, so a `go` that never hits a breakpoint returns instead of hanging.

### Limitation
`SetInterrupt` can only unblock a wait once the target is **connected**. A wait still establishing the KDNET link (an unreachable target) can't be cancelled this way and blocks like `kd` itself does — documented on the method.

### Also
Adds `examples/kdtest.rs`, a scratch driver that exercises the live-kernel path (attach → breakpoint → go), kept for future debugging.

### Verification
Against a live KDNET target: attach breaks in (~2s), `bp nt!NtCreateFile` is hit on `go` (~0.3s), and a `go` with no breakpoint returns at the bound (~5s) rather than hanging. `cargo build --all-targets`, `cargo fmt --check`, and clippy (no new warnings) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added example demonstrating kernel debugging workflow with breakpoint management and timeout handling.

* **Bug Fixes**
  * Fixed potential engine thread hangs during live kernel debugging operations.
  * Improved error reporting for kernel attach and break-in failures to provide clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->