### PR TITLE
dbgeng: leave a live kernel running on detach (don't freeze it)

### DIFF
--- a/examples/kdtest.rs
+++ b/examples/kdtest.rs
@@ -1,78 +1,63 @@
-//! Scratch experiment (not part of the public API): exercise the win-kexp DebugEngine
-//! live-kernel path — attach+break, set a breakpoint, resume to it, and verify a `go`
-//! with no breakpoint returns within its bound instead of hanging the engine thread.
+//! Scratch experiment (not part of the public API): verify that end_session leaves a
+//! live kernel RUNNING (not frozen). attach -> bp -> go -> end_session (resume+detach),
+//! wait, then re-attach: if System Uptime advanced by ~the wait, the target was running.
 //!
 //! Run: cargo run --example kdtest -- "net:port=50000,key=w.x.y.z"
 
-use std::time::Instant;
+use std::thread::sleep;
+use std::time::Duration;
 
 use win_kexp::dbgeng::DebugEngine;
 
-/// Runs a command, prints its output, and reports whether it succeeded so callers can
-/// stop early instead of validating bounded-wait behaviour from a broken state.
-fn run(e: &DebugEngine, cmd: &str) -> bool {
+fn run(e: &DebugEngine, cmd: &str) {
     println!("--- {cmd} ---");
-    let ok = match e.execute_command(cmd) {
-        Ok(out) => {
-            print!("{out}");
-            true
-        }
-        Err(err) => {
-            println!("ERR: {err}");
-            false
-        }
-    };
+    match e.execute_command(cmd) {
+        Ok(out) => print!("{out}"),
+        Err(err) => println!("ERR: {err}"),
+    }
     println!();
-    ok
 }
 
 fn main() {
     let conn = std::env::args().nth(1).expect("usage: kdtest <conn>");
     let e = DebugEngine::new();
 
-    let t = Instant::now();
     match e.attach_kernel(&conn) {
-        Ok(()) => println!("attach_kernel OK in {:.1}s", t.elapsed().as_secs_f32()),
+        Ok(()) => println!("attach #1 OK"),
         Err(err) => {
-            println!("attach_kernel ERR: {err}");
+            println!("attach #1 ERR: {err}");
             return;
         }
     }
+    run(&e, "vertarget"); // UPTIME #1
 
-    if !run(&e, "bp nt!NtCreateFile") || !run(&e, "bl") {
-        eprintln!("failed to set/list the breakpoint; aborting");
-        return;
-    }
-
-    println!("=== g (expect Breakpoint 0 hit at nt!NtCreateFile) ===");
-    let t = Instant::now();
+    run(&e, "bp nt!NtCreateFile");
+    println!("=== go (to nt!NtCreateFile) ===");
     match e.execute_and_wait("g", 60_000) {
         Ok(out) => print!("{out}"),
         Err(err) => println!("ERR: {err}"),
     }
-    println!("[g returned in {:.1}s]", t.elapsed().as_secs_f32());
-    run(&e, "r");
+    println!();
 
-    // Now clear the bp and `go` with NO breakpoint: the bounded wait must force a return
-    // around the 5s timeout instead of hanging the engine thread forever.
-    if !run(&e, "bc *") {
-        eprintln!("failed to clear breakpoints; aborting");
-        return;
-    }
-    println!("=== g with no breakpoint (expect a bounded return ~5s, NOT a hang) ===");
-    let t = Instant::now();
-    match e.execute_and_wait("g", 5_000) {
-        Ok(out) => print!("[ok] {out}"),
-        Err(err) => println!("[err] {err}"),
-    }
-    println!("[bounded g returned in {:.1}s]", t.elapsed().as_secs_f32());
-
-    // Leave the target running; detach.
-    if let Err(err) = e.execute_command("g") {
-        eprintln!("resume before detach failed: {err}");
-    }
+    println!("=== end_session (should resume + detach, leaving target RUNNING) ===");
     match e.end_session() {
-        Ok(()) => println!("done"),
-        Err(err) => eprintln!("end_session failed: {err}"),
+        Ok(()) => println!("end_session ok"),
+        Err(err) => println!("end_session ERR: {err}"),
     }
+
+    println!("--- sleeping 8s; if the fix works the guest is RUNNING during this ---");
+    sleep(Duration::from_secs(8));
+
+    println!("=== re-attach to read uptime again ===");
+    match e.attach_kernel(&conn) {
+        Ok(()) => println!("attach #2 OK"),
+        Err(err) => {
+            println!("attach #2 ERR: {err}  (=> target was frozen/wedged, fix FAILED)");
+            return;
+        }
+    }
+    run(&e, "vertarget"); // UPTIME #2 — compare to #1: ~8s+ greater => target was RUNNING
+
+    let _ = e.end_session();
+    println!("done (compare the two 'System Uptime' lines)");
 }

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -12,8 +12,8 @@ use windows::Win32::System::Diagnostics::Debug::Extensions::{
     DEBUG_ANY_ID, DEBUG_ATTACH_KERNEL_CONNECTION, DEBUG_ATTACH_LOCAL_KERNEL, DEBUG_BREAKPOINT_CODE,
     DEBUG_BREAKPOINT_ENABLED, DEBUG_CLASS_KERNEL, DEBUG_ENGOPT_INITIAL_BREAK,
     DEBUG_EVENT_BREAKPOINT, DEBUG_EXECUTE_ECHO, DEBUG_INTERRUPT_ACTIVE, DEBUG_KERNEL_SMALL_DUMP,
-    DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL, DEBUG_STATUS_NO_DEBUGGEE, IDebugBreakpoint,
-    IDebugBreakpoint2, IDebugClient6, IDebugControl4, IDebugDataSpaces4,
+    DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL, DEBUG_STATUS_GO, DEBUG_STATUS_NO_DEBUGGEE,
+    IDebugBreakpoint, IDebugBreakpoint2, IDebugClient6, IDebugControl4, IDebugDataSpaces4,
     IDebugEventContextCallbacks, IDebugOutputCallbacks, IDebugSymbols3,
 };
 
@@ -74,6 +74,9 @@ const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
 const DEBUG_ATTACH_DEFAULT: u32 = 0x0000_0000;
 /// `EndSession` flag used on teardown: detach passively without resuming.
 const DEBUG_END_PASSIVE: u32 = 0x0000_0000;
+/// `EndSession` flag: actively detach — the engine talks to the target to resume it
+/// before disconnecting, so a live kernel is left running instead of frozen at a break.
+const DEBUG_END_ACTIVE_DETACH: u32 = 0x0000_0002;
 /// How long to wait for a freshly launched/attached target to reach its initial
 /// break before giving up (ms).
 const LIVE_WAIT_MS: u32 = 30_000;
@@ -548,7 +551,26 @@ impl DebugEngine {
     /// Ends the current debug session without destroying the client, so it can be
     /// reused for another target.
     pub fn end_session(&self) -> Result<(), DbgEngError> {
+        // A live kernel left halted (at a break) and detached *passively* stays FROZEN —
+        // one CPU halted, the rest spinning — because a passive detach never tells the
+        // target to run. Resume it and actively detach instead, leaving it running.
+        if self.is_live_kernel() {
+            return self.resume_and_detach_live_kernel();
+        }
         unsafe { self.client.EndSession(DEBUG_END_PASSIVE) }.map_err(DbgEngError::OperationFailed)
+    }
+
+    /// Detaches from a live kernel leaving it **running**, not frozen at the last break.
+    /// Clears breakpoints (restoring their patched `int3` bytes), sets the target to run,
+    /// then does an *active* detach — which, unlike a passive one, communicates with the
+    /// target to resume it before disconnecting.
+    fn resume_and_detach_live_kernel(&self) -> Result<(), DbgEngError> {
+        let _ = self.execute_command("bc *");
+        unsafe {
+            let _ = self.control.SetExecutionStatus(DEBUG_STATUS_GO);
+            self.client.EndSession(DEBUG_END_ACTIVE_DETACH)
+        }
+        .map_err(DbgEngError::OperationFailed)
     }
 }
 
@@ -556,11 +578,18 @@ impl Drop for DebugEngine {
     fn drop(&mut self) {
         // Only tear down sessions we opened ourselves. Wrapping a borrowed WinDbg
         // client must not end the host's active session when the wrapper drops.
-        if self.owns_session {
-            // Best-effort teardown; ignore errors (e.g. when no session is active).
-            unsafe {
-                let _ = self.client.EndSession(DEBUG_END_PASSIVE);
-            }
+        if !self.owns_session {
+            return;
+        }
+        // Don't leave a live kernel frozen at a break if we're torn down without an
+        // explicit end_session (e.g. the process exits): resume + actively detach.
+        if self.is_live_kernel() {
+            let _ = self.resume_and_detach_live_kernel();
+            return;
+        }
+        // Best-effort teardown; ignore errors (e.g. when no session is active).
+        unsafe {
+            let _ = self.client.EndSession(DEBUG_END_PASSIVE);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a teardown bug found while testing live kernel debugging: after a session, the guest was left **frozen** (one CPU halted at the last break, the rest spinning ~19%, unresponsive).

`end_session` on a live kernel was a **passive** `EndSession`, which never communicates with the target — so detaching while halted at a break abandoned it frozen, and the breakpoint's `int3` was left patched.

## Fix
For a live kernel, `end_session` now:
1. `bc *` — clears breakpoints, restoring their patched `int3` bytes.
2. `SetExecutionStatus(DEBUG_STATUS_GO)`.
3. `EndSession(DEBUG_END_ACTIVE_DETACH)` — an *active* detach that communicates with the target to resume it before disconnecting.

`Drop` does the same for an owned session, so an implicit teardown (process exit) doesn't freeze the guest either. Non-kernel sessions (dumps/user-mode/TTD) keep the plain passive detach.

## Verification
Against a live KDNET target: `attach` (uptime 5:55) → `bp nt!NtCreateFile` → `go` (hit) → `end_session` (returned cleanly) → wait 8s → re-attach (uptime 6:10). **Uptime advanced ~15s = the full elapsed time**, confirming the guest kept running instead of freezing. (An earlier cross-thread `EndSession` approach deadlocked; this single-call active detach returns cleanly.)

`examples/kdtest.rs` is updated to this two-attach uptime regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed debug session termination for live kernel targets. Sessions now properly resume and actively detach from the target, ensuring the kernel remains in a running state rather than being frozen. Additionally, improved teardown handling prevents the debugger from leaving targets in an unstable state after session closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->