### PR TITLE
feat: add WinDbg pool map extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "win-kexp"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [features]
 shellcode_fallback = []
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,64 @@ cargo miri test --verbose
 
 Supported ARM64 shellcode versions are `23H2` and `24H2`; unset `WINDOWS_VERSION` defaults to `24H2`.
 
+## WinDbg Pool Map Extension
+
+Building the library for the native x64 MSVC target produces both the normal Rust
+library and `target\debug\win_kexp.dll`:
+
+```powershell
+rustup target add x86_64-pc-windows-msvc
+cargo build --lib
+```
+
+Run that command from an x64 MSVC Rust host. If an explicit
+`--target x86_64-pc-windows-msvc` is supplied instead, the DLL is written to
+`target\x86_64-pc-windows-msvc\debug\win_kexp.dll` and the `.load` path must use
+that target-qualified directory.
+
+The pool walker assumes Windows 10 19H1 or later allocator algorithms and requires
+full private/public type information for `nt`. Configure a Microsoft symbol-server
+path, break into the kernel target, and force-load kernel symbols before using it:
+
+```text
+.symfix
+.reload /f nt
+.load C:\path\to\win-kexp\target\debug\win_kexp.dll
+!win_kexp.help
+```
+
+The primary command is:
+
+```text
+!win_kexp.poolmap -tag Pipe
+!win_kexp.poolmap -tag ABC -paged
+!win_kexp.poolmap -tag Test -nonpaged -refresh
+!win_kexp.poolmap ffff800012345678
+```
+
+`-tag` accepts one through four ASCII bytes. Internally the tag remains the exact
+four-byte raw little-endian value; printable display text is only a rendering. The
+tag map retains nearby unrelated allocations and holes. `-paged` and `-nonpaged`
+filter exact pool identities and cannot be combined. An address query prints detail
+for the allocation or hole containing that address. `-refresh` discards a complete
+cached snapshot and walks again.
+
+“Snapshot” is literal: the extension examines current allocations, reusable frees,
+and cached/delay-free spans while the target is stopped. It does not install
+allocation breakpoints or reconstruct allocation history. The cache is invalidated
+when execution resumes or the debugger session changes, and incomplete or
+Ctrl+C-interrupted walks are never cached.
+
+When WinDbg accepts DML, map cells have colors and clickable address-detail links.
+The same rows use meaningful ASCII glyphs and include a legend when DML is stripped
+or plain-text output is captured.
+
+Pool walking is x64-only because the allocator encodings consulted here are specific
+to x64. The rest of the crate, including ARM64 shellcode support, remains buildable
+for ARM64. Per-session paged heaps are excluded from the initial pool-map scope and
+the command reports that limitation. Corrupt or unreadable allocator metadata is
+shown conservatively rather than treated as an exploitable condition.
+
 ## Modules
 
 | Module | Purpose |

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -5,7 +5,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
-use windows::core::{IUnknown, Interface, PCSTR, PCWSTR, PWSTR};
+use windows::Win32::Foundation::{S_FALSE, S_OK};
+use windows::core::{HRESULT, IUnknown, Interface, PCSTR, PCWSTR, PWSTR};
 
 // Import the necessary Windows Debug Engine interfaces
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
@@ -62,6 +63,26 @@ pub enum DbgEngError {
 
     #[error("Operation failed: {0}")]
     OperationFailed(windows::core::Error),
+
+    #[error("{operation} failed: {source}")]
+    Context {
+        operation: String,
+        #[source]
+        source: windows::core::Error,
+    },
+
+    #[error("short virtual read at {address:#x}: requested {requested} bytes, read {actual}")]
+    ShortRead {
+        address: u64,
+        requested: usize,
+        actual: usize,
+    },
+
+    #[error("requested debugger buffer is too large: {0} bytes")]
+    BufferTooLarge(usize),
+
+    #[error("debugger text contains an interior NUL")]
+    InvalidOutput,
 }
 
 /// `CreateProcess` flag: debug only the launched process, not its children.
@@ -162,6 +183,16 @@ impl DebugEngine {
         Self::from_client_interface(client)
     }
 
+    /// Fallible counterpart used by native extension callbacks.  Extension entry
+    /// points must translate bad client interfaces to HRESULTs instead of panicking.
+    pub fn try_from_windbg_client(client: &IUnknown) -> Result<Self, DbgEngError> {
+        let client: IDebugClient6 = client.cast().map_err(|source| DbgEngError::Context {
+            operation: "querying IDebugClient6".into(),
+            source,
+        })?;
+        Self::try_from_client_interface(client)
+    }
+
     pub fn create_from_windbg_client(client: &IUnknown) -> Self {
         let client: IDebugClient6 = client.cast().expect("[-] Failed to cast debug client");
         let new_client = unsafe {
@@ -198,15 +229,216 @@ impl DebugEngine {
         }
     }
 
+    pub fn try_from_client_interface(client: IDebugClient6) -> Result<Self, DbgEngError> {
+        let control = client
+            .cast::<IDebugControl4>()
+            .map_err(|source| DbgEngError::Context {
+                operation: "querying IDebugControl4".into(),
+                source,
+            })?;
+        let dataspaces =
+            client
+                .cast::<IDebugDataSpaces4>()
+                .map_err(|source| DbgEngError::Context {
+                    operation: "querying IDebugDataSpaces4".into(),
+                    source,
+                })?;
+        let symbols = client
+            .cast::<IDebugSymbols3>()
+            .map_err(|source| DbgEngError::Context {
+                operation: "querying IDebugSymbols3".into(),
+                source,
+            })?;
+        Ok(Self {
+            client,
+            control,
+            dataspaces,
+            symbols,
+            owns_session: false,
+        })
+    }
+
     pub fn read_memory(&self, address: u64, size: usize) -> Result<Vec<u8>, DbgEngError> {
+        let size_u32 = u32::try_from(size).map_err(|_| DbgEngError::BufferTooLarge(size))?;
         let mut buffer = vec![0; size];
+        let mut read = 0u32;
         unsafe {
-            self.dataspaces
-                .ReadVirtual(address, buffer.as_mut_ptr() as *mut _, size as u32, None)
-                .expect("[-] Failed to read memory")
-        };
+            self.dataspaces.ReadVirtual(
+                address,
+                buffer.as_mut_ptr().cast(),
+                size_u32,
+                Some(&mut read),
+            )
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("reading {size} bytes of virtual memory at {address:#x}"),
+            source,
+        })?;
+        if read as usize != size {
+            return Err(DbgEngError::ShortRead {
+                address,
+                requested: size,
+                actual: read as usize,
+            });
+        }
 
         Ok(buffer)
+    }
+
+    pub fn kernel_base(&self) -> Result<u64, DbgEngError> {
+        let name = CString::new("nt").unwrap();
+        let mut base = 0u64;
+        unsafe {
+            self.symbols.GetModuleByModuleName(
+                PCSTR::from_raw(name.as_ptr().cast()),
+                0,
+                None,
+                Some(&mut base),
+            )
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: "discovering the nt kernel base".into(),
+            source,
+        })?;
+        Ok(base)
+    }
+
+    pub fn symbol_offset(&self, name: &str) -> Result<u64, DbgEngError> {
+        let name = CString::new(name).map_err(|_| DbgEngError::InvalidCommand)?;
+        unsafe {
+            self.symbols
+                .GetOffsetByName(PCSTR::from_raw(name.as_ptr().cast()))
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("resolving symbol {}", name.to_string_lossy()),
+            source,
+        })
+    }
+
+    pub fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError> {
+        let name = CString::new(name).map_err(|_| DbgEngError::InvalidCommand)?;
+        unsafe {
+            self.symbols
+                .GetTypeId(module, PCSTR::from_raw(name.as_ptr().cast()))
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("resolving type {}", name.to_string_lossy()),
+            source,
+        })
+    }
+
+    pub fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError> {
+        unsafe { self.symbols.GetTypeSize(module, type_id) }.map_err(|source| {
+            DbgEngError::Context {
+                operation: format!("resolving size of type id {type_id}"),
+                source,
+            }
+        })
+    }
+
+    pub fn field_offset(&self, module: u64, type_id: u32, field: &str) -> Result<u32, DbgEngError> {
+        let field = CString::new(field).map_err(|_| DbgEngError::InvalidCommand)?;
+        unsafe {
+            self.symbols
+                .GetFieldOffset(module, type_id, PCSTR::from_raw(field.as_ptr().cast()))
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("resolving field {}", field.to_string_lossy()),
+            source,
+        })
+    }
+
+    pub fn valid_virtual_region(
+        &self,
+        base: u64,
+        size: usize,
+    ) -> Result<(u64, usize), DbgEngError> {
+        let size_u32 = u32::try_from(size).map_err(|_| DbgEngError::BufferTooLarge(size))?;
+        let mut valid_base = 0;
+        let mut valid_size = 0;
+        unsafe {
+            self.dataspaces
+                .GetValidRegionVirtual(base, size_u32, &mut valid_base, &mut valid_size)
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("querying valid virtual region at {base:#x}"),
+            source,
+        })?;
+        Ok((valid_base, valid_size as usize))
+    }
+
+    pub fn interrupted(&self) -> Result<bool, DbgEngError> {
+        // The generated windows wrapper calls HRESULT::ok(), which deliberately
+        // maps both S_OK and S_FALSE to Ok(()). GetInterrupt uses that distinction:
+        // S_OK means Ctrl+C was requested and S_FALSE means it was not.
+        let result = unsafe {
+            (Interface::vtable(&self.control).GetInterrupt)(Interface::as_raw(&self.control))
+        };
+        match result {
+            S_OK => Ok(true),
+            S_FALSE => Ok(false),
+            result => Err(DbgEngError::Context {
+                operation: "polling debugger interrupt".into(),
+                source: windows::core::Error::from_hresult(HRESULT(result.0)),
+            }),
+        }
+    }
+
+    fn output_inner(&self, text: &str, dml: bool) -> Result<(), DbgEngError> {
+        // DbgEng's output parameter is printf-style. Doubling percent signs makes
+        // user-controlled tags and diagnostics data rather than format directives.
+        let escaped = text.replace('%', "%%");
+        let message = CString::new(escaped).map_err(|_| DbgEngError::InvalidOutput)?;
+        let outctl = if dml {
+            DEBUG_OUTCTL_THIS_CLIENT | 0x20
+        } else {
+            DEBUG_OUTCTL_THIS_CLIENT
+        };
+        unsafe {
+            self.control.ControlledOutput(
+                outctl,
+                DEBUG_OUTPUT_NORMAL,
+                PCSTR::from_raw(message.as_ptr().cast()),
+            )
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: "writing debugger output".into(),
+            source,
+        })
+    }
+
+    pub fn output(&self, text: &str) -> Result<(), DbgEngError> {
+        self.output_inner(text, false)
+    }
+
+    pub fn output_dml(&self, text: &str) -> Result<(), DbgEngError> {
+        self.output_inner(text, true)
+    }
+
+    pub fn execution_status(&self) -> Result<u32, DbgEngError> {
+        unsafe { self.control.GetExecutionStatus() }.map_err(|source| DbgEngError::Context {
+            operation: "querying target execution status".into(),
+            source,
+        })
+    }
+
+    pub fn processor_type(&self) -> Result<u32, DbgEngError> {
+        unsafe { self.control.GetActualProcessorType() }.map_err(|source| DbgEngError::Context {
+            operation: "querying target processor type".into(),
+            source,
+        })
+    }
+
+    pub fn is_kernel_target(&self) -> Result<bool, DbgEngError> {
+        let mut class = 0;
+        let mut qualifier = 0;
+        unsafe { self.control.GetDebuggeeType(&mut class, &mut qualifier) }.map_err(|source| {
+            DbgEngError::Context {
+                operation: "querying target type".into(),
+                source,
+            }
+        })?;
+        Ok(class == DEBUG_CLASS_KERNEL)
     }
 
     /// Asks the engine to break in as soon as a freshly attached target initializes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dbgeng;
 pub mod pool;
+mod pool_extension;
 pub mod process;
 pub mod rop;
 pub mod shellcode;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -4,6 +4,107 @@ use windows::Win32::System::Pipes::CreatePipe;
 
 use crate::win32k::close_handle;
 
+pub(crate) mod decode;
+pub(crate) mod index;
+pub(crate) mod layout;
+pub(crate) mod render;
+pub(crate) mod snapshot;
+
+pub(crate) use index::PoolIndex;
+pub(crate) use snapshot::PoolSnapshot;
+
+/// Exact allocator identity.  Values are deliberately not collapsed into just
+/// paged/nonpaged because crossing one of these boundaries creates false holes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum PoolKind {
+    NonPagedExecutable,
+    NonPagedNx,
+    Paged,
+    PrototypePaged,
+    SpecialNonPaged,
+    SpecialNonPagedNx,
+    SpecialPaged,
+}
+
+impl PoolKind {
+    pub(crate) fn is_paged(self) -> bool {
+        matches!(
+            self,
+            Self::Paged | Self::PrototypePaged | Self::SpecialPaged
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum PoolBackend {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PoolState {
+    Allocated,
+    ReusableFree,
+    CachedFree,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct HeapIdentity {
+    pub pool_state: u64,
+    pub heap: u64,
+    pub special: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PoolSpan {
+    pub header_address: u64,
+    pub usable_address: u64,
+    pub size: u64,
+    pub raw_tag: u32,
+    pub display_tag: String,
+    pub pool_kind: PoolKind,
+    pub numa_node: u16,
+    pub heap: HeapIdentity,
+    pub subsegment: Option<u64>,
+    pub backend: PoolBackend,
+    pub state: PoolState,
+    pub size_class: u32,
+}
+
+impl PoolSpan {
+    pub(crate) fn end(&self) -> u64 {
+        self.usable_address.saturating_add(self.size)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allocation(
+        address: u64,
+        size: u64,
+        tag: u32,
+        pool_kind: PoolKind,
+        heap: HeapIdentity,
+        backend: PoolBackend,
+    ) -> Self {
+        Self {
+            header_address: address,
+            usable_address: address,
+            size,
+            raw_tag: tag,
+            display_tag: decode::display_tag(tag),
+            pool_kind,
+            numa_node: 0,
+            heap,
+            subsegment: None,
+            backend,
+            state: PoolState::Allocated,
+            size_class: size.min(u32::MAX as u64) as u32,
+        }
+    }
+}
+
 pub struct AnonymousPipe {
     read_handle: HANDLE,
     write_handle: HANDLE,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -79,6 +79,10 @@ impl PoolSpan {
         self.usable_address.saturating_add(self.size)
     }
 
+    pub(crate) fn contains_address(&self, address: u64) -> bool {
+        address >= self.header_address && address < self.end()
+    }
+
     #[cfg(test)]
     pub(crate) fn allocation(
         address: u64,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -24,13 +24,14 @@ pub(crate) enum PoolKind {
     SpecialNonPaged,
     SpecialNonPagedNx,
     SpecialPaged,
+    SpecialPrototypePaged,
 }
 
 impl PoolKind {
     pub(crate) fn is_paged(self) -> bool {
         matches!(
             self,
-            Self::Paged | Self::PrototypePaged | Self::SpecialPaged
+            Self::Paged | Self::PrototypePaged | Self::SpecialPaged | Self::SpecialPrototypePaged
         )
     }
 }

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -100,9 +100,9 @@ pub(crate) fn valid_page_segment_signature(
     signature: u64,
     segment: u64,
     context: u64,
-    heap_globals: u64,
+    heap_key: u64,
 ) -> bool {
-    signature == segment ^ context ^ heap_globals ^ PAGE_SEGMENT_SIGNATURE
+    signature == segment ^ context ^ heap_key ^ PAGE_SEGMENT_SIGNATURE
 }
 
 pub(crate) fn valid_descriptor_tree_signature(signature: u32) -> bool {
@@ -372,12 +372,16 @@ mod tests {
         assert!(valid_vs_signature(VS_SIGNATURE));
         let segment = 0xffff_8000_1234_0000;
         let context = 0xffff_8000_1000_0000;
-        let globals = 0xffff_8000_0100_0000;
+        let heap_key = 0x55aa_1234_9876_0000;
+        let signature = segment ^ context ^ heap_key ^ PAGE_SEGMENT_SIGNATURE;
         assert!(valid_page_segment_signature(
-            segment ^ context ^ globals ^ PAGE_SEGMENT_SIGNATURE,
+            signature, segment, context, heap_key
+        ));
+        assert!(!valid_page_segment_signature(
+            signature,
             segment,
             context,
-            globals
+            0xffff_8000_0100_0000
         ));
         assert!(valid_descriptor_tree_signature(DESCRIPTOR_TREE_SIGNATURE));
         let first = big_page_hash(0x9000, 8).unwrap();

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -1,0 +1,372 @@
+use super::PoolState;
+
+pub(crate) const PAGE_SIZE: u64 = 0x1000;
+pub(crate) const VS_SIGNATURE: u16 = 0x2bed;
+pub(crate) const PAGE_SEGMENT_SIGNATURE: u64 = 0xa2e6_4ead_a2e6_4ead;
+pub(crate) const DESCRIPTOR_TREE_SIGNATURE: u32 = 0xccdd_ccdd;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Descriptor {
+    pub unit_size: u32,
+    pub flags: u8,
+    pub committed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VsSizes {
+    pub size: u16,
+    pub previous_size: u16,
+    pub allocated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PoolHeader {
+    pub previous_size: u8,
+    pub block_size: u8,
+    pub pool_type: u8,
+    pub pool_index: u8,
+    pub tag: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PoolHeaderLayout {
+    pub size: usize,
+    pub previous_size: usize,
+    pub pool_index: usize,
+    pub block_size: usize,
+    pub pool_type: usize,
+    pub tag: usize,
+}
+
+fn range(bytes: &[u8], offset: usize, size: usize) -> Option<&[u8]> {
+    bytes.get(offset..offset.checked_add(size)?)
+}
+
+pub(crate) fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        range(bytes, offset, 2)?.try_into().ok()?,
+    ))
+}
+
+pub(crate) fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        range(bytes, offset, 4)?.try_into().ok()?,
+    ))
+}
+
+pub(crate) fn read_u64(bytes: &[u8], offset: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(
+        range(bytes, offset, 8)?.try_into().ok()?,
+    ))
+}
+
+pub(crate) fn decode_descriptor(word: u32) -> Option<Descriptor> {
+    let unit_size = word & 0x00ff_ffff;
+    let flags = (word >> 24) as u8;
+    (unit_size != 0).then_some(Descriptor {
+        unit_size,
+        flags,
+        committed: flags & 1 != 0,
+    })
+}
+
+pub(crate) fn decode_descriptor_at(
+    bytes: &[u8],
+    offset: usize,
+    descriptor_size: usize,
+    unit_size_offset: usize,
+    flags_offset: usize,
+) -> Option<Descriptor> {
+    let descriptor = range(bytes, offset, descriptor_size)?;
+    let unit_width = descriptor_size.checked_sub(unit_size_offset)?.min(3);
+    if unit_width == 0 {
+        return None;
+    }
+    let unit_bytes = range(descriptor, unit_size_offset, unit_width)?;
+    let unit_size = unit_bytes
+        .iter()
+        .enumerate()
+        .fold(0u32, |value, (shift, byte)| {
+            value | (u32::from(*byte) << (shift * 8))
+        });
+    let flags = *descriptor.get(flags_offset)? as u32;
+    decode_descriptor(unit_size | (flags << 24))
+}
+
+pub(crate) fn valid_page_segment_signature(
+    signature: u64,
+    segment: u64,
+    context: u64,
+    heap_globals: u64,
+) -> bool {
+    signature == segment ^ context ^ heap_globals ^ PAGE_SEGMENT_SIGNATURE
+}
+
+pub(crate) fn valid_descriptor_tree_signature(signature: u32) -> bool {
+    signature == DESCRIPTOR_TREE_SIGNATURE
+}
+
+/// Windows VS headers encode both size words with the heap key and header address.
+pub(crate) fn decode_vs_sizes(encoded: u64, header: u64, heap_key: u64) -> Option<VsSizes> {
+    let decoded = encoded ^ heap_key ^ header;
+    let size = (decoded >> 16) as u16;
+    let previous_size = (decoded >> 32) as u16;
+    (size != 0).then_some(VsSizes {
+        size,
+        previous_size,
+        allocated: (decoded >> 48) as u8 != 0,
+    })
+}
+
+pub(crate) fn valid_vs_signature(signature: u16) -> bool {
+    signature == VS_SIGNATURE
+}
+
+pub(crate) fn decode_lfh_offsets(encoded: u32, subsegment: u64, lfh_key: u32) -> (u16, u16) {
+    // EncodedData is one 32-bit value. Decoding the halves independently loses
+    // the upper half of LfhKey and produces a bogus FirstBlockOffset.
+    let decoded = encoded ^ lfh_key ^ (subsegment >> 12) as u32;
+    (decoded as u16, (decoded >> 16) as u16)
+}
+
+/// Each LFH slot uses two bits: 0 is reusable, 1 allocated, and 2/3 cached.
+pub(crate) fn lfh_bitmap_state(bitmap: &[u8], slot: usize) -> Option<PoolState> {
+    let bit = slot.checked_mul(2)?;
+    let byte = *bitmap.get(bit / 8)?;
+    Some(match (byte >> (bit % 8)) & 3 {
+        0 => PoolState::ReusableFree,
+        1 => PoolState::Allocated,
+        _ => PoolState::CachedFree,
+    })
+}
+
+/// A header that would straddle the page boundary is stored at the end of the
+/// preceding page.  Return the physical header location, checking all arithmetic.
+pub(crate) fn adjust_page_end_header(candidate: u64, header_size: u64) -> Option<u64> {
+    if header_size == 0 || header_size > PAGE_SIZE {
+        return None;
+    }
+    if candidate & (PAGE_SIZE - 1) == PAGE_SIZE - header_size {
+        candidate.checked_add(header_size)
+    } else {
+        Some(candidate)
+    }
+}
+
+pub(crate) fn decode_pool_header(
+    bytes: &[u8],
+    offset: usize,
+    layout: PoolHeaderLayout,
+) -> Option<PoolHeader> {
+    range(bytes, offset, layout.size)?;
+    // PDB field offsets for the two bitfield pairs can both name the containing
+    // USHORT. In that representation the second member occupies its high byte.
+    let pool_index_lane = usize::from(layout.pool_index == layout.previous_size);
+    let pool_type_lane = usize::from(layout.pool_type == layout.block_size);
+    let header = PoolHeader {
+        previous_size: *bytes.get(offset.checked_add(layout.previous_size)?)?,
+        pool_index: *bytes.get(
+            offset
+                .checked_add(layout.pool_index)?
+                .checked_add(pool_index_lane)?,
+        )?,
+        block_size: *bytes.get(offset.checked_add(layout.block_size)?)?,
+        pool_type: *bytes.get(
+            offset
+                .checked_add(layout.pool_type)?
+                .checked_add(pool_type_lane)?,
+        )?,
+        tag: read_u32(bytes, offset.checked_add(layout.tag)?)?,
+    };
+    // Zero-sized blocks and impossible pool types are corrupt metadata.
+    (header.block_size != 0 && header.pool_type <= 0x7f).then_some(header)
+}
+
+pub(crate) fn decode_rb_root(encoded: u64, tree_address: u64) -> Option<u64> {
+    let pointer = if encoded & 1 != 0 {
+        (encoded & !1) ^ tree_address
+    } else {
+        encoded
+    } & !0xf;
+    (pointer == 0 || is_kernel_pointer(pointer)).then_some(pointer)
+}
+
+/// Decode the two packed words in `_HEAP_LARGE_ALLOC_DATA`.
+///
+/// `VirtualAddress` shares its low 16 bits with `UnusedBytes`, while
+/// `AllocatedPages` occupies bits 12..63 of its containing word.
+pub(crate) fn decode_large_allocation(
+    virtual_address_field: u64,
+    allocated_pages_field: u64,
+) -> Option<(u64, u64)> {
+    let virtual_address = virtual_address_field & !0xffff;
+    let allocated_pages = allocated_pages_field >> 12;
+    (virtual_address != 0 && is_kernel_pointer(virtual_address) && allocated_pages != 0)
+        .then_some((virtual_address, allocated_pages))
+}
+
+pub(crate) fn is_kernel_pointer(pointer: u64) -> bool {
+    pointer == 0 || pointer >= 0xffff_8000_0000_0000
+}
+
+pub(crate) fn big_page_hash(address: u64, table_size: usize) -> Option<usize> {
+    if !table_size.is_power_of_two() {
+        None
+    } else {
+        // The allocator truncates the page number to ULONG before multiplying.
+        let mut hash = u64::from((address >> 12) as u32).wrapping_mul(0x9e5f);
+        hash ^= hash >> 32;
+        Some(hash as usize & (table_size - 1))
+    }
+}
+
+pub(crate) fn big_page_candidates(address: u64, table_size: usize) -> Option<[usize; 2]> {
+    let first = big_page_hash(address, table_size)?;
+    Some([first, (first + 1) % table_size])
+}
+
+pub(crate) fn display_tag(tag: u32) -> String {
+    tag.to_le_bytes()
+        .into_iter()
+        .map(|byte| {
+            if byte.is_ascii_graphic() || byte == b' ' {
+                byte as char
+            } else {
+                '.'
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn parse_tag(text: &str) -> Option<u32> {
+    let bytes = text.as_bytes();
+    if bytes.is_empty() || bytes.len() > 4 || !bytes.iter().all(u8::is_ascii) {
+        return None;
+    }
+    let mut raw = [b' '; 4];
+    raw[..bytes.len()].copy_from_slice(bytes);
+    Some(u32::from_le_bytes(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pool_decoder_bounds_and_shifted_offsets() {
+        assert_eq!(read_u32(&[0, 1, 2, 3, 4], 1), Some(0x0403_0201));
+        assert_eq!(read_u64(&[0; 7], 0), None);
+        assert_eq!(decode_descriptor(0x0100_0020).unwrap().unit_size, 0x20);
+        assert_eq!(decode_descriptor(0), None);
+        let mut descriptor = [0u8; 12];
+        descriptor[7] = 0x20;
+        descriptor[3] = 1;
+        assert_eq!(
+            decode_descriptor_at(&descriptor, 2, 10, 5, 1),
+            Some(Descriptor {
+                unit_size: 0x20,
+                flags: 1,
+                committed: true
+            })
+        );
+        let mut wide_descriptor = [0u8; 16];
+        wide_descriptor[5..8].copy_from_slice(&[0x56, 0x34, 0x12]);
+        wide_descriptor[2] = 1;
+        assert_eq!(
+            decode_descriptor_at(&wide_descriptor, 0, 8, 5, 2)
+                .unwrap()
+                .unit_size,
+            0x12_3456
+        );
+        assert_eq!(decode_descriptor_at(&wide_descriptor, 12, 8, 5, 2), None);
+        let decoded = decode_vs_sizes((4u64 << 16) ^ 0x1234 ^ 0x55, 0x1234, 0x55).unwrap();
+        assert_eq!(decoded.size, 4);
+        assert!(!decoded.allocated);
+        let lfh_key = 0xa5c3_0010;
+        let subsegment = 0x7000;
+        let decoded_offsets = u32::from(0x30u16) | (u32::from(0x248u16) << 16);
+        let encoded_offsets = decoded_offsets ^ lfh_key ^ (subsegment >> 12) as u32;
+        assert_eq!(
+            decode_lfh_offsets(encoded_offsets, subsegment, lfh_key),
+            (0x30, 0x248)
+        );
+        assert_eq!(
+            lfh_bitmap_state(&[0b0010_0100], 1),
+            Some(PoolState::Allocated)
+        );
+        assert_eq!(lfh_bitmap_state(&[], 0), None);
+
+        let mut shifted = [0u8; 24];
+        shifted[7..11].copy_from_slice(&[2, 3, 4, 1]);
+        shifted[15..19].copy_from_slice(b"TAG!");
+        let layout = PoolHeaderLayout {
+            size: 16,
+            previous_size: 0,
+            pool_index: 1,
+            block_size: 2,
+            pool_type: 3,
+            tag: 8,
+        };
+        let header = decode_pool_header(&shifted, 7, layout).unwrap();
+        assert_eq!(header.previous_size, 2);
+        assert_eq!(header.pool_index, 3);
+        assert_eq!(header.block_size, 4);
+        assert_eq!(header.tag, u32::from_le_bytes(*b"TAG!"));
+
+        let packed_layout = PoolHeaderLayout {
+            size: 8,
+            previous_size: 0,
+            pool_index: 0,
+            block_size: 2,
+            pool_type: 2,
+            tag: 4,
+        };
+        assert_eq!(
+            decode_pool_header(&[2, 3, 4, 1, b'P', b'A', b'C', b'K'], 0, packed_layout)
+                .unwrap()
+                .pool_index,
+            3
+        );
+    }
+
+    #[test]
+    fn test_pool_tag_and_allocator_algorithms() {
+        let tag = parse_tag("AB").unwrap();
+        assert_eq!(tag.to_le_bytes(), *b"AB  ");
+        assert_eq!(display_tag(u32::from_le_bytes(*b"A\0C ")), "A.C ");
+        assert!(valid_vs_signature(VS_SIGNATURE));
+        let segment = 0xffff_8000_1234_0000;
+        let context = 0xffff_8000_1000_0000;
+        let globals = 0xffff_8000_0100_0000;
+        assert!(valid_page_segment_signature(
+            segment ^ context ^ globals ^ PAGE_SEGMENT_SIGNATURE,
+            segment,
+            context,
+            globals
+        ));
+        assert!(valid_descriptor_tree_signature(DESCRIPTOR_TREE_SIGNATURE));
+        let first = big_page_hash(0x9000, 8).unwrap();
+        assert_eq!(
+            big_page_candidates(0x9000, 8),
+            Some([first, (first + 1) % 8])
+        );
+        assert_eq!(big_page_hash(0, 0), None);
+        assert_eq!(big_page_hash(0x9000, 3), None);
+        assert_eq!(big_page_candidates(0x9000, 3), None);
+        let high_address = 0xffff_8000_1234_5000;
+        let mut expected = u64::from((high_address >> 12) as u32) * 0x9e5f;
+        expected ^= expected >> 32;
+        assert_eq!(
+            big_page_hash(high_address, 0x100),
+            Some(expected as usize & 0xff)
+        );
+        assert_eq!(adjust_page_end_header(0x1ff0, 0x10), Some(0x2000));
+        let tree = 0xffff_8000_0001_0000;
+        let root = 0xffff_8000_0002_0000;
+        assert_eq!(decode_rb_root((root ^ tree) | 1, tree), Some(root));
+        assert_eq!(
+            decode_large_allocation(root | 0x1234, (0x2345u64 << 12) | 0xabc),
+            Some((root, 0x2345))
+        );
+    }
+}

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -146,8 +146,10 @@ pub(crate) fn adjust_page_end_header(candidate: u64, header_size: u64) -> Option
     if header_size == 0 || header_size > PAGE_SIZE {
         return None;
     }
-    if candidate & (PAGE_SIZE - 1) == PAGE_SIZE - header_size {
-        candidate.checked_add(header_size)
+    let page_offset = candidate & (PAGE_SIZE - 1);
+    let last_header_start = PAGE_SIZE - header_size;
+    if page_offset > last_header_start {
+        candidate.checked_sub(page_offset - last_header_start)
     } else {
         Some(candidate)
     }
@@ -385,7 +387,9 @@ mod tests {
             big_page_hash(high_address, 0x100),
             Some(expected as usize & 0xff)
         );
-        assert_eq!(adjust_page_end_header(0x1ff0, 0x10), Some(0x2000));
+        assert_eq!(adjust_page_end_header(0x1ff0, 0x10), Some(0x1ff0));
+        assert_eq!(adjust_page_end_header(0x1ff8, 0x10), Some(0x1ff0));
+        assert_eq!(adjust_page_end_header(0x2000, 0x10), Some(0x2000));
         let tree = 0xffff_8000_0001_0000;
         let root = 0xffff_8000_0002_0000;
         assert_eq!(decode_rb_root((root ^ tree) | 1, tree), Some(root));

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -129,14 +129,15 @@ pub(crate) fn decode_lfh_offsets(encoded: u32, subsegment: u64, lfh_key: u32) ->
     (decoded as u16, (decoded >> 16) as u16)
 }
 
-/// Each LFH slot uses two bits: 0 is reusable, 1 allocated, and 2/3 cached.
+/// Each LFH slot uses two bits. Bit 0 is the busy state, while bit 1 records
+/// unused-byte metadata and does not affect whether the block is allocated.
 pub(crate) fn lfh_bitmap_state(bitmap: &[u8], slot: usize) -> Option<PoolState> {
     let bit = slot.checked_mul(2)?;
     let byte = *bitmap.get(bit / 8)?;
-    Some(match (byte >> (bit % 8)) & 3 {
-        0 => PoolState::ReusableFree,
-        1 => PoolState::Allocated,
-        _ => PoolState::CachedFree,
+    Some(if (byte >> (bit % 8)) & 1 == 0 {
+        PoolState::ReusableFree
+    } else {
+        PoolState::Allocated
     })
 }
 
@@ -315,10 +316,17 @@ mod tests {
             decode_lfh_offsets(encoded_offsets, subsegment, lfh_key),
             (0x30, 0x248)
         );
+        let lfh_bitmap = [0b1110_0100];
         assert_eq!(
-            lfh_bitmap_state(&[0b0010_0100], 1),
-            Some(PoolState::Allocated)
+            lfh_bitmap_state(&lfh_bitmap, 0),
+            Some(PoolState::ReusableFree)
         );
+        assert_eq!(lfh_bitmap_state(&lfh_bitmap, 1), Some(PoolState::Allocated));
+        assert_eq!(
+            lfh_bitmap_state(&lfh_bitmap, 2),
+            Some(PoolState::ReusableFree)
+        );
+        assert_eq!(lfh_bitmap_state(&lfh_bitmap, 3), Some(PoolState::Allocated));
         assert_eq!(lfh_bitmap_state(&[], 0), None);
 
         let mut shifted = [0u8; 24];

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -220,9 +220,32 @@ pub(crate) fn big_page_hash(address: u64, table_size: usize) -> Option<usize> {
     }
 }
 
-pub(crate) fn big_page_candidates(address: u64, table_size: usize) -> Option<[usize; 2]> {
-    let first = big_page_hash(address, table_size)?;
-    Some([first, (first + 1) % table_size])
+pub(crate) struct BigPageProbe {
+    next: usize,
+    remaining: usize,
+    mask: usize,
+}
+
+impl Iterator for BigPageProbe {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let current = self.next;
+        self.next = (self.next + 1) & self.mask;
+        self.remaining -= 1;
+        Some(current)
+    }
+}
+
+pub(crate) fn big_page_probe(address: u64, table_size: usize) -> Option<BigPageProbe> {
+    Some(BigPageProbe {
+        next: big_page_hash(address, table_size)?,
+        remaining: table_size,
+        mask: table_size - 1,
+    })
 }
 
 pub(crate) fn display_tag(tag: u32) -> String {
@@ -347,12 +370,14 @@ mod tests {
         assert!(valid_descriptor_tree_signature(DESCRIPTOR_TREE_SIGNATURE));
         let first = big_page_hash(0x9000, 8).unwrap();
         assert_eq!(
-            big_page_candidates(0x9000, 8),
-            Some([first, (first + 1) % 8])
+            big_page_probe(0x9000, 8).unwrap().collect::<Vec<_>>(),
+            (0..8)
+                .map(|offset| (first + offset) % 8)
+                .collect::<Vec<_>>()
         );
         assert_eq!(big_page_hash(0, 0), None);
         assert_eq!(big_page_hash(0x9000, 3), None);
-        assert_eq!(big_page_candidates(0x9000, 3), None);
+        assert!(big_page_probe(0x9000, 3).is_none());
         let high_address = 0xffff_8000_1234_5000;
         let mut expected = u64::from((high_address >> 12) as u32) * 0x9e5f;
         expected ^= expected >> 32;

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -185,12 +185,8 @@ pub(crate) fn decode_pool_header(
     (header.block_size != 0 && header.pool_type <= 0x7f).then_some(header)
 }
 
-pub(crate) fn decode_rb_root(encoded: u64, tree_address: u64) -> Option<u64> {
-    let pointer = if encoded & 1 != 0 {
-        (encoded & !1) ^ tree_address
-    } else {
-        encoded
-    } & !0xf;
+pub(crate) fn decode_rb_root(root: u64, tree_address: u64, encoded: bool) -> Option<u64> {
+    let pointer = if encoded { root ^ tree_address } else { root } & !0xf;
     (pointer == 0 || is_kernel_pointer(pointer)).then_some(pointer)
 }
 
@@ -400,7 +396,9 @@ mod tests {
         assert_eq!(adjust_page_end_header(0x2000, 0x10), Some(0x2000));
         let tree = 0xffff_8000_0001_0000;
         let root = 0xffff_8000_0002_0000;
-        assert_eq!(decode_rb_root((root ^ tree) | 1, tree), Some(root));
+        assert_eq!(decode_rb_root(root, tree, false), Some(root));
+        assert_eq!(decode_rb_root(root ^ tree, tree, true), Some(root));
+        assert_eq!(decode_rb_root(tree, tree, true), Some(0));
         assert_eq!(
             decode_large_allocation(root | 0x1234, (0x2345u64 << 12) | 0xabc),
             Some((root, 0x2345))

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -193,6 +193,12 @@ pub(crate) fn decode_rb_root(root: u64, tree_address: u64, encoded: bool) -> Opt
     (pointer == 0 || is_kernel_pointer(pointer)).then_some(pointer)
 }
 
+/// Decode the 60-bit `NextEntry` field packed above the low four reserved bits
+/// in the x64 and ARM64 `_SLIST_HEADER.Region` word.
+pub(crate) fn decode_slist_header_next(region: u64) -> u64 {
+    (region as i64 >> 4) as u64
+}
+
 /// Decode the two packed words in `_HEAP_LARGE_ALLOC_DATA`.
 ///
 /// `VirtualAddress` shares its low 16 bits with `UnusedBytes`, while
@@ -409,6 +415,11 @@ mod tests {
         assert_eq!(decode_rb_root(root, tree, false), Some(root));
         assert_eq!(decode_rb_root(root ^ tree, tree, true), Some(root));
         assert_eq!(decode_rb_root(tree, tree, true), Some(0));
+        let slist_entry = 0xffff_8000_0012_3fe0;
+        assert_eq!(
+            decode_slist_header_next((slist_entry << 4) | 3),
+            slist_entry
+        );
         assert_eq!(
             decode_large_allocation(root | 0x1234, (0x2345u64 << 12) | 0xabc),
             Some((root, 0x2345))

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -4,6 +4,9 @@ pub(crate) const PAGE_SIZE: u64 = 0x1000;
 pub(crate) const VS_SIGNATURE: u16 = 0x2bed;
 pub(crate) const PAGE_SEGMENT_SIGNATURE: u64 = 0xa2e6_4ead_a2e6_4ead;
 pub(crate) const DESCRIPTOR_TREE_SIGNATURE: u32 = 0xccdd_ccdd;
+pub(crate) const DESCRIPTOR_FLAG_LFH: u8 = 0x01;
+pub(crate) const DESCRIPTOR_FLAG_COMMITTED: u8 = 0x02;
+pub(crate) const DESCRIPTOR_FLAG_VS: u8 = 0x20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Descriptor {
@@ -66,7 +69,7 @@ pub(crate) fn decode_descriptor(word: u32) -> Option<Descriptor> {
     (unit_size != 0).then_some(Descriptor {
         unit_size,
         flags,
-        committed: flags & 1 != 0,
+        committed: flags & DESCRIPTOR_FLAG_COMMITTED != 0,
     })
 }
 
@@ -278,22 +281,25 @@ mod tests {
     fn test_pool_decoder_bounds_and_shifted_offsets() {
         assert_eq!(read_u32(&[0, 1, 2, 3, 4], 1), Some(0x0403_0201));
         assert_eq!(read_u64(&[0; 7], 0), None);
-        assert_eq!(decode_descriptor(0x0100_0020).unwrap().unit_size, 0x20);
+        let committed = decode_descriptor(0x0200_0020).unwrap();
+        assert_eq!(committed.unit_size, 0x20);
+        assert!(committed.committed);
+        assert!(!decode_descriptor(0x0100_0020).unwrap().committed);
         assert_eq!(decode_descriptor(0), None);
         let mut descriptor = [0u8; 12];
         descriptor[7] = 0x20;
-        descriptor[3] = 1;
+        descriptor[3] = DESCRIPTOR_FLAG_COMMITTED;
         assert_eq!(
             decode_descriptor_at(&descriptor, 2, 10, 5, 1),
             Some(Descriptor {
                 unit_size: 0x20,
-                flags: 1,
+                flags: DESCRIPTOR_FLAG_COMMITTED,
                 committed: true
             })
         );
         let mut wide_descriptor = [0u8; 16];
         wide_descriptor[5..8].copy_from_slice(&[0x56, 0x34, 0x12]);
-        wide_descriptor[2] = 1;
+        wide_descriptor[2] = DESCRIPTOR_FLAG_COMMITTED;
         assert_eq!(
             decode_descriptor_at(&wide_descriptor, 0, 8, 5, 2)
                 .unwrap()

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -1,0 +1,305 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use super::{PoolSpan, PoolState, snapshot::PoolSnapshot};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Direction {
+    Underflow,
+    Overflow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Hole {
+    pub span_index: usize,
+    pub address: u64,
+    pub size: u64,
+    pub state: PoolState,
+    pub distance: u64,
+    pub immediate: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PoolIndex {
+    pub spans: Vec<PoolSpan>,
+    pub postings: HashMap<u32, Vec<usize>>,
+    pub diagnostics: Vec<String>,
+    row_postings: HashMap<RowIdentity, Vec<usize>>,
+    span_rows: Vec<RowIdentity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct RowIdentity {
+    pool_kind: super::PoolKind,
+    numa_node: u16,
+    heap: super::HeapIdentity,
+    backend: super::PoolBackend,
+    subsegment: Option<u64>,
+    size_class: u32,
+}
+
+impl From<&PoolSpan> for RowIdentity {
+    fn from(span: &PoolSpan) -> Self {
+        Self {
+            pool_kind: span.pool_kind,
+            numa_node: span.numa_node,
+            heap: span.heap,
+            backend: span.backend,
+            subsegment: span.subsegment,
+            size_class: span.size_class,
+        }
+    }
+}
+
+impl PoolIndex {
+    pub(crate) fn build(mut snapshot: PoolSnapshot) -> Self {
+        snapshot
+            .spans
+            .sort_by_key(|span| (span.heap, span.usable_address));
+        let mut postings: HashMap<u32, Vec<usize>> = HashMap::new();
+        let mut row_postings: HashMap<RowIdentity, Vec<usize>> = HashMap::new();
+        let mut span_rows = Vec::with_capacity(snapshot.spans.len());
+        for (index, span) in snapshot.spans.iter().enumerate() {
+            if span.state == PoolState::Allocated {
+                postings.entry(span.raw_tag).or_default().push(index);
+            }
+            let row = RowIdentity::from(span);
+            row_postings.entry(row).or_default().push(index);
+            span_rows.push(row);
+        }
+        Self {
+            spans: snapshot.spans,
+            postings,
+            diagnostics: snapshot.diagnostics,
+            row_postings,
+            span_rows,
+        }
+    }
+
+    fn same_boundary(left: &PoolSpan, right: &PoolSpan) -> bool {
+        left.pool_kind == right.pool_kind
+            && left.numa_node == right.numa_node
+            && left.heap == right.heap
+            && left.backend == right.backend
+            && left.subsegment == right.subsegment
+            && left.state != PoolState::Unreadable
+            && right.state != PoolState::Unreadable
+    }
+
+    pub(crate) fn predecessor(&self, index: usize) -> Option<usize> {
+        let previous = index.checked_sub(1)?;
+        Self::same_boundary(self.spans.get(previous)?, self.spans.get(index)?).then_some(previous)
+    }
+
+    pub(crate) fn successor(&self, index: usize) -> Option<usize> {
+        let next = index.checked_add(1)?;
+        Self::same_boundary(self.spans.get(index)?, self.spans.get(next)?).then_some(next)
+    }
+
+    pub(crate) fn holes(&self, allocation: usize, direction: Direction) -> Vec<Hole> {
+        let Some(origin) = self.spans.get(allocation) else {
+            return Vec::new();
+        };
+        let mut holes = Vec::new();
+        let mut cursor = allocation;
+        loop {
+            let next = match direction {
+                Direction::Underflow => self.predecessor(cursor),
+                Direction::Overflow => self.successor(cursor),
+            };
+            let Some(index) = next else { break };
+            let span = &self.spans[index];
+            if span.state == PoolState::Allocated {
+                break;
+            }
+            let distance = match direction {
+                Direction::Underflow => origin.usable_address.saturating_sub(span.end()),
+                Direction::Overflow => span.usable_address.saturating_sub(origin.end()),
+            };
+            holes.push(Hole {
+                span_index: index,
+                address: span.usable_address,
+                size: span.size,
+                state: span.state,
+                distance,
+                immediate: holes.is_empty() && distance == 0,
+            });
+            cursor = index;
+        }
+        holes
+    }
+
+    /// Matching allocations plus their local geometry. Unrelated allocations and
+    /// free spans are deliberately retained so tag filtering never erases a hole.
+    pub(crate) fn context_for_tag(&self, tag: u32) -> Vec<usize> {
+        let mut selected_rows = HashSet::new();
+        for &index in self.postings.get(&tag).into_iter().flatten() {
+            if let Some(row) = self.span_rows.get(index) {
+                selected_rows.insert(*row);
+            }
+        }
+        let mut result: Vec<_> = selected_rows
+            .into_iter()
+            .flat_map(|row| self.row_postings.get(&row).into_iter().flatten().copied())
+            .collect();
+        result.sort_unstable();
+        result
+    }
+
+    pub(crate) fn ranked_holes(&self, allocation: usize, direction: Direction) -> Vec<Hole> {
+        let Some(origin) = self.spans.get(allocation) else {
+            return Vec::new();
+        };
+        let mut holes = self.holes(allocation, direction);
+        holes.sort_by_key(|hole| {
+            let span = &self.spans[hole.span_index];
+            (
+                !hole.immediate,
+                hole.state != PoolState::ReusableFree,
+                span.backend != origin.backend || span.size_class != origin.size_class,
+                hole.distance,
+                u64::MAX - hole.size,
+                hole.address,
+            )
+        });
+        holes
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedSnapshot {
+    session: u64,
+    index: PoolIndex,
+}
+
+#[derive(Default)]
+pub(crate) struct SnapshotCache {
+    entry: Mutex<Option<CachedSnapshot>>,
+}
+
+impl SnapshotCache {
+    pub(crate) fn get_or_refresh<F>(
+        &self,
+        session: u64,
+        refresh: bool,
+        build: F,
+    ) -> Result<PoolIndex, String>
+    where
+        F: FnOnce() -> Result<PoolSnapshot, String>,
+    {
+        if !refresh
+            && let Some(cached) = self.entry.lock().unwrap().as_ref()
+            && cached.session == session
+        {
+            return Ok(cached.index.clone());
+        }
+        let snapshot = build()?;
+        let complete = snapshot.complete;
+        let index = PoolIndex::build(snapshot);
+        if complete {
+            *self.entry.lock().unwrap() = Some(CachedSnapshot {
+                session,
+                index: index.clone(),
+            });
+        }
+        Ok(index)
+    }
+
+    pub(crate) fn invalidate(&self) {
+        *self.entry.lock().unwrap() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::pool::{HeapIdentity, PoolBackend, PoolKind};
+
+    fn span(address: u64, tag: u32, state: PoolState, heap: u64) -> PoolSpan {
+        let mut span = PoolSpan::allocation(
+            address,
+            0x20,
+            tag,
+            PoolKind::NonPagedNx,
+            HeapIdentity {
+                pool_state: 1,
+                heap,
+                special: false,
+            },
+            PoolBackend::Lfh,
+        );
+        span.state = state;
+        span
+    }
+
+    #[test]
+    fn test_pool_snapshot_index_and_cache_invalidation() {
+        let tag = u32::from_le_bytes(*b"TEST");
+        let other = u32::from_le_bytes(*b"OTHR");
+        let snapshot = PoolSnapshot {
+            spans: vec![
+                span(0x1000, other, PoolState::Allocated, 1),
+                span(0x1020, tag, PoolState::Allocated, 1),
+                span(0x1040, 0, PoolState::ReusableFree, 1),
+                span(0x1060, 0, PoolState::CachedFree, 1),
+                span(0x1080, tag, PoolState::Allocated, 2),
+            ],
+            complete: true,
+            diagnostics: vec![],
+        };
+        let index = PoolIndex::build(snapshot.clone());
+        assert_eq!(index.postings[&tag], vec![1, 4]);
+        assert_eq!(index.successor(1), Some(2));
+        assert_eq!(index.successor(3), None); // heap boundary
+        let holes = index.ranked_holes(1, Direction::Overflow);
+        assert_eq!(holes[0].address, 0x1040);
+        assert!(holes[0].immediate);
+        assert!(index.context_for_tag(tag).contains(&0)); // unrelated neighbor preserved
+
+        let mut unreadable = span(0x1060, 0, PoolState::Unreadable, 1);
+        unreadable.size_class = 0x20;
+        let contextual = PoolIndex::build(PoolSnapshot {
+            spans: vec![
+                span(0x1000, tag, PoolState::Allocated, 1),
+                span(0x1020, other, PoolState::Allocated, 1),
+                span(0x1040, 0, PoolState::ReusableFree, 1),
+                unreadable,
+                span(0x1080, other, PoolState::Allocated, 1),
+            ],
+            complete: true,
+            diagnostics: vec![],
+        });
+        assert_eq!(contextual.context_for_tag(tag), vec![0, 1, 2, 3, 4]);
+        assert_eq!(contextual.successor(2), None);
+
+        let cache = SnapshotCache::default();
+        let builds = AtomicUsize::new(0);
+        let make = || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            Ok(snapshot.clone())
+        };
+        cache.get_or_refresh(7, false, make).unwrap();
+        cache.get_or_refresh(7, false, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+        cache.get_or_refresh(7, true, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+        cache.invalidate();
+        cache.get_or_refresh(7, false, make).unwrap();
+        cache.get_or_refresh(8, false, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 4);
+
+        let incomplete_builds = AtomicUsize::new(0);
+        let make_incomplete = || {
+            incomplete_builds.fetch_add(1, Ordering::SeqCst);
+            let mut value = snapshot.clone();
+            value.complete = false;
+            Ok(value)
+        };
+        cache.invalidate();
+        cache.get_or_refresh(9, false, make_incomplete).unwrap();
+        cache.get_or_refresh(9, false, make_incomplete).unwrap();
+        assert_eq!(incomplete_builds.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -187,6 +187,11 @@ impl SnapshotCache {
     where
         F: FnOnce() -> Result<PoolSnapshot, String>,
     {
+        // A forced refresh supersedes the cached view even if rebuilding fails or
+        // is interrupted. Never fall back to geometry the user explicitly replaced.
+        if refresh {
+            self.invalidate();
+        }
         if !refresh
             && let Some(cached) = self.entry.lock().unwrap().as_ref()
             && cached.session == session
@@ -201,6 +206,8 @@ impl SnapshotCache {
                 session,
                 index: index.clone(),
             });
+        } else {
+            self.invalidate();
         }
         Ok(index)
     }
@@ -301,5 +308,17 @@ mod tests {
         cache.get_or_refresh(9, false, make_incomplete).unwrap();
         cache.get_or_refresh(9, false, make_incomplete).unwrap();
         assert_eq!(incomplete_builds.load(Ordering::SeqCst), 2);
+
+        cache.invalidate();
+        cache.get_or_refresh(10, false, make).unwrap();
+        cache.get_or_refresh(10, true, make_incomplete).unwrap();
+        cache.get_or_refresh(10, false, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 6);
+        assert_eq!(incomplete_builds.load(Ordering::SeqCst), 3);
+
+        let failed_refresh = cache.get_or_refresh(10, true, || Err("interrupted".into()));
+        assert_eq!(failed_refresh.unwrap_err(), "interrupted");
+        cache.get_or_refresh(10, false, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 7);
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -202,6 +202,7 @@ const OPTIONAL_TYPES: &[TypeSpec] = &[
 
 const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
     ("_EX_HEAP_POOL_NODE", "Lookasides", &["Lookasides"]),
+    ("_RTL_RB_TREE", "Encoded", &["Encoded"]),
     (
         "_SEGMENT_HEAP",
         "LargeAllocMetadata",
@@ -504,6 +505,10 @@ mod tests {
         assert_eq!(
             layout.field("_HEAP_LFH_CONTEXT", "AffinitySlots"),
             Ok(FakeSymbols::field_value("AffinitizedInfoArrays") as usize)
+        );
+        assert_eq!(
+            layout.field("_RTL_RB_TREE", "Encoded"),
+            Ok(FakeSymbols::field_value("Encoded") as usize)
         );
     }
 

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -77,7 +77,6 @@ const TYPES: &[TypeSpec] = &[
             ("SegContexts", &["SegContexts", "SegmentContexts"]),
             ("VsContext", &["VsContext"]),
             ("LfhContext", &["LfhContext"]),
-            ("UserContext", &["UserContext"]),
         ],
     },
     TypeSpec {
@@ -132,10 +131,7 @@ const TYPES: &[TypeSpec] = &[
     },
     TypeSpec {
         name: "_HEAP_LFH_CONTEXT",
-        fields: &[
-            ("Buckets", &["Buckets"]),
-            ("AffinitySlots", &["AffinitySlots", "AffinitizedInfoArrays"]),
-        ],
+        fields: &[("Buckets", &["Buckets"])],
     },
     TypeSpec {
         name: "_HEAP_LFH_SUBSEGMENT",
@@ -172,6 +168,13 @@ const TYPES: &[TypeSpec] = &[
         ],
     },
     TypeSpec {
+        name: "_SLIST_HEADER",
+        fields: &[("Alignment", &["Alignment"]), ("Region", &["Region"])],
+    },
+];
+
+const OPTIONAL_TYPES: &[TypeSpec] = &[
+    TypeSpec {
         name: "_RTL_DYNAMIC_LOOKASIDE",
         fields: &[("BucketCount", &["BucketCount"]), ("Buckets", &["Buckets"])],
     },
@@ -179,13 +182,6 @@ const TYPES: &[TypeSpec] = &[
         name: "_RTL_LOOKASIDE",
         fields: &[("ListHead", &["ListHead"])],
     },
-    TypeSpec {
-        name: "_SLIST_HEADER",
-        fields: &[("Alignment", &["Alignment"]), ("Region", &["Region"])],
-    },
-];
-
-const OPTIONAL_TYPES: &[TypeSpec] = &[
     TypeSpec {
         name: "_POOL_TRACKER_BIG_PAGES",
         fields: &[
@@ -205,10 +201,16 @@ const OPTIONAL_TYPES: &[TypeSpec] = &[
 ];
 
 const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
+    ("_EX_HEAP_POOL_NODE", "Lookasides", &["Lookasides"]),
     (
         "_SEGMENT_HEAP",
         "LargeAllocMetadata",
         &["LargeAllocMetadata"],
+    ),
+    (
+        "_HEAP_LFH_CONTEXT",
+        "AffinitySlots",
+        &["AffinitySlots", "AffinitizedInfoArrays"],
     ),
     ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
 ];
@@ -499,6 +501,10 @@ mod tests {
             layout.field("_RTL_LOOKASIDE", "Size"),
             Ok(FakeSymbols::field_value("SizeClass") as usize)
         );
+        assert_eq!(
+            layout.field("_HEAP_LFH_CONTEXT", "AffinitySlots"),
+            Ok(FakeSymbols::field_value("AffinitizedInfoArrays") as usize)
+        );
     }
 
     #[test]
@@ -664,5 +670,38 @@ mod tests {
         )
         .unwrap();
         assert!(layout.type_layout("_HEAP_LARGE_ALLOC_DATA").is_err());
+    }
+
+    #[test]
+    fn test_resolve_tolerates_missing_optional_cache_metadata() {
+        for missing_type in ["_RTL_DYNAMIC_LOOKASIDE", "_RTL_LOOKASIDE"] {
+            let layout = PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_type: Some(missing_type),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+
+            assert!(layout.type_layout(missing_type).is_err());
+        }
+
+        for missing_field in [
+            ("_EX_HEAP_POOL_NODE", "Lookasides"),
+            ("_HEAP_LFH_CONTEXT", "AffinitySlots"),
+        ] {
+            let layout = PoolLayout::resolve(
+                &FakeSymbols {
+                    optional_fields: true,
+                    missing_field: Some(missing_field),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+
+            assert!(layout.field(missing_field.0, missing_field.1).is_err());
+        }
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -62,7 +62,6 @@ const TYPES: &[TypeSpec] = &[
     TypeSpec {
         name: "_EX_POOL_HEAP_MANAGER_STATE",
         fields: &[
-            ("HeapManager", &["HeapManager"]),
             ("PoolNode", &["PoolNode", "PoolNodes"]),
             ("NumberOfPools", &["NumberOfPools"]),
             ("SpecialHeaps", &["SpecialHeaps"]),
@@ -71,21 +70,6 @@ const TYPES: &[TypeSpec] = &[
     TypeSpec {
         name: "_EX_HEAP_POOL_NODE",
         fields: &[("Heaps", &["Heaps"])],
-    },
-    TypeSpec {
-        name: "_RTLP_HP_HEAP_MANAGER",
-        fields: &[("AllocTracker", &["AllocTracker"])],
-    },
-    TypeSpec {
-        name: "_RTLP_HP_ALLOC_TRACKER",
-        fields: &[("Tracker", &["Tracker", "AllocationTracker"])],
-    },
-    TypeSpec {
-        name: "_RTL_CSPARSE_BITMAP",
-        fields: &[
-            ("CommitDirectory", &["CommitDirectory"]),
-            ("UserData", &["UserData"]),
-        ],
     },
     TypeSpec {
         name: "_SEGMENT_HEAP",
@@ -105,7 +89,6 @@ const TYPES: &[TypeSpec] = &[
             ("UnitShift", &["UnitShift"]),
             ("FirstDescriptorIndex", &["FirstDescriptorIndex"]),
             ("SegmentMask", &["SegmentMask"]),
-            ("PagesPerUnitShift", &["PagesPerUnitShift"]),
         ],
     },
     TypeSpec {
@@ -128,7 +111,6 @@ const TYPES: &[TypeSpec] = &[
     TypeSpec {
         name: "_HEAP_VS_CONTEXT",
         fields: &[
-            ("SubsegmentList", &["SubsegmentList"]),
             ("FreeChunkTree", &["FreeChunkTree"]),
             ("DelayFreeContext", &["DelayFreeContext"]),
         ],
@@ -139,18 +121,11 @@ const TYPES: &[TypeSpec] = &[
     },
     TypeSpec {
         name: "_HEAP_VS_SUBSEGMENT",
-        fields: &[
-            ("ListEntry", &["ListEntry"]),
-            ("Size", &["Size"]),
-            ("Signature", &["Signature"]),
-        ],
+        fields: &[("Size", &["Size"]), ("Signature", &["Signature"])],
     },
     TypeSpec {
         name: "_HEAP_VS_CHUNK_HEADER",
-        fields: &[
-            ("Sizes", &["Sizes", "HeaderBits"]),
-            ("EncodedSegmentPageOffset", &["EncodedSegmentPageOffset"]),
-        ],
+        fields: &[("Sizes", &["Sizes", "HeaderBits"])],
     },
     TypeSpec {
         name: "_HEAP_VS_CHUNK_FREE_HEADER",
@@ -166,7 +141,6 @@ const TYPES: &[TypeSpec] = &[
     TypeSpec {
         name: "_HEAP_LFH_SUBSEGMENT",
         fields: &[
-            ("ListEntry", &["ListEntry", "AffinityListEntry"]),
             ("BlockOffsets", &["BlockOffsets"]),
             ("BlockBitmap", &["BlockBitmap"]),
             ("BlockCount", &["BlockCount"]),
@@ -182,7 +156,7 @@ const TYPES: &[TypeSpec] = &[
     },
     TypeSpec {
         name: "_RTL_RB_TREE",
-        fields: &[("Root", &["Root", "EncodedRoot"]), ("Min", &["Min"])],
+        fields: &[("Root", &["Root", "EncodedRoot"])],
     },
     TypeSpec {
         name: "_RTL_BALANCED_NODE",
@@ -228,19 +202,14 @@ const TYPES: &[TypeSpec] = &[
     },
 ];
 
-const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
-    ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
-    ("_RTL_DYNAMIC_LOOKASIDE", "ListHead", &["ListHead"]),
-    ("_RTL_DYNAMIC_LOOKASIDE", "Size", &["Size", "SizeClass"]),
-];
+const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] =
+    &[("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"])];
 
 const GLOBALS: &[(&str, &[&str])] = &[
     ("ExPoolState", &["nt!ExPoolState"]),
     ("RtlpHpHeapGlobals", &["nt!RtlpHpHeapGlobals"]),
     ("PoolBigPageTable", &["nt!PoolBigPageTable"]),
     ("PoolBigPageTableSize", &["nt!PoolBigPageTableSize"]),
-    ("RtlpLfhBucketIndexMap", &["nt!RtlpLfhBucketIndexMap"]),
-    ("RtlpBucketBlockSizes", &["nt!RtlpBucketBlockSizes"]),
 ];
 
 impl PoolLayout {
@@ -497,10 +466,6 @@ mod tests {
             layout.field("_RTL_LOOKASIDE", "Size"),
             Ok(FakeSymbols::field_value("SizeClass") as usize)
         );
-        assert_eq!(
-            layout.field("_RTL_DYNAMIC_LOOKASIDE", "ListHead"),
-            Ok(FakeSymbols::field_value("ListHead") as usize)
-        );
     }
 
     #[test]
@@ -535,5 +500,53 @@ mod tests {
             )),
             "_POOL_HEADER.PoolTag"
         );
+    }
+
+    #[test]
+    fn test_resolve_does_not_require_unused_metadata() {
+        for unused_type in [
+            "_RTLP_HP_HEAP_MANAGER",
+            "_RTLP_HP_ALLOC_TRACKER",
+            "_RTL_CSPARSE_BITMAP",
+        ] {
+            PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_type: Some(unused_type),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+        }
+
+        for (unused_type, unused_field) in [
+            ("_EX_POOL_HEAP_MANAGER_STATE", "HeapManager"),
+            ("_HEAP_SEG_CONTEXT", "PagesPerUnitShift"),
+            ("_HEAP_VS_CONTEXT", "SubsegmentList"),
+            ("_HEAP_VS_SUBSEGMENT", "ListEntry"),
+            ("_HEAP_VS_CHUNK_HEADER", "EncodedSegmentPageOffset"),
+            ("_HEAP_LFH_SUBSEGMENT", "ListEntry"),
+            ("_RTL_RB_TREE", "Min"),
+        ] {
+            PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_field: Some((unused_type, unused_field)),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+        }
+
+        for unused_global in ["nt!RtlpLfhBucketIndexMap", "nt!RtlpBucketBlockSizes"] {
+            PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_global: Some(unused_global),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+        }
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -1,0 +1,359 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use thiserror::Error;
+
+use super::decode::PoolHeaderLayout;
+use crate::dbgeng::{DbgEngError, DebugEngine};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SessionKey {
+    pub kernel_base: u64,
+    pub session: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TypeLayout {
+    pub size: u32,
+    pub fields: HashMap<&'static str, u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PoolLayout {
+    pub key: SessionKey,
+    pub globals: HashMap<&'static str, u64>,
+    pub types: HashMap<&'static str, TypeLayout>,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum LayoutError {
+    #[error("missing kernel pool symbols ({item}); run `.reload /f nt` and retry")]
+    Missing { item: String },
+}
+
+pub(crate) trait Symbols {
+    fn symbol(&self, name: &str) -> Result<u64, DbgEngError>;
+    fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError>;
+    fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError>;
+    fn field(&self, module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError>;
+}
+
+impl Symbols for DebugEngine {
+    fn symbol(&self, name: &str) -> Result<u64, DbgEngError> {
+        self.symbol_offset(name)
+    }
+    fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError> {
+        self.type_id(module, name)
+    }
+    fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError> {
+        self.type_size(module, type_id)
+    }
+    fn field(&self, module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError> {
+        self.field_offset(module, type_id, name)
+    }
+}
+
+struct TypeSpec {
+    name: &'static str,
+    fields: &'static [(&'static str, &'static [&'static str])],
+}
+
+const TYPES: &[TypeSpec] = &[
+    TypeSpec {
+        name: "_EX_POOL_HEAP_MANAGER_STATE",
+        fields: &[
+            ("HeapManager", &["HeapManager"]),
+            ("PoolNode", &["PoolNode", "PoolNodes"]),
+            ("NumberOfPools", &["NumberOfPools"]),
+            ("SpecialHeaps", &["SpecialHeaps"]),
+        ],
+    },
+    TypeSpec {
+        name: "_EX_HEAP_POOL_NODE",
+        fields: &[("Heaps", &["Heaps"])],
+    },
+    TypeSpec {
+        name: "_RTLP_HP_HEAP_MANAGER",
+        fields: &[("AllocTracker", &["AllocTracker"])],
+    },
+    TypeSpec {
+        name: "_RTLP_HP_ALLOC_TRACKER",
+        fields: &[("Tracker", &["Tracker", "AllocationTracker"])],
+    },
+    TypeSpec {
+        name: "_RTL_CSPARSE_BITMAP",
+        fields: &[
+            ("CommitDirectory", &["CommitDirectory"]),
+            ("UserData", &["UserData"]),
+        ],
+    },
+    TypeSpec {
+        name: "_SEGMENT_HEAP",
+        fields: &[
+            ("SegContexts", &["SegContexts", "SegmentContexts"]),
+            ("VsContext", &["VsContext"]),
+            ("LfhContext", &["LfhContext"]),
+            ("LargeAllocMetadata", &["LargeAllocMetadata"]),
+            ("UserContext", &["UserContext"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_SEG_CONTEXT",
+        fields: &[
+            ("SegmentListHead", &["SegmentListHead"]),
+            ("FreePageRanges", &["FreePageRanges", "FreePageRangeTree"]),
+            ("UnitShift", &["UnitShift"]),
+            ("FirstDescriptorIndex", &["FirstDescriptorIndex"]),
+            ("SegmentMask", &["SegmentMask"]),
+            ("PagesPerUnitShift", &["PagesPerUnitShift"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_PAGE_SEGMENT",
+        fields: &[
+            ("ListEntry", &["ListEntry"]),
+            ("DescArray", &["DescArray", "Descriptors"]),
+            ("Signature", &["Signature"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_PAGE_RANGE_DESCRIPTOR",
+        fields: &[
+            ("UnitSize", &["UnitSize"]),
+            ("RangeFlags", &["RangeFlags", "Flags"]),
+            ("TreeNode", &["TreeNode"]),
+            ("TreeSignature", &["TreeSignature"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_VS_CONTEXT",
+        fields: &[
+            ("SubsegmentList", &["SubsegmentList"]),
+            ("FreeChunkTree", &["FreeChunkTree"]),
+            ("DelayFreeContext", &["DelayFreeContext"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_VS_DELAY_FREE_CONTEXT",
+        fields: &[("ListHead", &["ListHead"])],
+    },
+    TypeSpec {
+        name: "_HEAP_VS_SUBSEGMENT",
+        fields: &[
+            ("ListEntry", &["ListEntry"]),
+            ("Size", &["Size"]),
+            ("Signature", &["Signature"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_VS_CHUNK_HEADER",
+        fields: &[
+            ("Sizes", &["Sizes", "HeaderBits"]),
+            ("EncodedSegmentPageOffset", &["EncodedSegmentPageOffset"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_VS_CHUNK_FREE_HEADER",
+        fields: &[("TreeNode", &["TreeNode", "Node"])],
+    },
+    TypeSpec {
+        name: "_HEAP_LFH_CONTEXT",
+        fields: &[
+            ("Buckets", &["Buckets"]),
+            ("AffinitySlots", &["AffinitySlots", "AffinitizedInfoArrays"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_LFH_SUBSEGMENT",
+        fields: &[
+            ("ListEntry", &["ListEntry", "AffinityListEntry"]),
+            ("BlockOffsets", &["BlockOffsets"]),
+            ("BlockBitmap", &["BlockBitmap"]),
+            ("BlockCount", &["BlockCount"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_LFH_SUBSEGMENT_ENCODED_OFFSETS",
+        fields: &[("EncodedData", &["EncodedData"])],
+    },
+    TypeSpec {
+        name: "_RTLP_HP_HEAP_GLOBALS",
+        fields: &[("HeapKey", &["HeapKey"]), ("LfhKey", &["LfhKey"])],
+    },
+    TypeSpec {
+        name: "_RTL_RB_TREE",
+        fields: &[("Root", &["Root", "EncodedRoot"]), ("Min", &["Min"])],
+    },
+    TypeSpec {
+        name: "_RTL_BALANCED_NODE",
+        fields: &[("Left", &["Left"]), ("Right", &["Right"])],
+    },
+    TypeSpec {
+        name: "_POOL_HEADER",
+        fields: &[
+            ("PreviousSize", &["PreviousSize"]),
+            ("PoolIndex", &["PoolIndex"]),
+            ("BlockSize", &["BlockSize"]),
+            ("PoolType", &["PoolType"]),
+            ("PoolTag", &["PoolTag"]),
+        ],
+    },
+    TypeSpec {
+        name: "_POOL_TRACKER_BIG_PAGES",
+        fields: &[
+            ("Va", &["Va"]),
+            ("Key", &["Key", "PoolTag"]),
+            ("NumberOfBytes", &["NumberOfBytes", "Size"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP_LARGE_ALLOC_DATA",
+        fields: &[
+            ("TreeNode", &["TreeNode"]),
+            ("VirtualAddress", &["VirtualAddress", "Address"]),
+            ("AllocatedPages", &["AllocatedPages", "NumberOfPages"]),
+        ],
+    },
+    TypeSpec {
+        name: "_RTL_DYNAMIC_LOOKASIDE",
+        fields: &[("BucketCount", &["BucketCount"]), ("Buckets", &["Buckets"])],
+    },
+    TypeSpec {
+        name: "_RTL_LOOKASIDE",
+        fields: &[("ListHead", &["ListHead"])],
+    },
+    TypeSpec {
+        name: "_SLIST_HEADER",
+        fields: &[("Alignment", &["Alignment"]), ("Region", &["Region"])],
+    },
+];
+
+const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
+    ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
+    ("_RTL_DYNAMIC_LOOKASIDE", "ListHead", &["ListHead"]),
+    ("_RTL_DYNAMIC_LOOKASIDE", "Size", &["Size", "SizeClass"]),
+];
+
+const GLOBALS: &[(&str, &[&str])] = &[
+    ("ExPoolState", &["nt!ExPoolState"]),
+    ("RtlpHpHeapGlobals", &["nt!RtlpHpHeapGlobals"]),
+    ("PoolBigPageTable", &["nt!PoolBigPageTable"]),
+    ("PoolBigPageTableSize", &["nt!PoolBigPageTableSize"]),
+    ("RtlpLfhBucketIndexMap", &["nt!RtlpLfhBucketIndexMap"]),
+    ("RtlpBucketBlockSizes", &["nt!RtlpBucketBlockSizes"]),
+];
+
+impl PoolLayout {
+    pub(crate) fn type_layout(&self, name: &str) -> Result<&TypeLayout, String> {
+        self.types
+            .get(name)
+            .ok_or_else(|| format!("resolved layout is missing type {name}"))
+    }
+
+    pub(crate) fn field(&self, type_name: &str, field: &str) -> Result<usize, String> {
+        self.type_layout(type_name)?
+            .fields
+            .get(field)
+            .copied()
+            .map(|value| value as usize)
+            .ok_or_else(|| format!("resolved layout is missing {type_name}.{field}"))
+    }
+
+    pub(crate) fn pool_header_layout(&self) -> Result<PoolHeaderLayout, String> {
+        Ok(PoolHeaderLayout {
+            size: self.type_layout("_POOL_HEADER")?.size as usize,
+            previous_size: self.field("_POOL_HEADER", "PreviousSize")?,
+            pool_index: self.field("_POOL_HEADER", "PoolIndex")?,
+            block_size: self.field("_POOL_HEADER", "BlockSize")?,
+            pool_type: self.field("_POOL_HEADER", "PoolType")?,
+            tag: self.field("_POOL_HEADER", "PoolTag")?,
+        })
+    }
+
+    pub(crate) fn resolve(symbols: &impl Symbols, key: SessionKey) -> Result<Self, LayoutError> {
+        let mut globals = HashMap::new();
+        for &(canonical, aliases) in GLOBALS {
+            let value = aliases
+                .iter()
+                .find_map(|name| symbols.symbol(name).ok())
+                .ok_or_else(|| LayoutError::Missing {
+                    item: canonical.into(),
+                })?;
+            globals.insert(canonical, value);
+        }
+        let mut types = HashMap::new();
+        for spec in TYPES {
+            let type_id =
+                symbols
+                    .type_id(key.kernel_base, spec.name)
+                    .map_err(|_| LayoutError::Missing {
+                        item: spec.name.into(),
+                    })?;
+            let size =
+                symbols
+                    .type_size(key.kernel_base, type_id)
+                    .map_err(|_| LayoutError::Missing {
+                        item: spec.name.into(),
+                    })?;
+            let mut fields = HashMap::new();
+            for &(canonical, aliases) in spec.fields {
+                let offset = aliases
+                    .iter()
+                    .find_map(|field| symbols.field(key.kernel_base, type_id, field).ok())
+                    .ok_or_else(|| LayoutError::Missing {
+                        item: format!("{}.{canonical}", spec.name),
+                    })?;
+                fields.insert(canonical, offset);
+            }
+            types.insert(spec.name, TypeLayout { size, fields });
+        }
+        for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
+            let Some(layout) = types.get_mut(type_name) else {
+                continue;
+            };
+            let Ok(type_id) = symbols.type_id(key.kernel_base, type_name) else {
+                continue;
+            };
+            if let Some(offset) = aliases
+                .iter()
+                .find_map(|field| symbols.field(key.kernel_base, type_id, field).ok())
+            {
+                layout.fields.insert(canonical, offset);
+            }
+        }
+        Ok(Self {
+            key,
+            globals,
+            types,
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct LayoutCache {
+    entries: Mutex<HashMap<SessionKey, PoolLayout>>,
+}
+
+impl LayoutCache {
+    pub(crate) fn global() -> &'static Self {
+        static CACHE: OnceLock<LayoutCache> = OnceLock::new();
+        CACHE.get_or_init(Self::default)
+    }
+
+    pub(crate) fn get_or_resolve(
+        &self,
+        symbols: &impl Symbols,
+        key: SessionKey,
+    ) -> Result<PoolLayout, LayoutError> {
+        if let Some(layout) = self.entries.lock().unwrap().get(&key).cloned() {
+            return Ok(layout);
+        }
+        let layout = PoolLayout::resolve(symbols, key)?;
+        self.entries.lock().unwrap().insert(key, layout.clone());
+        Ok(layout)
+    }
+
+    pub(crate) fn invalidate(&self) {
+        self.entries.lock().unwrap().clear();
+    }
+}

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -43,10 +43,10 @@ impl Symbols for DebugEngine {
         self.symbol_offset(name)
     }
     fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError> {
-        self.type_id(module, name)
+        DebugEngine::type_id(self, module, name)
     }
     fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError> {
-        self.type_size(module, type_id)
+        DebugEngine::type_size(self, module, type_id)
     }
     fn field(&self, module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError> {
         self.field_offset(module, type_id, name)
@@ -355,5 +355,185 @@ impl LayoutCache {
 
     pub(crate) fn invalidate(&self) {
         self.entries.lock().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeSymbols {
+        fallback_aliases: bool,
+        optional_fields: bool,
+        missing_global: Option<&'static str>,
+        missing_type: Option<&'static str>,
+        missing_field: Option<(&'static str, &'static str)>,
+    }
+
+    impl FakeSymbols {
+        fn error<T>() -> Result<T, DbgEngError> {
+            Err(DbgEngError::InvalidCommand)
+        }
+
+        fn field_value(name: &str) -> u32 {
+            name.bytes().map(u32::from).sum()
+        }
+
+        fn type_spec(type_id: u32) -> Option<&'static TypeSpec> {
+            type_id
+                .checked_sub(1)
+                .and_then(|index| TYPES.get(index as usize))
+        }
+
+        fn resolve_field(&self, spec: &TypeSpec, name: &str) -> Result<u32, DbgEngError> {
+            if let Some(&(canonical, aliases)) = spec
+                .fields
+                .iter()
+                .find(|(_, aliases)| aliases.contains(&name))
+            {
+                if self.missing_field == Some((spec.name, canonical))
+                    || (self.fallback_aliases && aliases.len() > 1 && name == aliases[0])
+                {
+                    return Self::error();
+                }
+                return Ok(Self::field_value(name));
+            }
+
+            if self.optional_fields
+                && let Some(&(_, _, aliases)) =
+                    OPTIONAL_FIELDS.iter().find(|(type_name, _, aliases)| {
+                        *type_name == spec.name && aliases.contains(&name)
+                    })
+            {
+                if self.fallback_aliases && aliases.len() > 1 && name == aliases[0] {
+                    return Self::error();
+                }
+                return Ok(Self::field_value(name));
+            }
+
+            Self::error()
+        }
+    }
+
+    impl Symbols for FakeSymbols {
+        fn symbol(&self, name: &str) -> Result<u64, DbgEngError> {
+            if self.missing_global == Some(name) {
+                return Self::error();
+            }
+            GLOBALS
+                .iter()
+                .position(|(_, aliases)| aliases.contains(&name))
+                .map(|index| 0xffff_8000_0000_0000 + (index as u64 + 1) * 0x1000)
+                .ok_or(DbgEngError::InvalidCommand)
+        }
+
+        fn type_id(&self, _module: u64, name: &str) -> Result<u32, DbgEngError> {
+            if self.missing_type == Some(name) {
+                return Self::error();
+            }
+            TYPES
+                .iter()
+                .position(|spec| spec.name == name)
+                .map(|index| index as u32 + 1)
+                .ok_or(DbgEngError::InvalidCommand)
+        }
+
+        fn type_size(&self, _module: u64, type_id: u32) -> Result<u32, DbgEngError> {
+            Self::type_spec(type_id)
+                .map(|_| 0x20 + type_id)
+                .ok_or(DbgEngError::InvalidCommand)
+        }
+
+        fn field(&self, _module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError> {
+            let Some(spec) = Self::type_spec(type_id) else {
+                return Self::error();
+            };
+            self.resolve_field(spec, name)
+        }
+    }
+
+    fn key() -> SessionKey {
+        SessionKey {
+            kernel_base: 0xffff_f800_0000_0000,
+            session: 7,
+        }
+    }
+
+    fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {
+        match result.unwrap_err() {
+            LayoutError::Missing { item } => item,
+        }
+    }
+
+    #[test]
+    fn test_resolve_required_layout_and_optional_absence() {
+        let layout = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
+
+        assert_eq!(layout.key, key());
+        assert_eq!(layout.globals.len(), GLOBALS.len());
+        assert_eq!(layout.types.len(), TYPES.len());
+        assert_eq!(
+            layout.field("_POOL_HEADER", "PoolTag"),
+            Ok(FakeSymbols::field_value("PoolTag") as usize)
+        );
+        assert!(layout.field("_RTL_LOOKASIDE", "Size").is_err());
+    }
+
+    #[test]
+    fn test_resolve_alias_fallback_and_optional_fields() {
+        let symbols = FakeSymbols {
+            fallback_aliases: true,
+            optional_fields: true,
+            ..FakeSymbols::default()
+        };
+        let layout = PoolLayout::resolve(&symbols, key()).unwrap();
+
+        assert_eq!(
+            layout.field("_EX_POOL_HEAP_MANAGER_STATE", "PoolNode"),
+            Ok(FakeSymbols::field_value("PoolNodes") as usize)
+        );
+        assert_eq!(
+            layout.field("_RTL_LOOKASIDE", "Size"),
+            Ok(FakeSymbols::field_value("SizeClass") as usize)
+        );
+        assert_eq!(
+            layout.field("_RTL_DYNAMIC_LOOKASIDE", "ListHead"),
+            Ok(FakeSymbols::field_value("ListHead") as usize)
+        );
+    }
+
+    #[test]
+    fn test_resolve_reports_missing_required_items() {
+        assert_eq!(
+            missing_item(PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_global: Some("nt!ExPoolState"),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )),
+            "ExPoolState"
+        );
+        assert_eq!(
+            missing_item(PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_type: Some("_POOL_HEADER"),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )),
+            "_POOL_HEADER"
+        );
+        assert_eq!(
+            missing_item(PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_field: Some(("_POOL_HEADER", "PoolTag")),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )),
+            "_POOL_HEADER.PoolTag"
+        );
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -77,7 +77,6 @@ const TYPES: &[TypeSpec] = &[
             ("SegContexts", &["SegContexts", "SegmentContexts"]),
             ("VsContext", &["VsContext"]),
             ("LfhContext", &["LfhContext"]),
-            ("LargeAllocMetadata", &["LargeAllocMetadata"]),
             ("UserContext", &["UserContext"]),
         ],
     },
@@ -173,6 +172,21 @@ const TYPES: &[TypeSpec] = &[
         ],
     },
     TypeSpec {
+        name: "_RTL_DYNAMIC_LOOKASIDE",
+        fields: &[("BucketCount", &["BucketCount"]), ("Buckets", &["Buckets"])],
+    },
+    TypeSpec {
+        name: "_RTL_LOOKASIDE",
+        fields: &[("ListHead", &["ListHead"])],
+    },
+    TypeSpec {
+        name: "_SLIST_HEADER",
+        fields: &[("Alignment", &["Alignment"]), ("Region", &["Region"])],
+    },
+];
+
+const OPTIONAL_TYPES: &[TypeSpec] = &[
+    TypeSpec {
         name: "_POOL_TRACKER_BIG_PAGES",
         fields: &[
             ("Va", &["Va"]),
@@ -188,29 +202,54 @@ const TYPES: &[TypeSpec] = &[
             ("AllocatedPages", &["AllocatedPages", "NumberOfPages"]),
         ],
     },
-    TypeSpec {
-        name: "_RTL_DYNAMIC_LOOKASIDE",
-        fields: &[("BucketCount", &["BucketCount"]), ("Buckets", &["Buckets"])],
-    },
-    TypeSpec {
-        name: "_RTL_LOOKASIDE",
-        fields: &[("ListHead", &["ListHead"])],
-    },
-    TypeSpec {
-        name: "_SLIST_HEADER",
-        fields: &[("Alignment", &["Alignment"]), ("Region", &["Region"])],
-    },
 ];
 
-const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] =
-    &[("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"])];
+const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
+    (
+        "_SEGMENT_HEAP",
+        "LargeAllocMetadata",
+        &["LargeAllocMetadata"],
+    ),
+    ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
+];
 
 const GLOBALS: &[(&str, &[&str])] = &[
     ("ExPoolState", &["nt!ExPoolState"]),
     ("RtlpHpHeapGlobals", &["nt!RtlpHpHeapGlobals"]),
+];
+
+const OPTIONAL_GLOBALS: &[(&str, &[&str])] = &[
     ("PoolBigPageTable", &["nt!PoolBigPageTable"]),
     ("PoolBigPageTableSize", &["nt!PoolBigPageTableSize"]),
 ];
+
+fn resolve_type(
+    symbols: &impl Symbols,
+    module: u64,
+    spec: &TypeSpec,
+) -> Result<TypeLayout, LayoutError> {
+    let type_id = symbols
+        .type_id(module, spec.name)
+        .map_err(|_| LayoutError::Missing {
+            item: spec.name.into(),
+        })?;
+    let size = symbols
+        .type_size(module, type_id)
+        .map_err(|_| LayoutError::Missing {
+            item: spec.name.into(),
+        })?;
+    let mut fields = HashMap::new();
+    for &(canonical, aliases) in spec.fields {
+        let offset = aliases
+            .iter()
+            .find_map(|field| symbols.field(module, type_id, field).ok())
+            .ok_or_else(|| LayoutError::Missing {
+                item: format!("{}.{canonical}", spec.name),
+            })?;
+        fields.insert(canonical, offset);
+    }
+    Ok(TypeLayout { size, fields })
+}
 
 impl PoolLayout {
     pub(crate) fn type_layout(&self, name: &str) -> Result<&TypeLayout, LayoutError> {
@@ -252,31 +291,19 @@ impl PoolLayout {
                 })?;
             globals.insert(canonical, value);
         }
+        for &(canonical, aliases) in OPTIONAL_GLOBALS {
+            if let Some(value) = aliases.iter().find_map(|name| symbols.symbol(name).ok()) {
+                globals.insert(canonical, value);
+            }
+        }
         let mut types = HashMap::new();
         for spec in TYPES {
-            let type_id =
-                symbols
-                    .type_id(key.kernel_base, spec.name)
-                    .map_err(|_| LayoutError::Missing {
-                        item: spec.name.into(),
-                    })?;
-            let size =
-                symbols
-                    .type_size(key.kernel_base, type_id)
-                    .map_err(|_| LayoutError::Missing {
-                        item: spec.name.into(),
-                    })?;
-            let mut fields = HashMap::new();
-            for &(canonical, aliases) in spec.fields {
-                let offset = aliases
-                    .iter()
-                    .find_map(|field| symbols.field(key.kernel_base, type_id, field).ok())
-                    .ok_or_else(|| LayoutError::Missing {
-                        item: format!("{}.{canonical}", spec.name),
-                    })?;
-                fields.insert(canonical, offset);
+            types.insert(spec.name, resolve_type(symbols, key.kernel_base, spec)?);
+        }
+        for spec in OPTIONAL_TYPES {
+            if let Ok(layout) = resolve_type(symbols, key.kernel_base, spec) {
+                types.insert(spec.name, layout);
             }
-            types.insert(spec.name, TypeLayout { size, fields });
         }
         for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
             let Some(layout) = types.get_mut(type_name) else {
@@ -354,7 +381,7 @@ mod tests {
         fn type_spec(type_id: u32) -> Option<&'static TypeSpec> {
             type_id
                 .checked_sub(1)
-                .and_then(|index| TYPES.get(index as usize))
+                .and_then(|index| TYPES.iter().chain(OPTIONAL_TYPES).nth(index as usize))
         }
 
         fn resolve_field(&self, spec: &TypeSpec, name: &str) -> Result<u32, DbgEngError> {
@@ -372,12 +399,14 @@ mod tests {
             }
 
             if self.optional_fields
-                && let Some(&(_, _, aliases)) =
+                && let Some(&(_, canonical, aliases)) =
                     OPTIONAL_FIELDS.iter().find(|(type_name, _, aliases)| {
                         *type_name == spec.name && aliases.contains(&name)
                     })
             {
-                if self.fallback_aliases && aliases.len() > 1 && name == aliases[0] {
+                if self.missing_field == Some((spec.name, canonical))
+                    || (self.fallback_aliases && aliases.len() > 1 && name == aliases[0])
+                {
                     return Self::error();
                 }
                 return Ok(Self::field_value(name));
@@ -394,6 +423,7 @@ mod tests {
             }
             GLOBALS
                 .iter()
+                .chain(OPTIONAL_GLOBALS)
                 .position(|(_, aliases)| aliases.contains(&name))
                 .map(|index| 0xffff_8000_0000_0000 + (index as u64 + 1) * 0x1000)
                 .ok_or(DbgEngError::InvalidCommand)
@@ -405,6 +435,7 @@ mod tests {
             }
             TYPES
                 .iter()
+                .chain(OPTIONAL_TYPES)
                 .position(|spec| spec.name == name)
                 .map(|index| index as u32 + 1)
                 .ok_or(DbgEngError::InvalidCommand)
@@ -442,8 +473,8 @@ mod tests {
         let layout = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
 
         assert_eq!(layout.key, key());
-        assert_eq!(layout.globals.len(), GLOBALS.len());
-        assert_eq!(layout.types.len(), TYPES.len());
+        assert_eq!(layout.globals.len(), GLOBALS.len() + OPTIONAL_GLOBALS.len());
+        assert_eq!(layout.types.len(), TYPES.len() + OPTIONAL_TYPES.len());
         assert_eq!(
             layout.field("_POOL_HEADER", "PoolTag"),
             Ok(FakeSymbols::field_value("PoolTag") as usize)
@@ -576,5 +607,62 @@ mod tests {
             )
             .unwrap();
         }
+    }
+
+    #[test]
+    fn test_resolve_tolerates_missing_optional_large_metadata() {
+        for missing_type in ["_HEAP_LARGE_ALLOC_DATA", "_POOL_TRACKER_BIG_PAGES"] {
+            let layout = PoolLayout::resolve(
+                &FakeSymbols {
+                    optional_fields: true,
+                    missing_type: Some(missing_type),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+
+            assert!(layout.type_layout(missing_type).is_err());
+            assert!(layout.type_layout("_POOL_HEADER").is_ok());
+        }
+
+        for missing_global in ["nt!PoolBigPageTable", "nt!PoolBigPageTableSize"] {
+            let canonical = OPTIONAL_GLOBALS
+                .iter()
+                .find(|(_, aliases)| aliases.contains(&missing_global))
+                .unwrap()
+                .0;
+            let layout = PoolLayout::resolve(
+                &FakeSymbols {
+                    missing_global: Some(missing_global),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )
+            .unwrap();
+
+            assert!(!layout.globals.contains_key(canonical));
+        }
+
+        let layout = PoolLayout::resolve(
+            &FakeSymbols {
+                optional_fields: true,
+                missing_field: Some(("_SEGMENT_HEAP", "LargeAllocMetadata")),
+                ..FakeSymbols::default()
+            },
+            key(),
+        )
+        .unwrap();
+        assert!(layout.field("_SEGMENT_HEAP", "LargeAllocMetadata").is_err());
+
+        let layout = PoolLayout::resolve(
+            &FakeSymbols {
+                missing_field: Some(("_HEAP_LARGE_ALLOC_DATA", "TreeNode")),
+                ..FakeSymbols::default()
+            },
+            key(),
+        )
+        .unwrap();
+        assert!(layout.type_layout("_HEAP_LARGE_ALLOC_DATA").is_err());
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -25,7 +25,7 @@ pub(crate) struct PoolLayout {
     pub types: HashMap<&'static str, TypeLayout>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub(crate) enum LayoutError {
     #[error("missing kernel pool symbols ({item}); run `.reload /f nt` and retry")]
     Missing { item: String },
@@ -213,22 +213,24 @@ const GLOBALS: &[(&str, &[&str])] = &[
 ];
 
 impl PoolLayout {
-    pub(crate) fn type_layout(&self, name: &str) -> Result<&TypeLayout, String> {
+    pub(crate) fn type_layout(&self, name: &str) -> Result<&TypeLayout, LayoutError> {
         self.types
             .get(name)
-            .ok_or_else(|| format!("resolved layout is missing type {name}"))
+            .ok_or_else(|| LayoutError::Missing { item: name.into() })
     }
 
-    pub(crate) fn field(&self, type_name: &str, field: &str) -> Result<usize, String> {
+    pub(crate) fn field(&self, type_name: &str, field: &str) -> Result<usize, LayoutError> {
         self.type_layout(type_name)?
             .fields
             .get(field)
             .copied()
             .map(|value| value as usize)
-            .ok_or_else(|| format!("resolved layout is missing {type_name}.{field}"))
+            .ok_or_else(|| LayoutError::Missing {
+                item: format!("{type_name}.{field}"),
+            })
     }
 
-    pub(crate) fn pool_header_layout(&self) -> Result<PoolHeaderLayout, String> {
+    pub(crate) fn pool_header_layout(&self) -> Result<PoolHeaderLayout, LayoutError> {
         Ok(PoolHeaderLayout {
             size: self.type_layout("_POOL_HEADER")?.size as usize,
             previous_size: self.field("_POOL_HEADER", "PreviousSize")?,
@@ -499,6 +501,32 @@ mod tests {
                 key(),
             )),
             "_POOL_HEADER.PoolTag"
+        );
+    }
+
+    #[test]
+    fn test_layout_accessors_report_typed_missing_items() {
+        let mut layout = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
+
+        assert_eq!(
+            layout.type_layout("_MISSING").unwrap_err(),
+            LayoutError::Missing {
+                item: "_MISSING".into()
+            }
+        );
+        assert_eq!(
+            layout.field("_POOL_HEADER", "Missing").unwrap_err(),
+            LayoutError::Missing {
+                item: "_POOL_HEADER.Missing".into()
+            }
+        );
+
+        layout.types.remove("_POOL_HEADER");
+        assert_eq!(
+            layout.pool_header_layout().unwrap_err(),
+            LayoutError::Missing {
+                item: "_POOL_HEADER".into()
+            }
         );
     }
 

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -80,25 +80,29 @@ fn cell(span: &PoolSpan, selected: bool, dml: bool) -> String {
     )
 }
 
-fn push_chunked(chunks: &mut Vec<String>, text: &str) {
+fn push_chunked(chunks: &mut Vec<String>, text: &str, dml: bool) {
     for fragment in text.split_inclusive('\n') {
-        push_atomic(chunks, fragment);
+        push_atomic(chunks, fragment, dml);
     }
 }
 
-fn push_atomic(chunks: &mut Vec<String>, fragment: &str) {
+fn push_atomic(chunks: &mut Vec<String>, fragment: &str, dml: bool) {
     if fragment.is_empty() {
         return;
     }
     if fragment.len() > OUTPUT_CHUNK {
         let mut remaining = fragment;
         while !remaining.is_empty() {
-            let take = safe_dml_boundary(remaining, OUTPUT_CHUNK);
+            let take = if dml {
+                safe_dml_boundary(remaining, OUTPUT_CHUNK)
+            } else {
+                safe_text_boundary(remaining, OUTPUT_CHUNK)
+            };
             debug_assert!(take != 0, "a single DML element exceeds the output limit");
             if take == 0 {
                 return;
             }
-            push_atomic(chunks, &remaining[..take]);
+            push_atomic(chunks, &remaining[..take], dml);
             remaining = &remaining[take..];
         }
         return;
@@ -109,23 +113,46 @@ fn push_atomic(chunks: &mut Vec<String>, fragment: &str) {
     chunks.last_mut().unwrap().push_str(fragment);
 }
 
+fn safe_text_boundary(text: &str, limit: usize) -> usize {
+    text.char_indices()
+        .map(|(offset, character)| offset + character.len_utf8())
+        .take_while(|end| *end <= limit)
+        .last()
+        .unwrap_or(0)
+}
+
 fn safe_dml_boundary(text: &str, limit: usize) -> usize {
-    let mut in_tag = false;
+    let mut tag_start = None;
     let mut in_entity = false;
+    let mut depth = 0usize;
     let mut boundary = 0;
     for (offset, character) in text.char_indices() {
         let end = offset + character.len_utf8();
         if end > limit {
             break;
         }
-        match character {
-            '<' if !in_entity => in_tag = true,
-            '>' if in_tag => in_tag = false,
-            '&' if !in_tag => in_entity = true,
-            ';' if in_entity => in_entity = false,
-            _ => {}
+        if let Some(start) = tag_start {
+            if character == '>' {
+                let tag = &text[start..end];
+                if tag.starts_with("</") {
+                    depth = depth.saturating_sub(1);
+                } else if !tag.ends_with("/>") && !tag.starts_with("<!") && !tag.starts_with("<?") {
+                    depth += 1;
+                }
+                tag_start = None;
+            }
+        } else if in_entity {
+            if character == ';' {
+                in_entity = false;
+            }
+        } else {
+            match character {
+                '<' => tag_start = Some(offset),
+                '&' => in_entity = true,
+                _ => {}
+            }
         }
-        if !in_tag && !in_entity {
+        if tag_start.is_none() && !in_entity && depth == 0 {
             boundary = end;
         }
     }
@@ -159,12 +186,17 @@ pub(crate) fn render_pool_map(index: &PoolIndex, options: RenderOptions) -> Vec<
         } else {
             diagnostic.clone()
         };
-        push_chunked(&mut chunks, &format!("Diagnostic: {diagnostic}\n"));
+        push_chunked(
+            &mut chunks,
+            &format!("Diagnostic: {diagnostic}\n"),
+            options.dml,
+        );
     }
     if rows.is_empty() {
         push_chunked(
             &mut chunks,
             "No matching pool allocations in the stopped-target snapshot.\n",
+            options.dml,
         );
         return chunks;
     }
@@ -181,12 +213,13 @@ pub(crate) fn render_pool_map(index: &PoolIndex, options: RenderOptions) -> Vec<
                 first.usable_address,
                 key.size_class
             ),
+            options.dml,
         );
         let mut previous_index = None;
         for index_value in indices {
             let span = &index.spans[index_value];
             if previous_index.is_some_and(|index| index + 1 != index_value) {
-                push_atomic(&mut chunks, "|");
+                push_atomic(&mut chunks, "|", options.dml);
             }
             push_atomic(
                 &mut chunks,
@@ -195,17 +228,23 @@ pub(crate) fn render_pool_map(index: &PoolIndex, options: RenderOptions) -> Vec<
                     options.tag == Some(span.raw_tag) && span.state == PoolState::Allocated,
                     options.dml,
                 ),
+                options.dml,
             );
             previous_index = Some(index_value);
         }
-        push_atomic(&mut chunks, "\n");
+        push_atomic(&mut chunks, "\n", options.dml);
     }
     push_chunked(
         &mut chunks,
         "Legend: S selected tag, A unrelated allocation, . reusable hole, c cached/delay-free, ? unreadable\n",
+        options.dml,
     );
     if let Some(tag) = options.tag {
-        push_chunked(&mut chunks, &render_advice(index, tag, options.dml));
+        push_chunked(
+            &mut chunks,
+            &render_advice(index, tag, options.dml),
+            options.dml,
+        );
     }
     chunks
 }
@@ -394,6 +433,30 @@ mod tests {
         assert!(dml.contains("<link cmd="));
         assert!(dml.contains("A&lt;&amp;&quot;"));
         assert!(escape_dml("<&\"").contains("&lt;&amp;&quot;"));
+
+        let complete_cell = cell(&index.spans[0], true, true);
+        let two_cells = complete_cell.repeat(2);
+        assert_eq!(
+            safe_dml_boundary(&two_cells, complete_cell.len() + complete_cell.len() / 2),
+            complete_cell.len()
+        );
+        let mut atomic_chunks = Vec::new();
+        let oversized_cells = complete_cell.repeat(200);
+        push_atomic(&mut atomic_chunks, &oversized_cells, true);
+        assert!(atomic_chunks.len() > 1);
+        assert_eq!(atomic_chunks.concat(), oversized_cells);
+        for chunk in &atomic_chunks {
+            assert_eq!(
+                chunk.matches("<link ").count(),
+                chunk.matches("</link>").count()
+            );
+            assert_eq!(
+                chunk.matches("<col ").count(),
+                chunk.matches("</col>").count()
+            );
+            assert!(chunk.len() <= OUTPUT_CHUNK);
+        }
+
         assert!(
             render_pool_map(
                 &index,

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -43,6 +43,7 @@ fn kind_name(kind: PoolKind) -> &'static str {
         PoolKind::SpecialNonPaged => "special-nonpaged",
         PoolKind::SpecialNonPagedNx => "special-nonpaged-nx",
         PoolKind::SpecialPaged => "special-paged",
+        PoolKind::SpecialPrototypePaged => "special-prototype-paged",
     }
 }
 

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -1,0 +1,450 @@
+use std::collections::BTreeMap;
+
+use super::index::{Direction, PoolIndex};
+use super::{HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState};
+
+const OUTPUT_CHUNK: usize = 7_500;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RenderOptions {
+    pub tag: Option<u32>,
+    pub dml: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RowKey {
+    kind: PoolKind,
+    node: u16,
+    heap: HeapIdentity,
+    backend: PoolBackend,
+    subsegment: Option<u64>,
+    size_class: u32,
+}
+
+pub(crate) fn escape_dml(text: &str) -> String {
+    text.chars()
+        .map(|character| match character {
+            '&' => "&amp;".to_string(),
+            '<' => "&lt;".to_string(),
+            '>' => "&gt;".to_string(),
+            '"' => "&quot;".to_string(),
+            '\'' => "&apos;".to_string(),
+            _ => character.to_string(),
+        })
+        .collect()
+}
+
+fn kind_name(kind: PoolKind) -> &'static str {
+    match kind {
+        PoolKind::NonPagedExecutable => "nonpaged-exec",
+        PoolKind::NonPagedNx => "nonpaged-nx",
+        PoolKind::Paged => "paged",
+        PoolKind::PrototypePaged => "prototype-paged",
+        PoolKind::SpecialNonPaged => "special-nonpaged",
+        PoolKind::SpecialNonPagedNx => "special-nonpaged-nx",
+        PoolKind::SpecialPaged => "special-paged",
+    }
+}
+
+fn backend_name(backend: PoolBackend) -> &'static str {
+    match backend {
+        PoolBackend::Lfh => "LFH",
+        PoolBackend::Vs => "VS",
+        PoolBackend::Segment => "segment",
+        PoolBackend::Large => "large",
+    }
+}
+
+fn glyph(span: &PoolSpan, selected: bool) -> (char, &'static str) {
+    if selected {
+        ('S', "0x00ff00")
+    } else {
+        match span.state {
+            PoolState::Allocated => ('A', "0x5dade2"),
+            PoolState::ReusableFree => ('.', "0xf4d03f"),
+            PoolState::CachedFree => ('c', "0xe67e22"),
+            PoolState::Unreadable => ('?', "0x7f8c8d"),
+        }
+    }
+}
+
+fn cell(span: &PoolSpan, selected: bool, dml: bool) -> String {
+    let (glyph, color) = glyph(span, selected);
+    if !dml {
+        return glyph.to_string();
+    }
+    let command = format!("!win_kexp.poolmap {:#x}", span.usable_address);
+    format!(
+        "<link cmd=\"{}\"><col fg=\"{color}\">{glyph}</col></link>",
+        escape_dml(&command)
+    )
+}
+
+fn push_chunked(chunks: &mut Vec<String>, text: &str) {
+    for fragment in text.split_inclusive('\n') {
+        push_atomic(chunks, fragment);
+    }
+}
+
+fn push_atomic(chunks: &mut Vec<String>, fragment: &str) {
+    if fragment.is_empty() {
+        return;
+    }
+    if fragment.len() > OUTPUT_CHUNK {
+        let mut remaining = fragment;
+        while !remaining.is_empty() {
+            let take = safe_dml_boundary(remaining, OUTPUT_CHUNK);
+            debug_assert!(take != 0, "a single DML element exceeds the output limit");
+            if take == 0 {
+                return;
+            }
+            push_atomic(chunks, &remaining[..take]);
+            remaining = &remaining[take..];
+        }
+        return;
+    }
+    if chunks.is_empty() || chunks.last().map_or(0, String::len) + fragment.len() > OUTPUT_CHUNK {
+        chunks.push(String::new());
+    }
+    chunks.last_mut().unwrap().push_str(fragment);
+}
+
+fn safe_dml_boundary(text: &str, limit: usize) -> usize {
+    let mut in_tag = false;
+    let mut in_entity = false;
+    let mut boundary = 0;
+    for (offset, character) in text.char_indices() {
+        let end = offset + character.len_utf8();
+        if end > limit {
+            break;
+        }
+        match character {
+            '<' if !in_entity => in_tag = true,
+            '>' if in_tag => in_tag = false,
+            '&' if !in_tag => in_entity = true,
+            ';' if in_entity => in_entity = false,
+            _ => {}
+        }
+        if !in_tag && !in_entity {
+            boundary = end;
+        }
+    }
+    boundary
+}
+
+pub(crate) fn render_pool_map(index: &PoolIndex, options: RenderOptions) -> Vec<String> {
+    let selected_indices = options
+        .tag
+        .map(|tag| index.context_for_tag(tag))
+        .unwrap_or_else(|| (0..index.spans.len()).collect());
+    let mut rows: BTreeMap<RowKey, Vec<usize>> = BTreeMap::new();
+    for span_index in selected_indices {
+        let span = &index.spans[span_index];
+        rows.entry(RowKey {
+            kind: span.pool_kind,
+            node: span.numa_node,
+            heap: span.heap,
+            backend: span.backend,
+            subsegment: span.subsegment,
+            size_class: span.size_class,
+        })
+        .or_default()
+        .push(span_index);
+    }
+
+    let mut chunks = Vec::new();
+    for diagnostic in &index.diagnostics {
+        let diagnostic = if options.dml {
+            escape_dml(diagnostic)
+        } else {
+            diagnostic.clone()
+        };
+        push_chunked(&mut chunks, &format!("Diagnostic: {diagnostic}\n"));
+    }
+    if rows.is_empty() {
+        push_chunked(
+            &mut chunks,
+            "No matching pool allocations in the stopped-target snapshot.\n",
+        );
+        return chunks;
+    }
+    for (key, indices) in rows {
+        let first = &index.spans[indices[0]];
+        push_atomic(
+            &mut chunks,
+            &format!(
+                "{} node={} {} heap={:#x} base={:#x} class={:#x}: ",
+                kind_name(key.kind),
+                key.node,
+                backend_name(key.backend),
+                key.heap.heap,
+                first.usable_address,
+                key.size_class
+            ),
+        );
+        let mut previous_index = None;
+        for index_value in indices {
+            let span = &index.spans[index_value];
+            if previous_index.is_some_and(|index| index + 1 != index_value) {
+                push_atomic(&mut chunks, "|");
+            }
+            push_atomic(
+                &mut chunks,
+                &cell(
+                    span,
+                    options.tag == Some(span.raw_tag) && span.state == PoolState::Allocated,
+                    options.dml,
+                ),
+            );
+            previous_index = Some(index_value);
+        }
+        push_atomic(&mut chunks, "\n");
+    }
+    push_chunked(
+        &mut chunks,
+        "Legend: S selected tag, A unrelated allocation, . reusable hole, c cached/delay-free, ? unreadable\n",
+    );
+    if let Some(tag) = options.tag {
+        push_chunked(&mut chunks, &render_advice(index, tag, options.dml));
+    }
+    chunks
+}
+
+pub(crate) fn render_advice(index: &PoolIndex, tag: u32, dml: bool) -> String {
+    let mut output = String::from("Observed geometry:\n");
+    for &allocation in index.postings.get(&tag).into_iter().flatten() {
+        let span = &index.spans[allocation];
+        let overflow = index.ranked_holes(allocation, Direction::Overflow);
+        let underflow = index.ranked_holes(allocation, Direction::Underflow);
+        output.push_str(&format!(
+            "- {} {} allocation {} at {:#x}+{:#x}; header distance {:#x}, page offset {:#x}.\n",
+            kind_name(span.pool_kind),
+            backend_name(span.backend),
+            if dml {
+                escape_dml(&span.display_tag)
+            } else {
+                span.display_tag.clone()
+            },
+            span.usable_address,
+            span.size,
+            span.usable_address.saturating_sub(span.header_address),
+            span.usable_address & 0xfff
+        ));
+        for (name, holes) in [("overflow", overflow), ("underflow", underflow)] {
+            if let Some(hole) = holes.first() {
+                output.push_str(&format!(
+                    "  {name}: {} hole at {:#x}+{:#x}, distance {:#x}.\n",
+                    match hole.state {
+                        PoolState::ReusableFree => "reusable",
+                        PoolState::CachedFree => "cached/delay-free",
+                        PoolState::Unreadable => "unreadable",
+                        PoolState::Allocated => "allocated",
+                    },
+                    hole.address,
+                    hole.size,
+                    hole.distance
+                ));
+            }
+        }
+        match span.backend {
+            PoolBackend::Lfh => output.push_str(
+                "  LFH: account for bucket size, affinity, and randomized slot selection; bitmap reuse is evidence, not a deterministic placement guarantee.\n",
+            ),
+            PoolBackend::Vs => output.push_str(
+                "  VS: consider splitting/coalescing, dynamic-lookaside retention, delay-free state, extra-header distance, and page boundaries.\n",
+            ),
+            PoolBackend::Segment => output.push_str(
+                "  Segment backend: descriptor/page-range adjacency is shown; validate commitment boundaries before relying on it.\n",
+            ),
+            PoolBackend::Large => output.push_str(
+                "  Large backend: geometry is page-granular and the tag/size evidence comes from the validated big-page entry.\n",
+            ),
+        }
+        output.push_str(if span.pool_kind == PoolKind::NonPagedExecutable {
+            "  This allocation is in executable nonpaged pool.\n"
+        } else if !span.pool_kind.is_paged() {
+            "  This allocation is in NX nonpaged pool; data adjacency does not imply executable memory.\n"
+        } else {
+            "  This allocation is in paged pool and can be unavailable at elevated IRQL.\n"
+        });
+        let spray_backend = matches!(span.backend, PoolBackend::Lfh | PoolBackend::Vs);
+        let spray_size = (0x40..=0x1_0000).contains(&span.size_class);
+        if span.pool_kind == PoolKind::Paged && spray_backend && spray_size {
+            output.push_str(
+                "  AnonymousPipe-driven PipeAttribute spraying uses normal paged pool and can be shaped to this LFH/VS size class; verify the exact observed bucket before use.\n",
+            );
+        } else if span.pool_kind == PoolKind::NonPagedNx && spray_backend && spray_size {
+            output.push_str(
+                "  AnonymousPipe-driven PipeQueueEntry spraying uses normal NX nonpaged pool and can be shaped to this LFH/VS size class; verify the exact observed bucket before use.\n",
+            );
+        }
+    }
+    output.push_str(
+        "Historical caveat: BlockSize confusion, CacheAligned/PreviousSize confusion, quota-pointer overwrite, and ghost-chunk techniques are 19H1-era observations, not guarantees on current Windows builds.\n",
+    );
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::snapshot::PoolSnapshot;
+
+    fn span(
+        address: u64,
+        tag: u32,
+        kind: PoolKind,
+        backend: PoolBackend,
+        state: PoolState,
+    ) -> PoolSpan {
+        let mut value = PoolSpan::allocation(
+            address,
+            0x40,
+            tag,
+            kind,
+            HeapIdentity {
+                pool_state: 1,
+                heap: 2,
+                special: false,
+            },
+            backend,
+        );
+        value.state = state;
+        value
+    }
+
+    #[test]
+    fn test_poolmap_heatmap_and_advice() {
+        let tag = u32::from_le_bytes(*b"A<&\"");
+        let mut spans = vec![
+            span(
+                0x1000,
+                tag,
+                PoolKind::NonPagedNx,
+                PoolBackend::Lfh,
+                PoolState::Allocated,
+            ),
+            span(
+                0x1040,
+                0,
+                PoolKind::NonPagedNx,
+                PoolBackend::Lfh,
+                PoolState::ReusableFree,
+            ),
+            span(
+                0x1080,
+                0,
+                PoolKind::NonPagedNx,
+                PoolBackend::Lfh,
+                PoolState::CachedFree,
+            ),
+            span(
+                0x2000,
+                tag,
+                PoolKind::Paged,
+                PoolBackend::Vs,
+                PoolState::Allocated,
+            ),
+            span(
+                0x2040,
+                0,
+                PoolKind::Paged,
+                PoolBackend::Vs,
+                PoolState::Unreadable,
+            ),
+        ];
+        spans[0].subsegment = Some(1);
+        spans[1].subsegment = Some(1);
+        spans[2].subsegment = Some(1);
+        spans[3].subsegment = Some(2);
+        spans[4].subsegment = Some(2);
+        let index = PoolIndex::build(PoolSnapshot {
+            spans,
+            complete: true,
+            diagnostics: vec!["per-session paged heaps are not included".into()],
+        });
+        let plain = render_pool_map(
+            &index,
+            RenderOptions {
+                tag: Some(tag),
+                dml: false,
+            },
+        )
+        .join("");
+        assert!(plain.contains("S.c"));
+        assert!(plain.contains("nonpaged-nx"));
+        assert!(plain.contains("paged"));
+        assert!(plain.contains("reusable hole at 0x1040+0x40"));
+        assert!(plain.contains("LFH: account for bucket"));
+        assert!(plain.contains("VS: consider splitting/coalescing"));
+        assert!(plain.contains("PipeAttribute"));
+        assert!(plain.contains("PipeQueueEntry"));
+        assert!(plain.contains("19H1-era observations"));
+        assert!(plain.contains("per-session paged heaps are not included"));
+        assert!(plain.contains("allocation A<&\" at"));
+        assert!(!plain.contains("A&lt;&amp;&quot;"));
+        let dml = render_pool_map(
+            &index,
+            RenderOptions {
+                tag: Some(tag),
+                dml: true,
+            },
+        )
+        .join("");
+        assert!(dml.contains("<link cmd="));
+        assert!(dml.contains("A&lt;&amp;&quot;"));
+        assert!(escape_dml("<&\"").contains("&lt;&amp;&quot;"));
+        assert!(
+            render_pool_map(
+                &index,
+                RenderOptions {
+                    tag: Some(tag),
+                    dml: true
+                }
+            )
+            .iter()
+            .all(|chunk| chunk.len() <= OUTPUT_CHUNK)
+        );
+
+        let mut many = Vec::new();
+        for slot in 0..180u64 {
+            let mut value = span(
+                0x10_0000 + slot * 0x40,
+                if slot == 0 { tag } else { 0 },
+                PoolKind::NonPagedNx,
+                PoolBackend::Lfh,
+                if slot == 0 {
+                    PoolState::Allocated
+                } else {
+                    PoolState::ReusableFree
+                },
+            );
+            value.subsegment = Some(7);
+            many.push(value);
+        }
+        let many_index = PoolIndex::build(PoolSnapshot {
+            spans: many,
+            complete: true,
+            diagnostics: vec![],
+        });
+        let dml_chunks = render_pool_map(
+            &many_index,
+            RenderOptions {
+                tag: Some(tag),
+                dml: true,
+            },
+        );
+        assert!(dml_chunks.len() > 1);
+        for chunk in dml_chunks {
+            assert_eq!(
+                chunk.matches("<link ").count(),
+                chunk.matches("</link>").count()
+            );
+            assert_eq!(
+                chunk.matches("<col ").count(),
+                chunk.matches("</col>").count()
+            );
+            assert!(chunk.len() <= OUTPUT_CHUNK);
+        }
+    }
+}

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use thiserror::Error;
 
 use super::decode::{
-    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_probe, decode_descriptor_at,
-    decode_large_allocation, decode_lfh_offsets, decode_pool_header, decode_rb_root,
-    decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32, read_u64,
-    valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
+    DESCRIPTOR_FLAG_LFH, DESCRIPTOR_FLAG_VS, PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header,
+    big_page_probe, decode_descriptor_at, decode_large_allocation, decode_lfh_offsets,
+    decode_pool_header, decode_rb_root, decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32,
+    read_u64, valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
 use super::{
     HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState,
@@ -828,10 +828,12 @@ fn discover_segment_context(
                 descriptor_index += unit_size.max(1);
                 continue;
             }
-            let backend = match decoded.flags & 0x0c {
-                0x08 => PoolBackend::Lfh,
-                0x0c => PoolBackend::Vs,
-                _ => PoolBackend::Segment,
+            let backend = if decoded.flags & DESCRIPTOR_FLAG_LFH != 0 {
+                PoolBackend::Lfh
+            } else if decoded.flags & DESCRIPTOR_FLAG_VS != 0 {
+                PoolBackend::Vs
+            } else {
+                PoolBackend::Segment
             };
             let mut region_address = address;
             let mut region_size = size;
@@ -1536,7 +1538,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::pool::layout::{SessionKey, TypeLayout};
+    use crate::pool::{
+        decode::DESCRIPTOR_FLAG_COMMITTED,
+        layout::{SessionKey, TypeLayout},
+    };
 
     const K: u64 = 0xffff_8000_0000_0000;
     const STATE: u64 = K + 0x10_0000;
@@ -1898,14 +1903,18 @@ mod tests {
         );
         fill(&mut bytes, SEGMENT + 0x100, 16 * 0x20);
         for (index, units, flags) in [
-            (1u64, 2u8, 0x09u8),
-            (3, 2, 0x0d),
-            (5, 1, 0x01),
+            (
+                1u64,
+                2u8,
+                DESCRIPTOR_FLAG_LFH | DESCRIPTOR_FLAG_COMMITTED | 0x0c,
+            ),
+            (3, 2, DESCRIPTOR_FLAG_VS | DESCRIPTOR_FLAG_COMMITTED | 0x0c),
+            (5, 1, DESCRIPTOR_FLAG_COMMITTED | 0x0c),
             (6, 1, 0x00),
-            (7, 1, 0x01),
+            (7, 1, DESCRIPTOR_FLAG_COMMITTED | 0x0c),
         ] {
             let descriptor = SEGMENT + 0x100 + index * 0x20;
-            if flags & 1 != 0 {
+            if flags & DESCRIPTOR_FLAG_COMMITTED != 0 {
                 put_u32(
                     &mut bytes,
                     descriptor,

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -744,10 +744,6 @@ fn discover_segment_context(
         .ok_or_else(|| SnapshotError::InvalidData {
             detail: "descriptor metadata size overflow".into(),
         })?;
-    let heap_globals = *layout
-        .globals
-        .get("RtlpHpHeapGlobals")
-        .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
     let mut entry = scalar(memory, list_head, 8)? & !0xf;
     let mut seen = HashSet::new();
     while entry != 0 && entry != list_head && seen.len() < traversal_limit {
@@ -775,8 +771,7 @@ fn discover_segment_context(
         let signature = read_u64(&segment_header, signature_offset)
             .or_else(|| read_u32(&segment_header, signature_offset).map(u64::from))
             .unwrap_or(0);
-        if !valid_page_segment_signature(signature, segment_address, context_address, heap_globals)
-        {
+        if !valid_page_segment_signature(signature, segment_address, context_address, heap_key) {
             discovery.diagnostics.push(format!(
                 "rejecting page segment {segment_address:#x} with invalid signature {signature:#x}"
             ));
@@ -1899,7 +1894,7 @@ mod tests {
         put_u64(
             &mut bytes,
             SEGMENT + 0x20,
-            SEGMENT ^ context ^ GLOBALS ^ super::super::decode::PAGE_SEGMENT_SIGNATURE,
+            SEGMENT ^ context ^ heap_key ^ super::super::decode::PAGE_SEGMENT_SIGNATURE,
         );
         fill(&mut bytes, SEGMENT + 0x100, 16 * 0x20);
         for (index, units, flags) in [

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1042,6 +1042,19 @@ fn lookup_big_page_target(
     address: u64,
     diagnostics: &mut Vec<String>,
 ) -> Result<Option<(u32, u64)>, SnapshotError> {
+    let Ok(entry) = layout.type_layout("_POOL_TRACKER_BIG_PAGES") else {
+        return Ok(None);
+    };
+    let entry_size = entry.size as usize;
+    let Ok(va_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Va") else {
+        return Ok(None);
+    };
+    let Ok(tag_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Key") else {
+        return Ok(None);
+    };
+    let Ok(size_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes") else {
+        return Ok(None);
+    };
     let Some(&table_pointer_address) = layout.globals.get("PoolBigPageTable") else {
         return Ok(None);
     };
@@ -1066,19 +1079,6 @@ fn lookup_big_page_target(
         diagnostics.push(format!("rejecting implausible big-page table size {count}"));
         return Ok(None);
     }
-    let Ok(entry) = layout.type_layout("_POOL_TRACKER_BIG_PAGES") else {
-        return Ok(None);
-    };
-    let entry_size = entry.size as usize;
-    let Ok(va_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Va") else {
-        return Ok(None);
-    };
-    let Ok(tag_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Key") else {
-        return Ok(None);
-    };
-    let Ok(size_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes") else {
-        return Ok(None);
-    };
     let mut probes = big_page_probe(address, count).ok_or_else(|| SnapshotError::InvalidData {
         detail: format!("invalid big-page table size {count}"),
     })?;
@@ -2096,45 +2096,44 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_skips_missing_optional_large_layout() {
-        let memory = synthetic_memory();
+    fn test_discovery_skips_missing_optional_large_layout() {
+        let memory = big_page_memory(LARGE_VA, 4, 0);
         let mut layout = synthetic_layout();
         layout.types.remove("_HEAP_LARGE_ALLOC_DATA");
-        let walker = SnapshotWalker {
-            memory: &memory,
-            layout: &layout,
-            traversal_limit: 1024,
-        };
+        let mut discovery = Discovery::default();
 
-        let snapshot = walker.walk().unwrap();
+        discover_large_allocations(
+            &memory,
+            &layout,
+            HEAP,
+            0,
+            PoolKind::NonPagedNx,
+            HeapIdentity {
+                pool_state: STATE,
+                heap: HEAP,
+                special: false,
+            },
+            0,
+            1024,
+            &mut discovery,
+        )
+        .unwrap();
 
-        for backend in [PoolBackend::Lfh, PoolBackend::Vs, PoolBackend::Segment] {
-            assert!(snapshot.spans.iter().any(|span| span.backend == backend));
-        }
-        assert!(
-            snapshot
-                .spans
-                .iter()
-                .all(|span| span.backend != PoolBackend::Large)
-        );
+        assert!(discovery.regions.is_empty());
+        assert_eq!(memory.read_calls.get(), 0);
     }
 
     #[test]
-    fn test_large_snapshot_falls_back_without_big_page_layout() {
-        let memory = synthetic_memory();
+    fn test_big_page_lookup_skips_missing_optional_layout() {
+        let memory = big_page_memory(LARGE_VA, 4, 0);
         let mut layout = synthetic_layout();
         layout.types.remove("_POOL_TRACKER_BIG_PAGES");
-        let walker = SnapshotWalker {
-            memory: &memory,
-            layout: &layout,
-            traversal_limit: 1024,
-        };
 
-        let snapshot = walker.walk().unwrap();
-
-        assert!(snapshot.spans.iter().any(|span| {
-            span.backend == PoolBackend::Large && span.raw_tag == 0 && span.size == 0x2000
-        }));
+        assert_eq!(
+            lookup_big_page_target(&memory, &layout, LARGE_VA, &mut Vec::new()).unwrap(),
+            None
+        );
+        assert_eq!(memory.read_calls.get(), 0);
     }
 
     #[test]

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1002,9 +1002,6 @@ pub(crate) struct SnapshotWalker<'a, M> {
 
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     pub(crate) fn walk(&self) -> Result<PoolSnapshot, String> {
-        if !cfg!(target_arch = "x86_64") {
-            return Err("pool walking is supported only for x64 targets".into());
-        }
         let mut snapshot = PoolSnapshot {
             diagnostics: vec!["per-session paged heaps are not included".into()],
             complete: true,

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1468,11 +1468,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 decode_pool_header(bytes, offset, region.pool_header).map(|header| header.tag)
             });
             let address = region.address + slot_offset as u64;
-            let header_size = if region.backend == PoolBackend::Large {
-                0
-            } else {
-                region.pool_header.size.min(size)
-            };
+            let header_size = region.pool_header.size.min(size);
             snapshot.spans.push(self.base_span(
                 region,
                 address,
@@ -1926,7 +1922,7 @@ mod tests {
             let decoded = (4u64 << 16) | (u64::from(allocated) << 48);
             put_u64(&mut bytes, address, decoded ^ address ^ heap_key);
         }
-        pool_header(&mut bytes, first_chunk + 0x20, b"VS!!");
+        pool_header(&mut bytes, first_chunk + 0x10, b"VS!!");
         let vs_context = HEAP + 0x300;
         put_u64(&mut bytes, vs_context, free_chunk + 8);
         put_u64(&mut bytes, free_chunk + 8, 0);
@@ -2052,7 +2048,10 @@ mod tests {
                 .any(|span| span.state == PoolState::Unreadable)
         );
         assert!(snapshot.spans.iter().any(|span| {
-            span.backend == PoolBackend::Vs && span.header_address == SEGMENT + 0x4000
+            span.backend == PoolBackend::Vs
+                && span.header_address == SEGMENT + 0x3ff0
+                && span.usable_address == SEGMENT + 0x4000
+                && span.raw_tag == u32::from_le_bytes(*b"VS!!")
         }));
         assert!(snapshot.spans.iter().any(|span| {
             span.backend == PoolBackend::Large

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -339,6 +339,13 @@ struct Discovery {
     diagnostics: Vec<String>,
 }
 
+const SPECIAL_POOL_KINDS: [PoolKind; 4] = [
+    PoolKind::SpecialNonPaged,
+    PoolKind::SpecialNonPagedNx,
+    PoolKind::SpecialPaged,
+    PoolKind::SpecialPrototypePaged,
+];
+
 fn discover_pool_regions(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
@@ -398,19 +405,10 @@ fn discover_pool_regions(
             }
         }
     }
-    for special_index in 0..3usize {
+    for (special_index, pool_kind) in SPECIAL_POOL_KINDS.into_iter().enumerate() {
         let pointer_address = state_address + special_offset as u64 + special_index as u64 * 8;
         match scalar(memory, pointer_address, 8) {
-            Ok(heap) if heap != 0 => heaps.push((
-                heap,
-                0,
-                match special_index {
-                    0 => PoolKind::SpecialNonPaged,
-                    1 => PoolKind::SpecialNonPagedNx,
-                    _ => PoolKind::SpecialPaged,
-                },
-                true,
-            )),
+            Ok(heap) if heap != 0 => heaps.push((heap, 0, pool_kind, true)),
             Ok(_) => {}
             Err(error) => discovery.diagnostics.push(format!(
                 "cannot read special pool heap {special_index}: {error}"
@@ -887,7 +885,8 @@ fn discover_segment_context(
                 };
                 let signature =
                     read_u16(&header, layout.field("_HEAP_VS_SUBSEGMENT", "Signature")?)
-                        .unwrap_or(0);
+                        .unwrap_or(0)
+                        & 0x7fff;
                 let declared =
                     read_u16(&header, layout.field("_HEAP_VS_SUBSEGMENT", "Size")?).unwrap_or(0);
                 if !valid_vs_signature(signature ^ declared) {
@@ -1068,7 +1067,7 @@ fn lookup_big_page_target(
     let Some(&size_address) = layout.globals.get("PoolBigPageTableSize") else {
         return Ok(None);
     };
-    let count = match scalar(memory, size_address, 8).or_else(|_| scalar(memory, size_address, 4)) {
+    let count = match scalar(memory, size_address, 4).or_else(|_| scalar(memory, size_address, 8)) {
         Ok(value) => value as usize,
         Err(error) => {
             diagnostics.push(format!("cannot read big-page table size: {error}"));
@@ -1569,8 +1568,11 @@ mod tests {
             if address == BIG_TABLE_POINTER && size == 8 {
                 return Ok(BIG_TABLE.to_le_bytes().to_vec());
             }
+            if address == BIG_TABLE_COUNT && size == 4 {
+                return Ok((self.count as u32).to_le_bytes().to_vec());
+            }
             if address == BIG_TABLE_COUNT && size == 8 {
-                return Ok((self.count as u64).to_le_bytes().to_vec());
+                return Ok(((1u64 << 32) | self.count as u64).to_le_bytes().to_vec());
             }
             let offset = address
                 .checked_sub(BIG_TABLE)
@@ -1915,7 +1917,7 @@ mod tests {
 
         let vs = SEGMENT + 0x3000;
         fill(&mut bytes, vs, 0x2000);
-        put_u16(&mut bytes, vs, 0x2bed ^ 2);
+        put_u16(&mut bytes, vs, 0x8000 | (0x2bed ^ 2));
         put_u16(&mut bytes, vs + 2, 2);
         let first_chunk = vs + 0xfe0;
         let cached_chunk = first_chunk + 0x40;
@@ -2093,6 +2095,13 @@ mod tests {
             walker.lookup_big_page(&table, 24, address),
             Some((u32::from_le_bytes(*b"NEXT"), 0x7000))
         );
+    }
+
+    #[test]
+    fn test_special_pool_kinds_cover_all_heap_slots() {
+        assert_eq!(SPECIAL_POOL_KINDS.len(), 4);
+        assert_eq!(SPECIAL_POOL_KINDS[3], PoolKind::SpecialPrototypePaged);
+        assert!(SPECIAL_POOL_KINDS[3].is_paged());
     }
 
     #[test]

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use thiserror::Error;
+
 use super::decode::{
     PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_probe, decode_descriptor_at,
     decode_large_allocation, decode_lfh_offsets, decode_pool_header, decode_rb_root,
@@ -7,6 +9,52 @@ use super::decode::{
     valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
 use super::{HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState, layout::PoolLayout};
+
+type SnapshotSource = Box<dyn std::error::Error + Send + Sync>;
+
+#[derive(Debug, Error)]
+pub(crate) enum SnapshotError {
+    #[error("read at {address:#x}+{size:#x}: {source}")]
+    Read {
+        address: u64,
+        size: usize,
+        #[source]
+        source: SnapshotSource,
+    },
+    #[error("valid-region query at {address:#x}+{size:#x}: {source}")]
+    RegionQuery {
+        address: u64,
+        size: usize,
+        #[source]
+        source: SnapshotSource,
+    },
+    #[error(
+        "sparse virtual range at {address:#x}+{size:#x} (valid {valid_base:#x}+{valid_size:#x})"
+    )]
+    RegionValidation {
+        address: u64,
+        size: usize,
+        valid_base: u64,
+        valid_size: usize,
+    },
+    #[error("snapshot layout lookup failed: {detail}")]
+    Layout { detail: String },
+    #[error("pool snapshot interrupted by Ctrl+C")]
+    Interrupted,
+    #[error("interrupt-status query failed: {source}")]
+    InterruptQuery {
+        #[source]
+        source: SnapshotSource,
+    },
+    #[error("invalid snapshot data: {detail}")]
+    InvalidData { detail: String },
+}
+
+impl From<String> for SnapshotError {
+    fn from(detail: String) -> Self {
+        Self::Layout { detail }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct PoolRegion {
@@ -33,54 +81,89 @@ pub(crate) struct PoolRegion {
 }
 
 pub(crate) trait PoolMemory {
-    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String>;
-    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String>;
-    fn interrupted(&self) -> bool;
+    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError>;
+    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError>;
+    fn interrupted(&self) -> Result<bool, SnapshotError>;
 }
 
 impl PoolMemory for crate::dbgeng::DebugEngine {
-    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String> {
+    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
         self.read_memory(address, size)
-            .map_err(|error| error.to_string())
+            .map_err(|source| SnapshotError::Read {
+                address,
+                size,
+                source: Box::new(source),
+            })
     }
 
-    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String> {
+    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
         self.valid_virtual_region(address, size)
-            .map_err(|error| error.to_string())
+            .map_err(|source| SnapshotError::RegionQuery {
+                address,
+                size,
+                source: Box::new(source),
+            })
     }
 
-    fn interrupted(&self) -> bool {
-        self.interrupted().unwrap_or(true)
+    fn interrupted(&self) -> Result<bool, SnapshotError> {
+        crate::dbgeng::DebugEngine::interrupted(self).map_err(|source| {
+            SnapshotError::InterruptQuery {
+                source: Box::new(source),
+            }
+        })
     }
 }
 
-fn guarded_read(memory: &impl PoolMemory, address: u64, size: usize) -> Result<Vec<u8>, String> {
+fn check_interrupted(memory: &impl PoolMemory) -> Result<(), SnapshotError> {
+    if memory.interrupted()? {
+        Err(SnapshotError::Interrupted)
+    } else {
+        Ok(())
+    }
+}
+
+fn guarded_read(
+    memory: &impl PoolMemory,
+    address: u64,
+    size: usize,
+) -> Result<Vec<u8>, SnapshotError> {
     if size == 0 {
         return Ok(Vec::new());
     }
-    let (valid_base, valid_size) = memory
-        .valid_region(address, size)
-        .map_err(|error| format!("valid-region query at {address:#x}+{size:#x}: {error}"))?;
+    let (valid_base, valid_size) = memory.valid_region(address, size)?;
     if valid_base != address || valid_size < size {
-        return Err(format!(
-            "sparse virtual range at {address:#x}+{size:#x} (valid {valid_base:#x}+{valid_size:#x})"
-        ));
+        return Err(SnapshotError::RegionValidation {
+            address,
+            size,
+            valid_base,
+            valid_size,
+        });
     }
-    memory
-        .read_exact(address, size)
-        .map_err(|error| format!("read at {address:#x}+{size:#x}: {error}"))
+    memory.read_exact(address, size)
 }
 
-fn scalar(memory: &impl PoolMemory, address: u64, size: usize) -> Result<u64, String> {
+fn scalar(memory: &impl PoolMemory, address: u64, size: usize) -> Result<u64, SnapshotError> {
     let bytes = guarded_read(memory, address, size)?;
     match size {
         1 => Ok(bytes[0] as u64),
-        2 => Ok(u16::from_le_bytes(bytes.try_into().map_err(|_| "short u16")?) as u64),
-        4 => Ok(u32::from_le_bytes(bytes.try_into().map_err(|_| "short u32")?) as u64),
-        8 => Ok(u64::from_le_bytes(
-            bytes.try_into().map_err(|_| "short u64")?,
-        )),
-        _ => Err(format!("unsupported scalar size {size}")),
+        2 => Ok(
+            u16::from_le_bytes(bytes.try_into().map_err(|_| SnapshotError::InvalidData {
+                detail: "short u16".into(),
+            })?) as u64,
+        ),
+        4 => Ok(
+            u32::from_le_bytes(bytes.try_into().map_err(|_| SnapshotError::InvalidData {
+                detail: "short u32".into(),
+            })?) as u64,
+        ),
+        8 => Ok(u64::from_le_bytes(bytes.try_into().map_err(|_| {
+            SnapshotError::InvalidData {
+                detail: "short u64".into(),
+            }
+        })?)),
+        _ => Err(SnapshotError::InvalidData {
+            detail: format!("unsupported scalar size {size}"),
+        }),
     }
 }
 
@@ -92,7 +175,7 @@ fn walk_tree_nodes(
     limit: usize,
     label: &str,
     diagnostics: &mut Vec<String>,
-) -> Vec<u64> {
+) -> Result<Vec<u64>, SnapshotError> {
     let mut nodes = Vec::new();
     let mut stack = vec![root];
     let mut seen = HashSet::new();
@@ -101,10 +184,7 @@ fn walk_tree_nodes(
         if node == 0 {
             continue;
         }
-        if memory.interrupted() {
-            diagnostics.push(format!("{label} traversal interrupted by Ctrl+C"));
-            break;
-        }
+        check_interrupted(memory)?;
         if !seen.insert(node) {
             diagnostics.push(format!("{label} cycle detected at {node:#x}"));
             continue;
@@ -127,7 +207,7 @@ fn walk_tree_nodes(
             Err(error) => diagnostics.push(format!("unreadable {label} node {node:#x}: {error}")),
         }
     }
-    nodes
+    Ok(nodes)
 }
 
 fn tree_nodes(
@@ -137,29 +217,29 @@ fn tree_nodes(
     limit: usize,
     label: &str,
     diagnostics: &mut Vec<String>,
-) -> Vec<u64> {
+) -> Result<Vec<u64>, SnapshotError> {
     let Ok(root_offset) = layout.field("_RTL_RB_TREE", "Root") else {
         diagnostics.push(format!("cannot resolve {label} root field"));
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let encoded = match scalar(memory, tree_address + root_offset as u64, 8) {
         Ok(value) => value,
         Err(error) => {
             diagnostics.push(format!("cannot read {label} root: {error}"));
-            return Vec::new();
+            return Ok(Vec::new());
         }
     };
     let Some(root) = decode_rb_root(encoded, tree_address) else {
         diagnostics.push(format!(
             "rejecting corrupt encoded {label} root {encoded:#x}"
         ));
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let Ok(left) = layout.field("_RTL_BALANCED_NODE", "Left") else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let Ok(right) = layout.field("_RTL_BALANCED_NODE", "Right") else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     walk_tree_nodes(memory, root, left, right, limit, label, diagnostics)
 }
@@ -171,36 +251,33 @@ fn walk_slist_nodes(
     limit: usize,
     label: &str,
     diagnostics: &mut Vec<String>,
-) -> Vec<u64> {
+) -> Result<Vec<u64>, SnapshotError> {
     let mut nodes = Vec::new();
     let mut seen = HashSet::new();
     let Ok(header) = layout.type_layout("_SLIST_HEADER") else {
         diagnostics.push(format!("cannot resolve {label} SLIST header type"));
-        return nodes;
+        return Ok(nodes);
     };
     let Ok(alignment_offset) = layout.field("_SLIST_HEADER", "Alignment") else {
         diagnostics.push(format!("cannot resolve {label} SLIST depth field"));
-        return nodes;
+        return Ok(nodes);
     };
     let Ok(region_offset) = layout.field("_SLIST_HEADER", "Region") else {
         diagnostics.push(format!("cannot resolve {label} SLIST next field"));
-        return nodes;
+        return Ok(nodes);
     };
     let bytes = match guarded_read(memory, head, header.size as usize) {
         Ok(value) => value,
         Err(error) => {
             diagnostics.push(format!("cannot read {label} list head: {error}"));
-            return nodes;
+            return Ok(nodes);
         }
     };
     let depth = read_u16(&bytes, alignment_offset).map_or(0, usize::from);
     let mut entry = read_u64(&bytes, region_offset).unwrap_or(0) & !0xf;
     let expected = depth.min(limit);
     while entry != 0 && nodes.len() < expected {
-        if memory.interrupted() {
-            diagnostics.push(format!("{label} list traversal interrupted by Ctrl+C"));
-            break;
-        }
+        check_interrupted(memory)?;
         if !seen.insert(entry) {
             diagnostics.push(format!("{label} list cycle detected at {entry:#x}"));
             break;
@@ -222,7 +299,7 @@ fn walk_slist_nodes(
             nodes.len()
         ));
     }
-    nodes
+    Ok(nodes)
 }
 
 fn insert_cached_chunk_candidates(
@@ -251,11 +328,14 @@ fn discover_pool_regions(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
     traversal_limit: usize,
-) -> Result<Discovery, String> {
-    let state_address = *layout
-        .globals
-        .get("ExPoolState")
-        .ok_or("missing ExPoolState")?;
+) -> Result<Discovery, SnapshotError> {
+    let state_address =
+        *layout
+            .globals
+            .get("ExPoolState")
+            .ok_or_else(|| SnapshotError::Layout {
+                detail: "missing ExPoolState".into(),
+            })?;
     let state = layout.type_layout("_EX_POOL_HEAP_MANAGER_STATE")?;
     let node = layout.type_layout("_EX_HEAP_POOL_NODE")?;
     let number_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "NumberOfPools")?;
@@ -264,7 +344,9 @@ fn discover_pool_regions(
     let heaps_offset = layout.field("_EX_HEAP_POOL_NODE", "Heaps")?;
     let number = scalar(memory, state_address + number_offset as u64, 4)? as usize;
     if number == 0 || number > 256 {
-        return Err(format!("implausible ExPoolState.NumberOfPools {number}"));
+        return Err(SnapshotError::InvalidData {
+            detail: format!("implausible ExPoolState.NumberOfPools {number}"),
+        });
     }
     let mut discovery = Discovery::default();
     let mut heaps = Vec::new();
@@ -324,10 +406,13 @@ fn discover_pool_regions(
         }
     }
 
-    let globals_address = *layout
-        .globals
-        .get("RtlpHpHeapGlobals")
-        .ok_or("missing RtlpHpHeapGlobals")?;
+    let globals_address =
+        *layout
+            .globals
+            .get("RtlpHpHeapGlobals")
+            .ok_or_else(|| SnapshotError::Layout {
+                detail: "missing RtlpHpHeapGlobals".into(),
+            })?;
     let heap_key = scalar(
         memory,
         globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "HeapKey")? as u64,
@@ -371,13 +456,13 @@ fn discover_vs_evidence(
     heap_address: u64,
     limit: usize,
     diagnostics: &mut Vec<String>,
-) -> (HashSet<u64>, HashSet<u64>) {
+) -> Result<(HashSet<u64>, HashSet<u64>), SnapshotError> {
     let Ok(vs_context_offset) = layout.field("_SEGMENT_HEAP", "VsContext") else {
-        return Default::default();
+        return Ok(Default::default());
     };
     let context = heap_address + vs_context_offset as u64;
     let Ok(tree_offset) = layout.field("_HEAP_VS_CONTEXT", "FreeChunkTree") else {
-        return Default::default();
+        return Ok(Default::default());
     };
     let tree_node_offset = layout
         .field("_HEAP_VS_CHUNK_FREE_HEADER", "TreeNode")
@@ -389,7 +474,7 @@ fn discover_vs_evidence(
         limit,
         "VS free tree",
         diagnostics,
-    )
+    )?
     .into_iter()
     .map(|node| node.saturating_sub(tree_node_offset as u64))
     .collect();
@@ -412,7 +497,7 @@ fn discover_vs_evidence(
             limit,
             "VS delay-free",
             diagnostics,
-        ) {
+        )? {
             insert_cached_chunk_candidates(&mut cached, entry, pool_header_size, vs_header_size);
         }
     }
@@ -471,7 +556,7 @@ fn discover_vs_evidence(
                     limit,
                     "VS dynamic-lookaside",
                     diagnostics,
-                ) {
+                )? {
                     // Lookaside links point at usable data, while delay-free links
                     // point at the VS chunk header. Keep both page-end header
                     // candidates; only a decoded chunk at that address can match.
@@ -485,7 +570,7 @@ fn discover_vs_evidence(
             }
         }
     }
-    (reusable, cached)
+    Ok((reusable, cached))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -500,7 +585,7 @@ fn discover_heap_regions(
     lfh_key: u64,
     traversal_limit: usize,
     discovery: &mut Discovery,
-) -> Result<(), String> {
+) -> Result<(), SnapshotError> {
     let heap = layout.type_layout("_SEGMENT_HEAP")?;
     let context = layout.type_layout("_HEAP_SEG_CONTEXT")?;
     let contexts_offset = layout.field("_SEGMENT_HEAP", "SegContexts")?;
@@ -510,7 +595,7 @@ fn discover_heap_regions(
         heap_address,
         traversal_limit,
         &mut discovery.diagnostics,
-    );
+    )?;
 
     // Touch both LFH roots through guarded reads. Descriptor metadata remains the
     // authoritative source of active subsegments, while these probes make corrupt
@@ -532,9 +617,7 @@ fn discover_heap_regions(
     }
 
     for context_index in 0..2usize {
-        if memory.interrupted() {
-            return Err("pool discovery interrupted by Ctrl+C".into());
-        }
+        check_interrupted(memory)?;
         let context_address =
             heap_address + contexts_offset as u64 + context_index as u64 * context.size as u64;
         if let Err(error) = discover_segment_context(
@@ -566,7 +649,7 @@ fn discover_heap_regions(
         heap_key,
         traversal_limit,
         discovery,
-    );
+    )?;
     let _ = heap.size;
     Ok(())
 }
@@ -585,7 +668,7 @@ fn discover_segment_context(
     reusable_chunks: &HashSet<u64>,
     cached_chunks: &HashSet<u64>,
     discovery: &mut Discovery,
-) -> Result<(), String> {
+) -> Result<(), SnapshotError> {
     let segment = layout.type_layout("_HEAP_PAGE_SEGMENT")?;
     let descriptor = layout.type_layout("_HEAP_PAGE_RANGE_DESCRIPTOR")?;
     let shift = scalar(
@@ -620,7 +703,7 @@ fn discover_segment_context(
         traversal_limit,
         "free-page tree",
         &mut discovery.diagnostics,
-    )
+    )?
     .into_iter()
     .collect();
 
@@ -634,13 +717,13 @@ fn discover_segment_context(
     let tree_node_offset = layout.field("_HEAP_PAGE_RANGE_DESCRIPTOR", "TreeNode")?;
     let metadata_size = descriptor_count
         .checked_mul(descriptor.size as usize)
-        .ok_or("descriptor metadata size overflow")?;
+        .ok_or_else(|| SnapshotError::InvalidData {
+            detail: "descriptor metadata size overflow".into(),
+        })?;
     let mut entry = scalar(memory, list_head, 8)? & !0xf;
     let mut seen = HashSet::new();
     while entry != 0 && entry != list_head && seen.len() < traversal_limit {
-        if memory.interrupted() {
-            return Err("segment-list traversal interrupted by Ctrl+C".into());
-        }
+        check_interrupted(memory)?;
         if !seen.insert(entry) {
             discovery
                 .diagnostics
@@ -664,10 +747,13 @@ fn discover_segment_context(
         let signature = read_u64(&segment_header, signature_offset)
             .or_else(|| read_u32(&segment_header, signature_offset).map(u64::from))
             .unwrap_or(0);
-        let heap_globals = *layout
-            .globals
-            .get("RtlpHpHeapGlobals")
-            .ok_or("missing RtlpHpHeapGlobals")?;
+        let heap_globals =
+            *layout
+                .globals
+                .get("RtlpHpHeapGlobals")
+                .ok_or_else(|| SnapshotError::Layout {
+                    detail: "missing RtlpHpHeapGlobals".into(),
+                })?;
         if !valid_page_segment_signature(signature, segment_address, context_address, heap_globals)
         {
             discovery.diagnostics.push(format!(
@@ -857,9 +943,9 @@ fn discover_large_allocations(
     heap_key: u64,
     traversal_limit: usize,
     discovery: &mut Discovery,
-) {
+) -> Result<(), SnapshotError> {
     let Ok(tree_offset) = layout.field("_SEGMENT_HEAP", "LargeAllocMetadata") else {
-        return;
+        return Ok(());
     };
     let tree_address = heap_address + tree_offset as u64;
     let nodes = tree_nodes(
@@ -869,18 +955,18 @@ fn discover_large_allocations(
         traversal_limit,
         "large-allocation tree",
         &mut discovery.diagnostics,
-    );
+    )?;
     let Ok(large) = layout.type_layout("_HEAP_LARGE_ALLOC_DATA") else {
-        return;
+        return Ok(());
     };
     let Ok(tree_node) = layout.field("_HEAP_LARGE_ALLOC_DATA", "TreeNode") else {
-        return;
+        return Ok(());
     };
     let Ok(virtual_offset) = layout.field("_HEAP_LARGE_ALLOC_DATA", "VirtualAddress") else {
-        return;
+        return Ok(());
     };
     let Ok(pages_offset) = layout.field("_HEAP_LARGE_ALLOC_DATA", "AllocatedPages") else {
-        return;
+        return Ok(());
     };
     for node in nodes {
         let allocation_address = node.saturating_sub(tree_node as u64);
@@ -911,7 +997,7 @@ fn discover_large_allocations(
             layout,
             virtual_address,
             &mut discovery.diagnostics,
-        ) {
+        )? {
             Some(value) => value,
             None => (0, bytes),
         };
@@ -939,56 +1025,117 @@ fn discover_large_allocations(
             cached_chunks: HashSet::new(),
         });
     }
+    Ok(())
 }
+
+const BIG_PAGE_PROBE_BATCH: usize = 256;
 
 fn lookup_big_page_target(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
     address: u64,
     diagnostics: &mut Vec<String>,
-) -> Option<(u32, u64)> {
-    let table_pointer_address = *layout.globals.get("PoolBigPageTable")?;
-    let table = scalar(memory, table_pointer_address, 8).ok()?;
-    let size_address = *layout.globals.get("PoolBigPageTableSize")?;
-    let count = scalar(memory, size_address, 8)
-        .or_else(|_| scalar(memory, size_address, 4))
-        .ok()? as usize;
+) -> Result<Option<(u32, u64)>, SnapshotError> {
+    let table_pointer_address =
+        *layout
+            .globals
+            .get("PoolBigPageTable")
+            .ok_or_else(|| SnapshotError::Layout {
+                detail: "missing PoolBigPageTable".into(),
+            })?;
+    let table = match scalar(memory, table_pointer_address, 8) {
+        Ok(value) => value,
+        Err(error) => {
+            diagnostics.push(format!("cannot read big-page table pointer: {error}"));
+            return Ok(None);
+        }
+    };
+    let size_address =
+        *layout
+            .globals
+            .get("PoolBigPageTableSize")
+            .ok_or_else(|| SnapshotError::Layout {
+                detail: "missing PoolBigPageTableSize".into(),
+            })?;
+    let count = match scalar(memory, size_address, 8).or_else(|_| scalar(memory, size_address, 4)) {
+        Ok(value) => value as usize,
+        Err(error) => {
+            diagnostics.push(format!("cannot read big-page table size: {error}"));
+            return Ok(None);
+        }
+    };
     if table == 0 || count == 0 || count > 0x10_0000 || !count.is_power_of_two() {
         diagnostics.push(format!("rejecting implausible big-page table size {count}"));
-        return None;
+        return Ok(None);
     }
-    let entry = layout.type_layout("_POOL_TRACKER_BIG_PAGES").ok()?;
-    let va_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Va").ok()?;
-    let tag_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Key").ok()?;
-    let size_offset = layout
-        .field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes")
-        .ok()?;
-    for index in big_page_probe(address, count)? {
-        let entry_address = table + index as u64 * entry.size as u64;
-        let bytes = match guarded_read(memory, entry_address, entry.size as usize) {
+    let entry = layout.type_layout("_POOL_TRACKER_BIG_PAGES")?;
+    let entry_size = entry.size as usize;
+    let va_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Va")?;
+    let tag_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Key")?;
+    let size_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes")?;
+    let mut probes = big_page_probe(address, count).ok_or_else(|| SnapshotError::InvalidData {
+        detail: format!("invalid big-page table size {count}"),
+    })?;
+    let mut remaining = count;
+    'probe: while let Some(first_index) = probes.next() {
+        check_interrupted(memory)?;
+        let batch_len = BIG_PAGE_PROBE_BATCH.min(remaining).min(count - first_index);
+        let byte_len =
+            entry_size
+                .checked_mul(batch_len)
+                .ok_or_else(|| SnapshotError::InvalidData {
+                    detail: "big-page probe batch size overflow".into(),
+                })?;
+        let entry_address = table
+            .checked_add(first_index as u64 * entry.size as u64)
+            .ok_or_else(|| SnapshotError::InvalidData {
+                detail: "big-page probe address overflow".into(),
+            })?;
+        let bytes = match guarded_read(memory, entry_address, byte_len) {
             Ok(bytes) => bytes,
             Err(error) => {
                 diagnostics.push(format!(
-                    "cannot read big-page entry {index} at {entry_address:#x}: {error}"
+                    "cannot read big-page entries {first_index}..{} at {entry_address:#x}: {error}",
+                    first_index + batch_len
                 ));
+                for _ in 1..batch_len {
+                    let _ = probes.next();
+                }
+                remaining -= batch_len;
                 continue;
             }
         };
-        let candidate = read_u64(&bytes, va_offset)?;
-        if candidate == 0 {
-            break;
+        for batch_index in 0..batch_len {
+            let offset = batch_index * entry_size;
+            let index = first_index + batch_index;
+            let Some(candidate) = read_u64(&bytes, offset + va_offset) else {
+                diagnostics.push(format!("truncated big-page entry {index}"));
+                continue;
+            };
+            if candidate == 0 {
+                break 'probe;
+            }
+            if candidate & !1 == address {
+                let Some(tag) = read_u32(&bytes, offset + tag_offset) else {
+                    diagnostics.push(format!("truncated big-page tag at entry {index}"));
+                    continue;
+                };
+                let Some(size) = read_u64(&bytes, offset + size_offset) else {
+                    diagnostics.push(format!("truncated big-page size at entry {index}"));
+                    continue;
+                };
+                return Ok(Some((tag, size)));
+            }
         }
-        if candidate & !1 == address {
-            return Some((
-                read_u32(&bytes, tag_offset)?,
-                read_u64(&bytes, size_offset)?,
-            ));
+        for _ in 1..batch_len {
+            let _ = probes.next();
         }
+        remaining -= batch_len;
     }
     diagnostics.push(format!(
         "no validated big-page entry for large allocation {address:#x}"
     ));
-    None
+    Ok(None)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1005,7 +1152,7 @@ pub(crate) struct SnapshotWalker<'a, M> {
 }
 
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
-    pub(crate) fn walk(&self) -> Result<PoolSnapshot, String> {
+    pub(crate) fn walk(&self) -> Result<PoolSnapshot, SnapshotError> {
         let mut snapshot = PoolSnapshot {
             diagnostics: vec!["per-session paged heaps are not included".into()],
             complete: true,
@@ -1017,13 +1164,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         }
         snapshot.diagnostics.extend(discovery.diagnostics);
         for region in discovery.regions {
-            if self.memory.interrupted() {
-                snapshot.complete = false;
-                snapshot
-                    .diagnostics
-                    .push("pool walk interrupted by Ctrl+C".into());
-                break;
-            }
+            check_interrupted(self.memory)?;
             self.walk_region(&region, &mut snapshot);
         }
         snapshot
@@ -1348,7 +1489,10 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::{
+        cell::Cell,
+        collections::{BTreeMap, HashMap},
+    };
 
     use super::*;
     use crate::pool::layout::{SessionKey, TypeLayout};
@@ -1368,21 +1512,29 @@ mod tests {
     struct SyntheticMemory {
         bytes: BTreeMap<u64, u8>,
         holes: Vec<(u64, u64)>,
+        read_calls: Cell<usize>,
+        interrupt_checks: Cell<usize>,
+        interrupt_after_checks: Option<usize>,
     }
 
     impl PoolMemory for SyntheticMemory {
-        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String> {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            self.read_calls.set(self.read_calls.get() + 1);
             (0..size)
                 .map(|offset| {
                     self.bytes
                         .get(&(address + offset as u64))
                         .copied()
-                        .ok_or_else(|| "sparse synthetic memory".into())
+                        .ok_or_else(|| SnapshotError::Read {
+                            address,
+                            size,
+                            source: Box::new(std::io::Error::other("sparse synthetic memory")),
+                        })
                 })
                 .collect()
         }
 
-        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String> {
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
             let end = address.saturating_add(size as u64);
             for &(hole_start, hole_end) in &self.holes {
                 if address >= hole_start && address < hole_end {
@@ -1395,8 +1547,12 @@ mod tests {
             Ok((address, size))
         }
 
-        fn interrupted(&self) -> bool {
-            false
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            let checks = self.interrupt_checks.get();
+            self.interrupt_checks.set(checks + 1);
+            Ok(self
+                .interrupt_after_checks
+                .is_some_and(|limit| checks >= limit))
         }
     }
 
@@ -1746,7 +1902,34 @@ mod tests {
         SyntheticMemory {
             bytes,
             holes: vec![(SEGMENT + 0x7800, SEGMENT + 0x8000)],
+            read_calls: Cell::new(0),
+            interrupt_checks: Cell::new(0),
+            interrupt_after_checks: None,
         }
+    }
+
+    fn configure_big_page_probe(
+        memory: &mut SyntheticMemory,
+        address: u64,
+        count: usize,
+        collision_distance: usize,
+    ) {
+        put_u64(&mut memory.bytes, BIG_TABLE_COUNT, count as u64);
+        fill(&mut memory.bytes, BIG_TABLE, count * 0x20);
+        let first = super::super::decode::big_page_hash(address, count).unwrap();
+        for distance in 0..collision_distance {
+            let index = (first + distance) % count;
+            put_u64(
+                &mut memory.bytes,
+                BIG_TABLE + index as u64 * 0x20,
+                address + (distance as u64 + 1) * 0x10_0000,
+            );
+        }
+        let index = (first + collision_distance) % count;
+        let entry = BIG_TABLE + index as u64 * 0x20;
+        put_u64(&mut memory.bytes, entry, address);
+        put(&mut memory.bytes, entry + 8, b"BTCH");
+        put_u64(&mut memory.bytes, entry + 0x10, 0x9000);
     }
 
     #[test]
@@ -1830,5 +2013,46 @@ mod tests {
             walker.lookup_big_page(&table, 24, address),
             Some((u32::from_le_bytes(*b"NEXT"), 0x7000))
         );
+    }
+
+    #[test]
+    fn test_big_page_lookup_batches_collision_chain() {
+        let mut memory = synthetic_memory();
+        let layout = synthetic_layout();
+        configure_big_page_probe(&mut memory, LARGE_VA, 512, 300);
+        let reads_before = memory.read_calls.get();
+        let mut diagnostics = Vec::new();
+
+        assert_eq!(
+            lookup_big_page_target(&memory, &layout, LARGE_VA, &mut diagnostics).unwrap(),
+            Some((u32::from_le_bytes(*b"BTCH"), 0x9000))
+        );
+        assert!(memory.read_calls.get() - reads_before <= 5);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_big_page_lookup_honors_interrupt_between_batches() {
+        let mut memory = synthetic_memory();
+        let layout = synthetic_layout();
+        configure_big_page_probe(&mut memory, LARGE_VA, 512, 300);
+        memory.interrupt_after_checks = Some(1);
+
+        assert!(matches!(
+            lookup_big_page_target(&memory, &layout, LARGE_VA, &mut Vec::new()),
+            Err(SnapshotError::Interrupted)
+        ));
+        assert_eq!(memory.interrupt_checks.get(), 2);
+    }
+
+    #[test]
+    fn test_snapshot_errors_preserve_category_and_source() {
+        let memory = synthetic_memory();
+        let error = memory.read_exact(0, 1).unwrap_err();
+        assert!(matches!(&error, SnapshotError::Read { .. }));
+        assert!(std::error::Error::source(&error).is_some());
+
+        let error = guarded_read(&memory, SEGMENT + 0x7800, 0x10).unwrap_err();
+        assert!(matches!(error, SnapshotError::RegionValidation { .. }));
     }
 }

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -361,6 +361,11 @@ fn discover_pool_regions(
     let node_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "PoolNode")?;
     let special_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "SpecialHeaps")?;
     let heaps_offset = layout.field("_EX_HEAP_POOL_NODE", "Heaps")?;
+    let lookasides_offset = layout.field("_EX_HEAP_POOL_NODE", "Lookasides").ok();
+    let dynamic_lookaside_size = layout
+        .type_layout("_RTL_DYNAMIC_LOOKASIDE")
+        .ok()
+        .map(|lookaside| lookaside.size as u64);
     let number = scalar(memory, state_address + number_offset as u64, 4)? as usize;
     if number == 0 || number > 256 {
         return Err(SnapshotError::InvalidData {
@@ -391,24 +396,28 @@ fn discover_pool_regions(
                 }
             };
             if heap != 0 {
-                heaps.push((
-                    heap,
-                    numa_node as u16,
-                    match heap_index {
-                        0 => PoolKind::NonPagedExecutable,
-                        1 => PoolKind::NonPagedNx,
-                        2 => PoolKind::Paged,
-                        _ => PoolKind::PrototypePaged,
-                    },
-                    false,
-                ));
+                let pool_kind = match heap_index {
+                    0 => PoolKind::NonPagedExecutable,
+                    1 => PoolKind::NonPagedNx,
+                    2 => PoolKind::Paged,
+                    _ => PoolKind::PrototypePaged,
+                };
+                let dynamic_lookaside =
+                    lookasides_offset
+                        .zip(dynamic_lookaside_size)
+                        .and_then(|(offset, size)| {
+                            node_address.checked_add(offset as u64).and_then(|base| {
+                                base.checked_add(u64::from(pool_kind.is_paged()) * size)
+                            })
+                        });
+                heaps.push((heap, numa_node as u16, pool_kind, false, dynamic_lookaside));
             }
         }
     }
     for (special_index, pool_kind) in SPECIAL_POOL_KINDS.into_iter().enumerate() {
         let pointer_address = state_address + special_offset as u64 + special_index as u64 * 8;
         match scalar(memory, pointer_address, 8) {
-            Ok(heap) if heap != 0 => heaps.push((heap, 0, pool_kind, true)),
+            Ok(heap) if heap != 0 => heaps.push((heap, 0, pool_kind, true, None)),
             Ok(_) => {}
             Err(error) => discovery.diagnostics.push(format!(
                 "cannot read special pool heap {special_index}: {error}"
@@ -430,7 +439,7 @@ fn discover_pool_regions(
         globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "LfhKey")? as u64,
         8,
     )?;
-    for (heap_address, numa_node, pool_kind, special) in heaps {
+    for (heap_address, numa_node, pool_kind, special, dynamic_lookaside) in heaps {
         let identity = HeapIdentity {
             pool_state: state_address,
             heap: heap_address,
@@ -443,6 +452,7 @@ fn discover_pool_regions(
             numa_node,
             pool_kind,
             identity,
+            dynamic_lookaside,
             heap_key,
             lfh_key,
             traversal_limit,
@@ -461,6 +471,7 @@ fn discover_vs_evidence(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
     heap_address: u64,
+    dynamic_lookaside: Option<u64>,
     limit: usize,
     diagnostics: &mut Vec<String>,
 ) -> Result<(HashSet<u64>, HashSet<u64>), SnapshotError> {
@@ -509,12 +520,7 @@ fn discover_vs_evidence(
         }
     }
 
-    let dynamic = layout
-        .field("_SEGMENT_HEAP", "UserContext")
-        .ok()
-        .and_then(|offset| scalar(memory, heap_address + offset as u64, 8).ok())
-        .unwrap_or(0);
-    if dynamic != 0 {
+    if let Some(dynamic) = dynamic_lookaside {
         let bucket_count = layout
             .field("_RTL_DYNAMIC_LOOKASIDE", "BucketCount")
             .ok()
@@ -588,6 +594,7 @@ fn discover_heap_regions(
     numa_node: u16,
     pool_kind: PoolKind,
     identity: HeapIdentity,
+    dynamic_lookaside: Option<u64>,
     heap_key: u64,
     lfh_key: u64,
     traversal_limit: usize,
@@ -600,6 +607,7 @@ fn discover_heap_regions(
         memory,
         layout,
         heap_address,
+        dynamic_lookaside,
         traversal_limit,
         &mut discovery.diagnostics,
     )?;
@@ -1527,7 +1535,8 @@ mod tests {
     const BIG_TABLE_POINTER: u64 = K + 0x12_0000;
     const BIG_TABLE_COUNT: u64 = K + 0x12_0010;
     const HEAP: u64 = K + 0x20_0000;
-    const DYNAMIC_LOOKASIDE: u64 = K + 0x21_0000;
+    const POOL_NODE: u64 = STATE + 0x40;
+    const DYNAMIC_LOOKASIDE: u64 = POOL_NODE + 0x20;
     const SEGMENT: u64 = K + 0x30_0000;
     const LARGE_META: u64 = K + 0x80_0000;
     const LARGE_VA: u64 = K + 0x90_0000;
@@ -1649,7 +1658,7 @@ mod tests {
         types.insert(
             "_EX_POOL_HEAP_MANAGER_STATE",
             type_layout(
-                0x100,
+                0x200,
                 &[
                     ("HeapManager", 8),
                     ("PoolNode", 0x40),
@@ -1658,7 +1667,10 @@ mod tests {
                 ],
             ),
         );
-        types.insert("_EX_HEAP_POOL_NODE", type_layout(0x40, &[("Heaps", 0)]));
+        types.insert(
+            "_EX_HEAP_POOL_NODE",
+            type_layout(0x120, &[("Heaps", 0), ("Lookasides", 0x20)]),
+        );
         types.insert(
             "_SEGMENT_HEAP",
             type_layout(
@@ -1668,7 +1680,6 @@ mod tests {
                     ("VsContext", 0x300),
                     ("LfhContext", 0x380),
                     ("LargeAllocMetadata", 0x400),
-                    ("UserContext", 0x500),
                 ],
             ),
         );
@@ -1732,10 +1743,7 @@ mod tests {
             "_HEAP_VS_CHUNK_FREE_HEADER",
             type_layout(0x20, &[("TreeNode", 8)]),
         );
-        types.insert(
-            "_HEAP_LFH_CONTEXT",
-            type_layout(0x20, &[("Buckets", 0), ("AffinitySlots", 8)]),
-        );
+        types.insert("_HEAP_LFH_CONTEXT", type_layout(0x20, &[("Buckets", 0)]));
         types.insert(
             "_HEAP_LFH_SUBSEGMENT",
             type_layout(
@@ -1853,7 +1861,7 @@ mod tests {
 
     fn synthetic_memory() -> SyntheticMemory {
         let mut bytes = BTreeMap::new();
-        fill(&mut bytes, STATE, 0x100);
+        fill(&mut bytes, STATE, 0x200);
         put_u32(&mut bytes, STATE, 1);
         for heap_index in 0..4 {
             put_u64(&mut bytes, STATE + 0x40 + heap_index * 8, HEAP);
@@ -1940,7 +1948,6 @@ mod tests {
         put_u64(&mut bytes, delay_head + 8, cached_chunk + 0x20);
         put_u64(&mut bytes, cached_chunk + 0x20, 0);
 
-        put_u64(&mut bytes, HEAP + 0x500, DYNAMIC_LOOKASIDE);
         fill(&mut bytes, DYNAMIC_LOOKASIDE, 0x80);
         put_u32(&mut bytes, DYNAMIC_LOOKASIDE + 8, 1);
         let lookaside_chunk = free_chunk + 0x40;
@@ -2038,6 +2045,11 @@ mod tests {
         }));
         assert!(snapshot.spans.iter().any(|span| {
             span.backend == PoolBackend::Vs && span.state == PoolState::CachedFree
+        }));
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Vs
+                && span.header_address == SEGMENT + 0x40b0
+                && span.state == PoolState::CachedFree
         }));
         assert!(
             snapshot

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -237,17 +237,26 @@ fn tree_nodes(
         diagnostics.push(format!("cannot resolve {label} root field"));
         return Ok(Vec::new());
     };
-    let encoded = match scalar(memory, tree_address + root_offset as u64, 8) {
+    let root_value = match scalar(memory, tree_address + root_offset as u64, 8) {
         Ok(value) => value,
         Err(error) => {
             diagnostics.push(format!("cannot read {label} root: {error}"));
             return Ok(Vec::new());
         }
     };
-    let Some(root) = decode_rb_root(encoded, tree_address) else {
-        diagnostics.push(format!(
-            "rejecting corrupt encoded {label} root {encoded:#x}"
-        ));
+    let encoded = if let Ok(encoded_offset) = layout.field("_RTL_RB_TREE", "Encoded") {
+        match scalar(memory, tree_address + encoded_offset as u64, 1) {
+            Ok(value) => value & 1 != 0,
+            Err(error) => {
+                diagnostics.push(format!("cannot read {label} encoded flag: {error}"));
+                return Ok(Vec::new());
+            }
+        }
+    } else {
+        false
+    };
+    let Some(root) = decode_rb_root(root_value, tree_address, encoded) else {
+        diagnostics.push(format!("rejecting corrupt {label} root {root_value:#x}"));
         return Ok(Vec::new());
     };
     let Ok(left) = layout.field("_RTL_BALANCED_NODE", "Left") else {
@@ -1766,7 +1775,7 @@ mod tests {
         );
         types.insert(
             "_RTL_RB_TREE",
-            type_layout(0x10, &[("Root", 0), ("Min", 8)]),
+            type_layout(0x10, &[("Root", 0), ("Encoded", 8)]),
         );
         types.insert(
             "_RTL_BALANCED_NODE",
@@ -1970,7 +1979,8 @@ mod tests {
         pool_header(&mut bytes, SEGMENT + 0x7000, b"SPRS");
 
         let large_tree = HEAP + 0x400;
-        put_u64(&mut bytes, large_tree, (LARGE_META ^ large_tree) | 1);
+        put_u64(&mut bytes, large_tree, LARGE_META ^ large_tree);
+        put(&mut bytes, large_tree + 8, &[1]);
         fill(&mut bytes, LARGE_META, 0x28);
         put_u64(&mut bytes, LARGE_META + 0x18, LARGE_VA | 0x1800);
         put_u64(&mut bytes, LARGE_META + 0x20, (2u64 << 12) | 0x5a5);

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -5,8 +5,9 @@ use thiserror::Error;
 use super::decode::{
     DESCRIPTOR_FLAG_LFH, DESCRIPTOR_FLAG_VS, PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header,
     big_page_probe, decode_descriptor_at, decode_large_allocation, decode_lfh_offsets,
-    decode_pool_header, decode_rb_root, decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32,
-    read_u64, valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
+    decode_pool_header, decode_rb_root, decode_slist_header_next, decode_vs_sizes,
+    lfh_bitmap_state, read_u16, read_u32, read_u64, valid_descriptor_tree_signature,
+    valid_page_segment_signature, valid_vs_signature,
 };
 use super::{
     HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState,
@@ -298,7 +299,9 @@ fn walk_slist_nodes(
         }
     };
     let depth = read_u16(&bytes, alignment_offset).map_or(0, usize::from);
-    let mut entry = read_u64(&bytes, region_offset).unwrap_or(0) & !0xf;
+    let mut entry = read_u64(&bytes, region_offset)
+        .map(decode_slist_header_next)
+        .unwrap_or(0);
     let expected = depth.min(limit);
     while entry != 0 && nodes.len() < expected {
         check_interrupted(memory)?;
@@ -1862,6 +1865,10 @@ mod tests {
         put(bytes, address, &value.to_le_bytes());
     }
 
+    fn packed_slist_next(entry: u64) -> u64 {
+        (entry << 4) | 3
+    }
+
     fn pool_header(bytes: &mut BTreeMap<u64, u8>, address: u64, tag: &[u8; 4]) {
         fill(bytes, address, 0x10);
         put(bytes, address, &[1, 0, 4, 1]);
@@ -1958,7 +1965,11 @@ mod tests {
         put_u64(&mut bytes, free_chunk + 16, 0);
         let delay_head = vs_context + 0x10;
         put_u16(&mut bytes, delay_head, 1);
-        put_u64(&mut bytes, delay_head + 8, cached_chunk + 0x20);
+        put_u64(
+            &mut bytes,
+            delay_head + 8,
+            packed_slist_next(cached_chunk + 0x20),
+        );
         put_u64(&mut bytes, cached_chunk + 0x20, 0);
 
         fill(&mut bytes, DYNAMIC_LOOKASIDE, 0x80);
@@ -1972,7 +1983,11 @@ mod tests {
         );
         let lookaside_head = DYNAMIC_LOOKASIDE + 0x40;
         put_u16(&mut bytes, lookaside_head, 1);
-        put_u64(&mut bytes, lookaside_head + 8, lookaside_chunk + 0x20);
+        put_u64(
+            &mut bytes,
+            lookaside_head + 8,
+            packed_slist_next(lookaside_chunk + 0x20),
+        );
         put_u64(&mut bytes, lookaside_chunk + 0x20, 0);
         put_u32(&mut bytes, lookaside_head + 0x30, 0x40);
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::decode::{
-    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_candidates, decode_descriptor_at,
+    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_probe, decode_descriptor_at,
     decode_large_allocation, decode_lfh_offsets, decode_pool_header, decode_rb_root,
     decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32, read_u64,
     valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
@@ -963,7 +963,7 @@ fn lookup_big_page_target(
     let size_offset = layout
         .field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes")
         .ok()?;
-    for index in big_page_candidates(address, count)? {
+    for index in big_page_probe(address, count)? {
         let entry_address = table + index as u64 * entry.size as u64;
         let bytes = match guarded_read(memory, entry_address, entry.size as usize) {
             Ok(bytes) => bytes,
@@ -974,7 +974,11 @@ fn lookup_big_page_target(
                 continue;
             }
         };
-        if read_u64(&bytes, va_offset)? & !1 == address {
+        let candidate = read_u64(&bytes, va_offset)?;
+        if candidate == 0 {
+            break;
+        }
+        if candidate & !1 == address {
             return Some((
                 read_u32(&bytes, tag_offset)?,
                 read_u64(&bytes, size_offset)?,
@@ -1328,10 +1332,13 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             return None;
         }
         let count = table.len() / entry_size;
-        for index in big_page_candidates(address, count)? {
+        for index in big_page_probe(address, count)? {
             let offset = index * entry_size;
-            let candidate = read_u64(table, offset)? & !1;
-            if candidate == address {
+            let candidate = read_u64(table, offset)?;
+            if candidate == 0 {
+                break;
+            }
+            if candidate & !1 == address {
                 return Some((read_u32(table, offset + 8)?, read_u64(table, offset + 12)?));
             }
         }
@@ -1729,6 +1736,8 @@ mod tests {
         fill(&mut bytes, BIG_TABLE, 4 * 0x20);
         let first = super::super::decode::big_page_hash(LARGE_VA, 4).unwrap();
         let adjacent = (first + 1) % 4;
+        let collision = BIG_TABLE + first as u64 * 0x20;
+        put_u64(&mut bytes, collision, LARGE_VA + 0x10_0000);
         let entry = BIG_TABLE + adjacent as u64 * 0x20;
         put_u64(&mut bytes, entry, LARGE_VA);
         put(&mut bytes, entry + 8, b"BIG!");
@@ -1805,13 +1814,18 @@ mod tests {
                 .any(|message| message.contains("only committed through"))
         );
 
-        let mut table = vec![0u8; 4 * 24];
+        let mut table = vec![0u8; 8 * 24];
         let address = K + 0xb0_0000;
-        let first = super::super::decode::big_page_hash(address, 4).unwrap();
-        let second = ((first + 1) % 4) * 24;
-        table[second..second + 8].copy_from_slice(&address.to_le_bytes());
-        table[second + 8..second + 12].copy_from_slice(b"NEXT");
-        table[second + 12..second + 20].copy_from_slice(&0x7000u64.to_le_bytes());
+        let first = super::super::decode::big_page_hash(address, 8).unwrap();
+        for distance in 0..2 {
+            let collision = ((first + distance) % 8) * 24;
+            table[collision..collision + 8]
+                .copy_from_slice(&(address + (distance as u64 + 1) * 0x10_0000).to_le_bytes());
+        }
+        let third = ((first + 2) % 8) * 24;
+        table[third..third + 8].copy_from_slice(&address.to_le_bytes());
+        table[third + 8..third + 12].copy_from_slice(b"NEXT");
+        table[third + 12..third + 20].copy_from_slice(&0x7000u64.to_le_bytes());
         assert_eq!(
             walker.lookup_big_page(&table, 24, address),
             Some((u32::from_le_bytes(*b"NEXT"), 0x7000))

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1,0 +1,1823 @@
+use std::collections::HashSet;
+
+use super::decode::{
+    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_candidates, decode_descriptor_at,
+    decode_large_allocation, decode_lfh_offsets, decode_pool_header, decode_rb_root,
+    decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32, read_u64,
+    valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
+};
+use super::{HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState, layout::PoolLayout};
+
+#[derive(Debug, Clone)]
+pub(crate) struct PoolRegion {
+    pub address: u64,
+    pub size: usize,
+    pub pool_kind: PoolKind,
+    pub numa_node: u16,
+    pub heap: HeapIdentity,
+    pub subsegment: Option<u64>,
+    pub backend: PoolBackend,
+    pub unit_size: u32,
+    pub bitmap: Vec<u8>,
+    pub heap_key: u64,
+    pub pool_header: PoolHeaderLayout,
+    pub vs_header_size: usize,
+    pub vs_sizes_offset: usize,
+    pub known_tag: Option<u32>,
+    /// Allocator-derived states for segment/page-range cells.
+    pub states: Vec<PoolState>,
+    /// VS chunk-header addresses present in the free tree.
+    pub reusable_chunks: HashSet<u64>,
+    /// VS chunk-header addresses present in delay-free/lookaside lists.
+    pub cached_chunks: HashSet<u64>,
+}
+
+pub(crate) trait PoolMemory {
+    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String>;
+    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String>;
+    fn interrupted(&self) -> bool;
+}
+
+impl PoolMemory for crate::dbgeng::DebugEngine {
+    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String> {
+        self.read_memory(address, size)
+            .map_err(|error| error.to_string())
+    }
+
+    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String> {
+        self.valid_virtual_region(address, size)
+            .map_err(|error| error.to_string())
+    }
+
+    fn interrupted(&self) -> bool {
+        self.interrupted().unwrap_or(true)
+    }
+}
+
+fn guarded_read(memory: &impl PoolMemory, address: u64, size: usize) -> Result<Vec<u8>, String> {
+    if size == 0 {
+        return Ok(Vec::new());
+    }
+    let (valid_base, valid_size) = memory
+        .valid_region(address, size)
+        .map_err(|error| format!("valid-region query at {address:#x}+{size:#x}: {error}"))?;
+    if valid_base != address || valid_size < size {
+        return Err(format!(
+            "sparse virtual range at {address:#x}+{size:#x} (valid {valid_base:#x}+{valid_size:#x})"
+        ));
+    }
+    memory
+        .read_exact(address, size)
+        .map_err(|error| format!("read at {address:#x}+{size:#x}: {error}"))
+}
+
+fn scalar(memory: &impl PoolMemory, address: u64, size: usize) -> Result<u64, String> {
+    let bytes = guarded_read(memory, address, size)?;
+    match size {
+        1 => Ok(bytes[0] as u64),
+        2 => Ok(u16::from_le_bytes(bytes.try_into().map_err(|_| "short u16")?) as u64),
+        4 => Ok(u32::from_le_bytes(bytes.try_into().map_err(|_| "short u32")?) as u64),
+        8 => Ok(u64::from_le_bytes(
+            bytes.try_into().map_err(|_| "short u64")?,
+        )),
+        _ => Err(format!("unsupported scalar size {size}")),
+    }
+}
+
+fn walk_tree_nodes(
+    memory: &impl PoolMemory,
+    root: u64,
+    left_offset: usize,
+    right_offset: usize,
+    limit: usize,
+    label: &str,
+    diagnostics: &mut Vec<String>,
+) -> Vec<u64> {
+    let mut nodes = Vec::new();
+    let mut stack = vec![root];
+    let mut seen = HashSet::new();
+    while let Some(node) = stack.pop() {
+        let node = node & !0xf;
+        if node == 0 {
+            continue;
+        }
+        if memory.interrupted() {
+            diagnostics.push(format!("{label} traversal interrupted by Ctrl+C"));
+            break;
+        }
+        if !seen.insert(node) {
+            diagnostics.push(format!("{label} cycle detected at {node:#x}"));
+            continue;
+        }
+        if nodes.len() >= limit {
+            diagnostics.push(format!("{label} traversal limit reached"));
+            break;
+        }
+        let size = left_offset.max(right_offset).saturating_add(8);
+        match guarded_read(memory, node, size) {
+            Ok(bytes) => {
+                nodes.push(node);
+                if let Some(right) = read_u64(&bytes, right_offset) {
+                    stack.push(right);
+                }
+                if let Some(left) = read_u64(&bytes, left_offset) {
+                    stack.push(left);
+                }
+            }
+            Err(error) => diagnostics.push(format!("unreadable {label} node {node:#x}: {error}")),
+        }
+    }
+    nodes
+}
+
+fn tree_nodes(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    tree_address: u64,
+    limit: usize,
+    label: &str,
+    diagnostics: &mut Vec<String>,
+) -> Vec<u64> {
+    let Ok(root_offset) = layout.field("_RTL_RB_TREE", "Root") else {
+        diagnostics.push(format!("cannot resolve {label} root field"));
+        return Vec::new();
+    };
+    let encoded = match scalar(memory, tree_address + root_offset as u64, 8) {
+        Ok(value) => value,
+        Err(error) => {
+            diagnostics.push(format!("cannot read {label} root: {error}"));
+            return Vec::new();
+        }
+    };
+    let Some(root) = decode_rb_root(encoded, tree_address) else {
+        diagnostics.push(format!(
+            "rejecting corrupt encoded {label} root {encoded:#x}"
+        ));
+        return Vec::new();
+    };
+    let Ok(left) = layout.field("_RTL_BALANCED_NODE", "Left") else {
+        return Vec::new();
+    };
+    let Ok(right) = layout.field("_RTL_BALANCED_NODE", "Right") else {
+        return Vec::new();
+    };
+    walk_tree_nodes(memory, root, left, right, limit, label, diagnostics)
+}
+
+fn walk_slist_nodes(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    head: u64,
+    limit: usize,
+    label: &str,
+    diagnostics: &mut Vec<String>,
+) -> Vec<u64> {
+    let mut nodes = Vec::new();
+    let mut seen = HashSet::new();
+    let Ok(header) = layout.type_layout("_SLIST_HEADER") else {
+        diagnostics.push(format!("cannot resolve {label} SLIST header type"));
+        return nodes;
+    };
+    let Ok(alignment_offset) = layout.field("_SLIST_HEADER", "Alignment") else {
+        diagnostics.push(format!("cannot resolve {label} SLIST depth field"));
+        return nodes;
+    };
+    let Ok(region_offset) = layout.field("_SLIST_HEADER", "Region") else {
+        diagnostics.push(format!("cannot resolve {label} SLIST next field"));
+        return nodes;
+    };
+    let bytes = match guarded_read(memory, head, header.size as usize) {
+        Ok(value) => value,
+        Err(error) => {
+            diagnostics.push(format!("cannot read {label} list head: {error}"));
+            return nodes;
+        }
+    };
+    let depth = read_u16(&bytes, alignment_offset).map_or(0, usize::from);
+    let mut entry = read_u64(&bytes, region_offset).unwrap_or(0) & !0xf;
+    let expected = depth.min(limit);
+    while entry != 0 && nodes.len() < expected {
+        if memory.interrupted() {
+            diagnostics.push(format!("{label} list traversal interrupted by Ctrl+C"));
+            break;
+        }
+        if !seen.insert(entry) {
+            diagnostics.push(format!("{label} list cycle detected at {entry:#x}"));
+            break;
+        }
+        nodes.push(entry);
+        match scalar(memory, entry, 8) {
+            Ok(next) => entry = next & !0xf,
+            Err(error) => {
+                diagnostics.push(format!("unreadable {label} list entry {entry:#x}: {error}"));
+                break;
+            }
+        }
+    }
+    if depth > limit {
+        diagnostics.push(format!("{label} list traversal limit reached"));
+    } else if nodes.len() != depth {
+        diagnostics.push(format!(
+            "{label} list depth is {depth}, but only {} entries were readable",
+            nodes.len()
+        ));
+    }
+    nodes
+}
+
+fn insert_cached_chunk_candidates(
+    cached: &mut HashSet<u64>,
+    entry: u64,
+    pool_header_size: u64,
+    vs_header_size: u64,
+) {
+    cached.insert(entry);
+    let overhead = pool_header_size.saturating_add(vs_header_size);
+    if let Some(header) = entry.checked_sub(overhead) {
+        cached.insert(header);
+        if header & (PAGE_SIZE - 1) == PAGE_SIZE - pool_header_size {
+            cached.insert(header.saturating_sub(16));
+        }
+    }
+}
+
+#[derive(Default)]
+struct Discovery {
+    regions: Vec<PoolRegion>,
+    diagnostics: Vec<String>,
+}
+
+fn discover_pool_regions(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    traversal_limit: usize,
+) -> Result<Discovery, String> {
+    let state_address = *layout
+        .globals
+        .get("ExPoolState")
+        .ok_or("missing ExPoolState")?;
+    let state = layout.type_layout("_EX_POOL_HEAP_MANAGER_STATE")?;
+    let node = layout.type_layout("_EX_HEAP_POOL_NODE")?;
+    let number_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "NumberOfPools")?;
+    let node_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "PoolNode")?;
+    let special_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "SpecialHeaps")?;
+    let heaps_offset = layout.field("_EX_HEAP_POOL_NODE", "Heaps")?;
+    let number = scalar(memory, state_address + number_offset as u64, 4)? as usize;
+    if number == 0 || number > 256 {
+        return Err(format!("implausible ExPoolState.NumberOfPools {number}"));
+    }
+    let mut discovery = Discovery::default();
+    let mut heaps = Vec::new();
+    for numa_node in 0..number {
+        let Some(node_address) = state_address
+            .checked_add(node_offset as u64)
+            .and_then(|address| address.checked_add(numa_node as u64 * node.size as u64))
+        else {
+            discovery
+                .diagnostics
+                .push("pool-node address overflow".into());
+            continue;
+        };
+        for heap_index in 0..4usize {
+            let pointer_address = node_address + heaps_offset as u64 + heap_index as u64 * 8;
+            let heap = match scalar(memory, pointer_address, 8) {
+                Ok(value) => value,
+                Err(error) => {
+                    discovery.diagnostics.push(format!(
+                        "cannot read pool node {numa_node} heap {heap_index}: {error}"
+                    ));
+                    continue;
+                }
+            };
+            if heap != 0 {
+                heaps.push((
+                    heap,
+                    numa_node as u16,
+                    match heap_index {
+                        0 => PoolKind::NonPagedExecutable,
+                        1 => PoolKind::NonPagedNx,
+                        2 => PoolKind::Paged,
+                        _ => PoolKind::PrototypePaged,
+                    },
+                    false,
+                ));
+            }
+        }
+    }
+    for special_index in 0..3usize {
+        let pointer_address = state_address + special_offset as u64 + special_index as u64 * 8;
+        match scalar(memory, pointer_address, 8) {
+            Ok(heap) if heap != 0 => heaps.push((
+                heap,
+                0,
+                match special_index {
+                    0 => PoolKind::SpecialNonPaged,
+                    1 => PoolKind::SpecialNonPagedNx,
+                    _ => PoolKind::SpecialPaged,
+                },
+                true,
+            )),
+            Ok(_) => {}
+            Err(error) => discovery.diagnostics.push(format!(
+                "cannot read special pool heap {special_index}: {error}"
+            )),
+        }
+    }
+
+    let globals_address = *layout
+        .globals
+        .get("RtlpHpHeapGlobals")
+        .ok_or("missing RtlpHpHeapGlobals")?;
+    let heap_key = scalar(
+        memory,
+        globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "HeapKey")? as u64,
+        8,
+    )?;
+    let lfh_key = scalar(
+        memory,
+        globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "LfhKey")? as u64,
+        8,
+    )?;
+    for (heap_address, numa_node, pool_kind, special) in heaps {
+        let identity = HeapIdentity {
+            pool_state: state_address,
+            heap: heap_address,
+            special,
+        };
+        if let Err(error) = discover_heap_regions(
+            memory,
+            layout,
+            heap_address,
+            numa_node,
+            pool_kind,
+            identity,
+            heap_key,
+            lfh_key,
+            traversal_limit,
+            &mut discovery,
+        ) {
+            discovery.diagnostics.push(format!(
+                "cannot fully discover heap {heap_address:#x}: {error}"
+            ));
+        }
+    }
+    let _ = state.size;
+    Ok(discovery)
+}
+
+fn discover_vs_evidence(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    heap_address: u64,
+    limit: usize,
+    diagnostics: &mut Vec<String>,
+) -> (HashSet<u64>, HashSet<u64>) {
+    let Ok(vs_context_offset) = layout.field("_SEGMENT_HEAP", "VsContext") else {
+        return Default::default();
+    };
+    let context = heap_address + vs_context_offset as u64;
+    let Ok(tree_offset) = layout.field("_HEAP_VS_CONTEXT", "FreeChunkTree") else {
+        return Default::default();
+    };
+    let tree_node_offset = layout
+        .field("_HEAP_VS_CHUNK_FREE_HEADER", "TreeNode")
+        .unwrap_or(0);
+    let reusable = tree_nodes(
+        memory,
+        layout,
+        context + tree_offset as u64,
+        limit,
+        "VS free tree",
+        diagnostics,
+    )
+    .into_iter()
+    .map(|node| node.saturating_sub(tree_node_offset as u64))
+    .collect();
+
+    let mut cached = HashSet::new();
+    let pool_header_size = layout
+        .type_layout("_POOL_HEADER")
+        .map_or(0, |value| value.size as u64);
+    let vs_header_size = layout
+        .type_layout("_HEAP_VS_CHUNK_HEADER")
+        .map_or(0, |value| value.size as u64);
+    if let (Ok(delay_offset), Ok(list_offset)) = (
+        layout.field("_HEAP_VS_CONTEXT", "DelayFreeContext"),
+        layout.field("_HEAP_VS_DELAY_FREE_CONTEXT", "ListHead"),
+    ) {
+        for entry in walk_slist_nodes(
+            memory,
+            layout,
+            context + delay_offset as u64 + list_offset as u64,
+            limit,
+            "VS delay-free",
+            diagnostics,
+        ) {
+            insert_cached_chunk_candidates(&mut cached, entry, pool_header_size, vs_header_size);
+        }
+    }
+
+    let dynamic = layout
+        .field("_SEGMENT_HEAP", "UserContext")
+        .ok()
+        .and_then(|offset| scalar(memory, heap_address + offset as u64, 8).ok())
+        .unwrap_or(0);
+    if dynamic != 0 {
+        let bucket_count = layout
+            .field("_RTL_DYNAMIC_LOOKASIDE", "BucketCount")
+            .ok()
+            .and_then(|offset| scalar(memory, dynamic + offset as u64, 4).ok())
+            .unwrap_or(0) as usize;
+        let buckets_offset = layout.field("_RTL_DYNAMIC_LOOKASIDE", "Buckets").ok();
+        let lookaside = layout.type_layout("_RTL_LOOKASIDE").ok();
+        let list_offset = layout.field("_RTL_LOOKASIDE", "ListHead").ok();
+        if bucket_count > 64 {
+            diagnostics.push(format!(
+                "rejecting implausible VS dynamic-lookaside bucket count {bucket_count}"
+            ));
+        } else if let (Some(buckets_offset), Some(lookaside), Some(list_offset)) =
+            (buckets_offset, lookaside, list_offset)
+        {
+            for bucket in 0..bucket_count {
+                let Some(bucket_address) = dynamic
+                    .checked_add(buckets_offset as u64)
+                    .and_then(|value| value.checked_add(bucket as u64 * u64::from(lookaside.size)))
+                else {
+                    diagnostics.push("VS dynamic-lookaside bucket address overflow".into());
+                    break;
+                };
+                if let Ok(size_offset) = layout.field("_RTL_LOOKASIDE", "Size") {
+                    match scalar(memory, bucket_address + size_offset as u64, 4) {
+                        Ok(0) => continue,
+                        Ok(size) if size > 0x1_0000 => {
+                            diagnostics.push(format!(
+                                "rejecting VS dynamic-lookaside bucket {bucket} size {size:#x}"
+                            ));
+                            continue;
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            diagnostics.push(format!(
+                                "cannot read VS dynamic-lookaside bucket {bucket} size: {error}"
+                            ));
+                            continue;
+                        }
+                    }
+                }
+                for entry in walk_slist_nodes(
+                    memory,
+                    layout,
+                    bucket_address + list_offset as u64,
+                    limit,
+                    "VS dynamic-lookaside",
+                    diagnostics,
+                ) {
+                    // Lookaside links point at usable data, while delay-free links
+                    // point at the VS chunk header. Keep both page-end header
+                    // candidates; only a decoded chunk at that address can match.
+                    insert_cached_chunk_candidates(
+                        &mut cached,
+                        entry,
+                        pool_header_size,
+                        vs_header_size,
+                    );
+                }
+            }
+        }
+    }
+    (reusable, cached)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn discover_heap_regions(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    heap_address: u64,
+    numa_node: u16,
+    pool_kind: PoolKind,
+    identity: HeapIdentity,
+    heap_key: u64,
+    lfh_key: u64,
+    traversal_limit: usize,
+    discovery: &mut Discovery,
+) -> Result<(), String> {
+    let heap = layout.type_layout("_SEGMENT_HEAP")?;
+    let context = layout.type_layout("_HEAP_SEG_CONTEXT")?;
+    let contexts_offset = layout.field("_SEGMENT_HEAP", "SegContexts")?;
+    let (reusable_chunks, cached_chunks) = discover_vs_evidence(
+        memory,
+        layout,
+        heap_address,
+        traversal_limit,
+        &mut discovery.diagnostics,
+    );
+
+    // Touch both LFH roots through guarded reads. Descriptor metadata remains the
+    // authoritative source of active subsegments, while these probes make corrupt
+    // bucket/affinity metadata an isolated diagnostic instead of a fatal read.
+    if let Ok(lfh_offset) = layout.field("_SEGMENT_HEAP", "LfhContext") {
+        let lfh = heap_address + lfh_offset as u64;
+        for (field, label) in [
+            ("Buckets", "LFH buckets"),
+            ("AffinitySlots", "LFH affinity slots"),
+        ] {
+            if let Ok(offset) = layout.field("_HEAP_LFH_CONTEXT", field)
+                && let Err(error) = guarded_read(memory, lfh + offset as u64, 8)
+            {
+                discovery
+                    .diagnostics
+                    .push(format!("cannot read {label}: {error}"));
+            }
+        }
+    }
+
+    for context_index in 0..2usize {
+        if memory.interrupted() {
+            return Err("pool discovery interrupted by Ctrl+C".into());
+        }
+        let context_address =
+            heap_address + contexts_offset as u64 + context_index as u64 * context.size as u64;
+        if let Err(error) = discover_segment_context(
+            memory,
+            layout,
+            context_address,
+            numa_node,
+            pool_kind,
+            identity,
+            heap_key,
+            lfh_key,
+            traversal_limit,
+            &reusable_chunks,
+            &cached_chunks,
+            discovery,
+        ) {
+            discovery.diagnostics.push(format!(
+                "cannot discover segment context {context_index} at {context_address:#x}: {error}"
+            ));
+        }
+    }
+    discover_large_allocations(
+        memory,
+        layout,
+        heap_address,
+        numa_node,
+        pool_kind,
+        identity,
+        heap_key,
+        traversal_limit,
+        discovery,
+    );
+    let _ = heap.size;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn discover_segment_context(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    context_address: u64,
+    numa_node: u16,
+    pool_kind: PoolKind,
+    identity: HeapIdentity,
+    heap_key: u64,
+    lfh_key: u64,
+    traversal_limit: usize,
+    reusable_chunks: &HashSet<u64>,
+    cached_chunks: &HashSet<u64>,
+    discovery: &mut Discovery,
+) -> Result<(), String> {
+    let segment = layout.type_layout("_HEAP_PAGE_SEGMENT")?;
+    let descriptor = layout.type_layout("_HEAP_PAGE_RANGE_DESCRIPTOR")?;
+    let shift = scalar(
+        memory,
+        context_address + layout.field("_HEAP_SEG_CONTEXT", "UnitShift")? as u64,
+        1,
+    )? as u32;
+    if !(12..=20).contains(&shift) {
+        return Ok(());
+    }
+    let first_descriptor = scalar(
+        memory,
+        context_address + layout.field("_HEAP_SEG_CONTEXT", "FirstDescriptorIndex")? as u64,
+        1,
+    )? as usize;
+    let segment_mask = scalar(
+        memory,
+        context_address + layout.field("_HEAP_SEG_CONTEXT", "SegmentMask")? as u64,
+        8,
+    )?;
+    let segment_size = (!segment_mask).wrapping_add(1);
+    let descriptor_count = (segment_size >> shift).min(4096) as usize;
+    if descriptor_count == 0 || first_descriptor >= descriptor_count {
+        return Ok(());
+    }
+
+    let free_tree = context_address + layout.field("_HEAP_SEG_CONTEXT", "FreePageRanges")? as u64;
+    let free_nodes: HashSet<_> = tree_nodes(
+        memory,
+        layout,
+        free_tree,
+        traversal_limit,
+        "free-page tree",
+        &mut discovery.diagnostics,
+    )
+    .into_iter()
+    .collect();
+
+    let list_head = context_address + layout.field("_HEAP_SEG_CONTEXT", "SegmentListHead")? as u64;
+    let list_entry = layout.field("_HEAP_PAGE_SEGMENT", "ListEntry")?;
+    let desc_array = layout.field("_HEAP_PAGE_SEGMENT", "DescArray")?;
+    let signature_offset = layout.field("_HEAP_PAGE_SEGMENT", "Signature")?;
+    let unit_offset = layout.field("_HEAP_PAGE_RANGE_DESCRIPTOR", "UnitSize")?;
+    let flags_offset = layout.field("_HEAP_PAGE_RANGE_DESCRIPTOR", "RangeFlags")?;
+    let tree_signature_offset = layout.field("_HEAP_PAGE_RANGE_DESCRIPTOR", "TreeSignature")?;
+    let tree_node_offset = layout.field("_HEAP_PAGE_RANGE_DESCRIPTOR", "TreeNode")?;
+    let metadata_size = descriptor_count
+        .checked_mul(descriptor.size as usize)
+        .ok_or("descriptor metadata size overflow")?;
+    let mut entry = scalar(memory, list_head, 8)? & !0xf;
+    let mut seen = HashSet::new();
+    while entry != 0 && entry != list_head && seen.len() < traversal_limit {
+        if memory.interrupted() {
+            return Err("segment-list traversal interrupted by Ctrl+C".into());
+        }
+        if !seen.insert(entry) {
+            discovery
+                .diagnostics
+                .push(format!("segment-list cycle at {entry:#x}"));
+            break;
+        }
+        let segment_address = entry.saturating_sub(list_entry as u64);
+        let segment_header = match guarded_read(memory, segment_address, segment.size as usize) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                discovery.diagnostics.push(format!(
+                    "cannot read segment header {segment_address:#x}: {error}"
+                ));
+                match scalar(memory, entry, 8) {
+                    Ok(next) => entry = next & !0xf,
+                    Err(_) => break,
+                }
+                continue;
+            }
+        };
+        let signature = read_u64(&segment_header, signature_offset)
+            .or_else(|| read_u32(&segment_header, signature_offset).map(u64::from))
+            .unwrap_or(0);
+        let heap_globals = *layout
+            .globals
+            .get("RtlpHpHeapGlobals")
+            .ok_or("missing RtlpHpHeapGlobals")?;
+        if !valid_page_segment_signature(signature, segment_address, context_address, heap_globals)
+        {
+            discovery.diagnostics.push(format!(
+                "rejecting page segment {segment_address:#x} with invalid signature {signature:#x}"
+            ));
+            entry = read_u64(&segment_header, list_entry).unwrap_or(0) & !0xf;
+            continue;
+        }
+        let metadata_address = segment_address + desc_array as u64;
+        let metadata = match guarded_read(memory, metadata_address, metadata_size) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                discovery.diagnostics.push(format!(
+                    "cannot read descriptors at {metadata_address:#x}: {error}"
+                ));
+                entry = read_u64(&segment_header, list_entry).unwrap_or(0) & !0xf;
+                continue;
+            }
+        };
+        let mut descriptor_index = first_descriptor;
+        while descriptor_index < descriptor_count {
+            let offset = descriptor_index * descriptor.size as usize;
+            let Some(decoded) = decode_descriptor_at(
+                &metadata,
+                offset,
+                descriptor.size as usize,
+                unit_offset,
+                flags_offset,
+            ) else {
+                descriptor_index += 1;
+                continue;
+            };
+            if decoded.committed
+                && !read_u32(&metadata, offset + tree_signature_offset)
+                    .is_some_and(valid_descriptor_tree_signature)
+            {
+                discovery.diagnostics.push(format!(
+                    "rejecting descriptor {descriptor_index} at {:#x} with invalid tree signature",
+                    metadata_address + offset as u64
+                ));
+                descriptor_index += decoded.unit_size.max(1) as usize;
+                continue;
+            }
+            let unit_size = decoded.unit_size as usize;
+            let Some(address) = segment_address.checked_add((descriptor_index as u64) << shift)
+            else {
+                break;
+            };
+            let size = unit_size.checked_shl(shift).unwrap_or(0);
+            if size == 0 {
+                descriptor_index += unit_size.max(1);
+                continue;
+            }
+            let backend = match decoded.flags & 0x0c {
+                0x08 => PoolBackend::Lfh,
+                0x0c => PoolBackend::Vs,
+                _ => PoolBackend::Segment,
+            };
+            let mut region_address = address;
+            let mut region_size = size;
+            let mut bitmap = Vec::new();
+            let mut block_size = size.min(u32::MAX as usize) as u32;
+            if backend == PoolBackend::Lfh {
+                let subsegment = layout.type_layout("_HEAP_LFH_SUBSEGMENT")?;
+                let offsets = layout.field("_HEAP_LFH_SUBSEGMENT", "BlockOffsets")?
+                    + layout.field("_HEAP_LFH_SUBSEGMENT_ENCODED_OFFSETS", "EncodedData")?;
+                let count_offset = layout.field("_HEAP_LFH_SUBSEGMENT", "BlockCount")?;
+                let bitmap_offset = layout.field("_HEAP_LFH_SUBSEGMENT", "BlockBitmap")?;
+                let header = match guarded_read(memory, address, subsegment.size as usize) {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        discovery
+                            .diagnostics
+                            .push(format!("cannot read LFH subsegment {address:#x}: {error}"));
+                        descriptor_index += unit_size;
+                        continue;
+                    }
+                };
+                let encoded = read_u32(&header, offsets).unwrap_or(0);
+                let (decoded_block_size, decoded_first) =
+                    decode_lfh_offsets(encoded, address, lfh_key as u32);
+                block_size = u32::from(decoded_block_size);
+                let first = usize::from(decoded_first);
+                let blocks = read_u16(&header, count_offset)
+                    .map(usize::from)
+                    .unwrap_or(0);
+                if block_size < 8
+                    || blocks == 0
+                    || first >= region_size
+                    || blocks.saturating_mul(block_size as usize) > region_size - first
+                {
+                    discovery.diagnostics.push(format!(
+                        "rejecting implausible LFH metadata at {address:#x}"
+                    ));
+                    descriptor_index += unit_size;
+                    continue;
+                }
+                bitmap = match guarded_read(
+                    memory,
+                    address + bitmap_offset as u64,
+                    blocks.div_ceil(4),
+                ) {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        discovery
+                            .diagnostics
+                            .push(format!("cannot read LFH bitmap at {address:#x}: {error}"));
+                        descriptor_index += unit_size;
+                        continue;
+                    }
+                };
+                region_address += first as u64;
+                region_size = blocks * block_size as usize;
+            } else if backend == PoolBackend::Vs {
+                let vs = layout.type_layout("_HEAP_VS_SUBSEGMENT")?;
+                let header = match guarded_read(memory, address, vs.size as usize) {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        discovery
+                            .diagnostics
+                            .push(format!("cannot read VS subsegment {address:#x}: {error}"));
+                        descriptor_index += unit_size;
+                        continue;
+                    }
+                };
+                let signature =
+                    read_u16(&header, layout.field("_HEAP_VS_SUBSEGMENT", "Signature")?)
+                        .unwrap_or(0);
+                let declared =
+                    read_u16(&header, layout.field("_HEAP_VS_SUBSEGMENT", "Size")?).unwrap_or(0);
+                if !valid_vs_signature(signature ^ declared) {
+                    discovery.diagnostics.push(format!(
+                        "rejecting VS subsegment {address:#x} with invalid signature"
+                    ));
+                    descriptor_index += unit_size;
+                    continue;
+                }
+                let first = (vs.size as usize).next_multiple_of(16);
+                if first >= region_size {
+                    descriptor_index += unit_size;
+                    continue;
+                }
+                region_address += first as u64;
+                region_size -= first;
+                block_size = 0;
+            }
+            let descriptor_node = metadata_address + offset as u64 + tree_node_offset as u64;
+            let state = if free_nodes.contains(&descriptor_node) || !decoded.committed {
+                PoolState::ReusableFree
+            } else {
+                PoolState::Allocated
+            };
+            discovery.regions.push(PoolRegion {
+                address: region_address,
+                size: region_size,
+                pool_kind,
+                numa_node,
+                heap: identity,
+                subsegment: Some(address),
+                backend,
+                unit_size: block_size,
+                bitmap,
+                heap_key,
+                pool_header: layout.pool_header_layout()?,
+                vs_header_size: layout.type_layout("_HEAP_VS_CHUNK_HEADER")?.size as usize,
+                vs_sizes_offset: layout.field("_HEAP_VS_CHUNK_HEADER", "Sizes")?,
+                known_tag: None,
+                states: vec![state],
+                reusable_chunks: reusable_chunks.clone(),
+                cached_chunks: cached_chunks.clone(),
+            });
+            descriptor_index += unit_size;
+        }
+        entry = read_u64(&segment_header, list_entry).unwrap_or(0) & !0xf;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn discover_large_allocations(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    heap_address: u64,
+    numa_node: u16,
+    pool_kind: PoolKind,
+    identity: HeapIdentity,
+    heap_key: u64,
+    traversal_limit: usize,
+    discovery: &mut Discovery,
+) {
+    let Ok(tree_offset) = layout.field("_SEGMENT_HEAP", "LargeAllocMetadata") else {
+        return;
+    };
+    let tree_address = heap_address + tree_offset as u64;
+    let nodes = tree_nodes(
+        memory,
+        layout,
+        tree_address,
+        traversal_limit,
+        "large-allocation tree",
+        &mut discovery.diagnostics,
+    );
+    let Ok(large) = layout.type_layout("_HEAP_LARGE_ALLOC_DATA") else {
+        return;
+    };
+    let Ok(tree_node) = layout.field("_HEAP_LARGE_ALLOC_DATA", "TreeNode") else {
+        return;
+    };
+    let Ok(virtual_offset) = layout.field("_HEAP_LARGE_ALLOC_DATA", "VirtualAddress") else {
+        return;
+    };
+    let Ok(pages_offset) = layout.field("_HEAP_LARGE_ALLOC_DATA", "AllocatedPages") else {
+        return;
+    };
+    for node in nodes {
+        let allocation_address = node.saturating_sub(tree_node as u64);
+        let allocation = match guarded_read(memory, allocation_address, large.size as usize) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                discovery.diagnostics.push(format!(
+                    "cannot read large-allocation metadata {allocation_address:#x}: {error}"
+                ));
+                continue;
+            }
+        };
+        let Some((virtual_address, pages)) = read_u64(&allocation, virtual_offset)
+            .zip(read_u64(&allocation, pages_offset))
+            .and_then(|(virtual_address, pages)| decode_large_allocation(virtual_address, pages))
+        else {
+            continue;
+        };
+        if pages > 0x10_0000 {
+            discovery.diagnostics.push(format!(
+                "rejecting implausible large allocation at {allocation_address:#x}"
+            ));
+            continue;
+        }
+        let bytes = pages.saturating_mul(PAGE_SIZE);
+        let (tag, tracked_size) = match lookup_big_page_target(
+            memory,
+            layout,
+            virtual_address,
+            &mut discovery.diagnostics,
+        ) {
+            Some(value) => value,
+            None => (0, bytes),
+        };
+        let size = tracked_size.min(bytes).min(usize::MAX as u64) as usize;
+        let Ok(pool_header) = layout.pool_header_layout() else {
+            continue;
+        };
+        discovery.regions.push(PoolRegion {
+            address: virtual_address,
+            size,
+            pool_kind,
+            numa_node,
+            heap: identity,
+            subsegment: None,
+            backend: PoolBackend::Large,
+            unit_size: size.min(u32::MAX as usize) as u32,
+            bitmap: Vec::new(),
+            heap_key,
+            pool_header,
+            vs_header_size: 0,
+            vs_sizes_offset: 0,
+            known_tag: Some(tag),
+            states: vec![PoolState::Allocated],
+            reusable_chunks: HashSet::new(),
+            cached_chunks: HashSet::new(),
+        });
+    }
+}
+
+fn lookup_big_page_target(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    address: u64,
+    diagnostics: &mut Vec<String>,
+) -> Option<(u32, u64)> {
+    let table_pointer_address = *layout.globals.get("PoolBigPageTable")?;
+    let table = scalar(memory, table_pointer_address, 8).ok()?;
+    let size_address = *layout.globals.get("PoolBigPageTableSize")?;
+    let count = scalar(memory, size_address, 8)
+        .or_else(|_| scalar(memory, size_address, 4))
+        .ok()? as usize;
+    if table == 0 || count == 0 || count > 0x10_0000 || !count.is_power_of_two() {
+        diagnostics.push(format!("rejecting implausible big-page table size {count}"));
+        return None;
+    }
+    let entry = layout.type_layout("_POOL_TRACKER_BIG_PAGES").ok()?;
+    let va_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Va").ok()?;
+    let tag_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Key").ok()?;
+    let size_offset = layout
+        .field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes")
+        .ok()?;
+    for index in big_page_candidates(address, count)? {
+        let entry_address = table + index as u64 * entry.size as u64;
+        let bytes = match guarded_read(memory, entry_address, entry.size as usize) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                diagnostics.push(format!(
+                    "cannot read big-page entry {index} at {entry_address:#x}: {error}"
+                ));
+                continue;
+            }
+        };
+        if read_u64(&bytes, va_offset)? & !1 == address {
+            return Some((
+                read_u32(&bytes, tag_offset)?,
+                read_u64(&bytes, size_offset)?,
+            ));
+        }
+    }
+    diagnostics.push(format!(
+        "no validated big-page entry for large allocation {address:#x}"
+    ));
+    None
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PoolSnapshot {
+    pub spans: Vec<PoolSpan>,
+    pub diagnostics: Vec<String>,
+    pub complete: bool,
+}
+
+pub(crate) struct SnapshotWalker<'a, M> {
+    pub memory: &'a M,
+    pub layout: &'a PoolLayout,
+    pub traversal_limit: usize,
+}
+
+impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
+    pub(crate) fn walk(&self) -> Result<PoolSnapshot, String> {
+        if !cfg!(target_arch = "x86_64") {
+            return Err("pool walking is supported only for x64 targets".into());
+        }
+        let mut snapshot = PoolSnapshot {
+            diagnostics: vec!["per-session paged heaps are not included".into()],
+            complete: true,
+            ..PoolSnapshot::default()
+        };
+        let discovery = discover_pool_regions(self.memory, self.layout, self.traversal_limit)?;
+        if !discovery.diagnostics.is_empty() {
+            snapshot.complete = false;
+        }
+        snapshot.diagnostics.extend(discovery.diagnostics);
+        for region in discovery.regions {
+            if self.memory.interrupted() {
+                snapshot.complete = false;
+                snapshot
+                    .diagnostics
+                    .push("pool walk interrupted by Ctrl+C".into());
+                break;
+            }
+            self.walk_region(&region, &mut snapshot);
+        }
+        snapshot
+            .spans
+            .sort_by_key(|span| (span.heap, span.usable_address));
+        Ok(snapshot)
+    }
+
+    fn walk_region(&self, region: &PoolRegion, snapshot: &mut PoolSnapshot) {
+        let requested_end = region.address.saturating_add(region.size as u64);
+        let mut cursor = region.address;
+        while cursor < requested_end {
+            let remaining = requested_end.saturating_sub(cursor).min(usize::MAX as u64) as usize;
+            let (reported_base, reported_size) = match self.memory.valid_region(cursor, remaining) {
+                Ok(valid) => valid,
+                Err(error) => {
+                    snapshot.diagnostics.push(format!(
+                        "cannot query region {cursor:#x}+{remaining:#x}: {error}"
+                    ));
+                    self.unreadable(region, cursor, requested_end - cursor, snapshot);
+                    break;
+                }
+            };
+            let valid_base = reported_base.max(cursor).min(requested_end);
+            if valid_base > cursor {
+                snapshot.diagnostics.push(format!(
+                    "region {:#x}+{:#x} is only committed through {cursor:#x}; unreadable space extends {:#x} bytes",
+                    region.address,
+                    region.size,
+                    valid_base - cursor
+                ));
+                self.unreadable(region, cursor, valid_base - cursor, snapshot);
+            }
+            let valid_end = reported_base
+                .saturating_add(reported_size as u64)
+                .min(requested_end);
+            if valid_end <= valid_base {
+                snapshot.diagnostics.push(format!(
+                    "valid-region query made no progress at {cursor:#x}"
+                ));
+                self.unreadable(region, valid_base, requested_end - valid_base, snapshot);
+                break;
+            }
+            let bytes = match self
+                .memory
+                .read_exact(valid_base, (valid_end - valid_base) as usize)
+            {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    snapshot
+                        .diagnostics
+                        .push(format!("cannot read region {valid_base:#x}: {error}"));
+                    self.unreadable(region, valid_base, valid_end - valid_base, snapshot);
+                    cursor = valid_end;
+                    continue;
+                }
+            };
+            match region.backend {
+                PoolBackend::Lfh => self.walk_lfh(region, valid_base, &bytes, snapshot),
+                PoolBackend::Vs => self.walk_vs(region, valid_base, &bytes, snapshot),
+                PoolBackend::Segment | PoolBackend::Large => {
+                    self.walk_page_ranges(region, valid_base, &bytes, snapshot)
+                }
+            }
+            cursor = valid_end;
+        }
+    }
+
+    fn base_span(
+        &self,
+        region: &PoolRegion,
+        header: u64,
+        usable: u64,
+        size: u64,
+        tag: u32,
+        state: PoolState,
+    ) -> PoolSpan {
+        PoolSpan {
+            header_address: header,
+            usable_address: usable,
+            size,
+            raw_tag: tag,
+            display_tag: super::decode::display_tag(tag),
+            pool_kind: region.pool_kind,
+            numa_node: region.numa_node,
+            heap: region.heap,
+            subsegment: region.subsegment,
+            backend: region.backend,
+            state,
+            size_class: region.unit_size,
+        }
+    }
+
+    fn unreadable(
+        &self,
+        region: &PoolRegion,
+        address: u64,
+        size: u64,
+        snapshot: &mut PoolSnapshot,
+    ) {
+        if size != 0 {
+            snapshot.complete = false;
+            snapshot.spans.push(self.base_span(
+                region,
+                address,
+                address,
+                size,
+                0,
+                PoolState::Unreadable,
+            ));
+        }
+    }
+
+    fn walk_lfh(&self, region: &PoolRegion, base: u64, bytes: &[u8], snapshot: &mut PoolSnapshot) {
+        let unit = region.unit_size as usize;
+        if unit < region.pool_header.size {
+            snapshot.diagnostics.push(format!(
+                "rejecting implausible LFH unit size {} at {base:#x}",
+                region.unit_size
+            ));
+            snapshot.complete = false;
+            return;
+        }
+        let slice_offset = base.saturating_sub(region.address) as usize;
+        let first_slot = slice_offset.div_ceil(unit);
+        let slice_end = slice_offset.saturating_add(bytes.len());
+        let mut slot = first_slot;
+        while let Some(slot_offset) = slot.checked_mul(unit) {
+            if slot_offset.saturating_add(unit) > slice_end {
+                break;
+            }
+            let offset = slot_offset - slice_offset;
+            let address = region.address + slot_offset as u64;
+            if address / PAGE_SIZE != (address + unit as u64 - 1) / PAGE_SIZE {
+                snapshot.diagnostics.push(format!(
+                    "LFH slot {address:#x}+{unit:#x} would cross a page"
+                ));
+                snapshot.complete = false;
+                slot += 1;
+                continue;
+            }
+            let Some(state) = lfh_bitmap_state(&region.bitmap, slot) else {
+                snapshot
+                    .diagnostics
+                    .push(format!("truncated LFH bitmap at slot {slot}"));
+                snapshot.complete = false;
+                break;
+            };
+            let tag = decode_pool_header(bytes, offset, region.pool_header)
+                .map_or(0, |header| header.tag);
+            let usable = address + region.pool_header.size as u64;
+            snapshot.spans.push(self.base_span(
+                region,
+                address,
+                usable,
+                unit as u64 - region.pool_header.size as u64,
+                tag,
+                state,
+            ));
+            slot += 1;
+        }
+    }
+
+    fn walk_vs(&self, region: &PoolRegion, base: u64, bytes: &[u8], snapshot: &mut PoolSnapshot) {
+        let mut offset = ((16 - (base as usize & 0xf)) & 0xf).min(bytes.len());
+        let mut chunks = 0usize;
+        let mut reported_corruption = false;
+        while offset
+            .saturating_add(region.vs_header_size)
+            .saturating_add(region.pool_header.size)
+            <= bytes.len()
+            && chunks < self.traversal_limit
+        {
+            let header_address = base + offset as u64;
+            let Some(encoded) = read_u64(bytes, offset + region.vs_sizes_offset) else {
+                break;
+            };
+            let Some(sizes) = decode_vs_sizes(encoded, header_address, region.heap_key) else {
+                if !reported_corruption {
+                    snapshot.diagnostics.push(format!(
+                        "rejecting corrupt VS metadata beginning at {header_address:#x}"
+                    ));
+                    reported_corruption = true;
+                }
+                snapshot.complete = false;
+                offset = offset.saturating_add(16);
+                continue;
+            };
+            let chunk_size = (sizes.size as usize).saturating_mul(16);
+            if chunk_size < region.vs_header_size + region.pool_header.size
+                || header_address.saturating_add(chunk_size as u64)
+                    > region.address.saturating_add(region.size as u64)
+            {
+                if !reported_corruption {
+                    snapshot.diagnostics.push(format!(
+                        "rejecting implausible VS chunk size {chunk_size:#x} at {header_address:#x}"
+                    ));
+                    reported_corruption = true;
+                }
+                snapshot.complete = false;
+                offset = offset.saturating_add(16);
+                continue;
+            }
+            if offset.saturating_add(chunk_size) > bytes.len() {
+                snapshot.complete = false;
+                break;
+            }
+            let candidate = header_address + region.vs_header_size as u64;
+            let Some(physical_header) =
+                adjust_page_end_header(candidate, region.pool_header.size as u64)
+            else {
+                snapshot.complete = false;
+                break;
+            };
+            let pool_offset = physical_header.saturating_sub(base) as usize;
+            let tag = decode_pool_header(bytes, pool_offset, region.pool_header)
+                .map_or(0, |header| header.tag);
+            let state = if region.cached_chunks.contains(&header_address) {
+                PoolState::CachedFree
+            } else if region.reusable_chunks.contains(&header_address) {
+                PoolState::ReusableFree
+            } else if sizes.allocated {
+                PoolState::Allocated
+            } else {
+                PoolState::ReusableFree
+            };
+            let overhead = physical_header
+                .saturating_sub(header_address)
+                .saturating_add(region.pool_header.size as u64);
+            let mut span = self.base_span(
+                region,
+                physical_header,
+                physical_header + region.pool_header.size as u64,
+                (chunk_size as u64).saturating_sub(overhead),
+                tag,
+                state,
+            );
+            span.size_class = chunk_size.min(u32::MAX as usize) as u32;
+            snapshot.spans.push(span);
+            let _ = sizes.previous_size;
+            offset += chunk_size;
+            chunks += 1;
+        }
+        if chunks >= self.traversal_limit {
+            snapshot.complete = false;
+            snapshot
+                .diagnostics
+                .push(format!("VS traversal limit reached at {base:#x}"));
+        }
+    }
+
+    fn walk_page_ranges(
+        &self,
+        region: &PoolRegion,
+        base: u64,
+        bytes: &[u8],
+        snapshot: &mut PoolSnapshot,
+    ) {
+        let unit = region.unit_size.max(1) as usize;
+        let slice_offset = base.saturating_sub(region.address) as usize;
+        let first_slot = slice_offset.div_ceil(unit);
+        let slice_end = slice_offset.saturating_add(bytes.len());
+        let mut slot = first_slot;
+        while let Some(slot_offset) = slot.checked_mul(unit) {
+            if slot_offset >= slice_end {
+                break;
+            }
+            let offset = slot_offset - slice_offset;
+            let remaining = bytes.len() - offset;
+            let size = unit.min(remaining);
+            let state = region
+                .states
+                .get(slot)
+                .copied()
+                .or_else(|| region.states.first().copied())
+                .unwrap_or(PoolState::Unreadable);
+            let tag = region.known_tag.or_else(|| {
+                decode_pool_header(bytes, offset, region.pool_header).map(|header| header.tag)
+            });
+            let address = region.address + slot_offset as u64;
+            let header_size = if region.backend == PoolBackend::Large {
+                0
+            } else {
+                region.pool_header.size.min(size)
+            };
+            snapshot.spans.push(self.base_span(
+                region,
+                address,
+                address + header_size as u64,
+                size.saturating_sub(header_size) as u64,
+                tag.unwrap_or(0),
+                state,
+            ));
+            slot += 1;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lookup_big_page(
+        &self,
+        table: &[u8],
+        entry_size: usize,
+        address: u64,
+    ) -> Option<(u32, u64)> {
+        if entry_size < 20 || !table.len().is_multiple_of(entry_size) {
+            return None;
+        }
+        let count = table.len() / entry_size;
+        for index in big_page_candidates(address, count)? {
+            let offset = index * entry_size;
+            let candidate = read_u64(table, offset)? & !1;
+            if candidate == address {
+                return Some((read_u32(table, offset + 8)?, read_u64(table, offset + 12)?));
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use super::*;
+    use crate::pool::layout::{SessionKey, TypeLayout};
+
+    const K: u64 = 0xffff_8000_0000_0000;
+    const STATE: u64 = K + 0x10_0000;
+    const GLOBALS: u64 = K + 0x11_0000;
+    const BIG_TABLE_POINTER: u64 = K + 0x12_0000;
+    const BIG_TABLE_COUNT: u64 = K + 0x12_0010;
+    const HEAP: u64 = K + 0x20_0000;
+    const DYNAMIC_LOOKASIDE: u64 = K + 0x21_0000;
+    const SEGMENT: u64 = K + 0x30_0000;
+    const LARGE_META: u64 = K + 0x80_0000;
+    const LARGE_VA: u64 = K + 0x90_0000;
+    const BIG_TABLE: u64 = K + 0xa0_0000;
+
+    struct SyntheticMemory {
+        bytes: BTreeMap<u64, u8>,
+        holes: Vec<(u64, u64)>,
+    }
+
+    impl PoolMemory for SyntheticMemory {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, String> {
+            (0..size)
+                .map(|offset| {
+                    self.bytes
+                        .get(&(address + offset as u64))
+                        .copied()
+                        .ok_or_else(|| "sparse synthetic memory".into())
+                })
+                .collect()
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), String> {
+            let end = address.saturating_add(size as u64);
+            for &(hole_start, hole_end) in &self.holes {
+                if address >= hole_start && address < hole_end {
+                    return Ok((hole_end, end.saturating_sub(hole_end) as usize));
+                }
+                if address < hole_start && end > hole_start {
+                    return Ok((address, hole_start.saturating_sub(address) as usize));
+                }
+            }
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> bool {
+            false
+        }
+    }
+
+    fn type_layout(size: u32, fields: &[(&'static str, u32)]) -> TypeLayout {
+        TypeLayout {
+            size,
+            fields: fields.iter().copied().collect(),
+        }
+    }
+
+    fn synthetic_layout() -> PoolLayout {
+        let mut types = HashMap::new();
+        types.insert(
+            "_EX_POOL_HEAP_MANAGER_STATE",
+            type_layout(
+                0x100,
+                &[
+                    ("HeapManager", 8),
+                    ("PoolNode", 0x40),
+                    ("NumberOfPools", 0),
+                    ("SpecialHeaps", 0x20),
+                ],
+            ),
+        );
+        types.insert("_EX_HEAP_POOL_NODE", type_layout(0x40, &[("Heaps", 0)]));
+        types.insert(
+            "_SEGMENT_HEAP",
+            type_layout(
+                0x800,
+                &[
+                    ("SegContexts", 0x100),
+                    ("VsContext", 0x300),
+                    ("LfhContext", 0x380),
+                    ("LargeAllocMetadata", 0x400),
+                    ("UserContext", 0x500),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_SEG_CONTEXT",
+            type_layout(
+                0x80,
+                &[
+                    ("SegmentListHead", 0),
+                    ("FreePageRanges", 0x10),
+                    ("UnitShift", 0x20),
+                    ("FirstDescriptorIndex", 0x21),
+                    ("SegmentMask", 0x28),
+                    ("PagesPerUnitShift", 0x30),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_PAGE_SEGMENT",
+            type_layout(
+                0x100,
+                &[("ListEntry", 0), ("Signature", 0x20), ("DescArray", 0x100)],
+            ),
+        );
+        types.insert(
+            "_HEAP_PAGE_RANGE_DESCRIPTOR",
+            type_layout(
+                0x20,
+                &[
+                    ("UnitSize", 0x1f),
+                    ("RangeFlags", 0x18),
+                    ("TreeNode", 0),
+                    ("TreeSignature", 0),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_VS_CONTEXT",
+            type_layout(
+                0x40,
+                &[
+                    ("FreeChunkTree", 0),
+                    ("DelayFreeContext", 0x10),
+                    ("SubsegmentList", 0x30),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_VS_DELAY_FREE_CONTEXT",
+            type_layout(0x10, &[("ListHead", 0)]),
+        );
+        types.insert(
+            "_HEAP_VS_SUBSEGMENT",
+            type_layout(0xfe0, &[("Signature", 0), ("Size", 2), ("ListEntry", 8)]),
+        );
+        types.insert(
+            "_HEAP_VS_CHUNK_HEADER",
+            type_layout(0x10, &[("Sizes", 0), ("EncodedSegmentPageOffset", 8)]),
+        );
+        types.insert(
+            "_HEAP_VS_CHUNK_FREE_HEADER",
+            type_layout(0x20, &[("TreeNode", 8)]),
+        );
+        types.insert(
+            "_HEAP_LFH_CONTEXT",
+            type_layout(0x20, &[("Buckets", 0), ("AffinitySlots", 8)]),
+        );
+        types.insert(
+            "_HEAP_LFH_SUBSEGMENT",
+            type_layout(
+                0x20,
+                &[
+                    ("BlockOffsets", 0),
+                    ("BlockCount", 4),
+                    ("BlockBitmap", 8),
+                    ("ListEntry", 0x10),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_LFH_SUBSEGMENT_ENCODED_OFFSETS",
+            type_layout(4, &[("EncodedData", 0)]),
+        );
+        types.insert(
+            "_RTLP_HP_HEAP_GLOBALS",
+            type_layout(0x10, &[("HeapKey", 0), ("LfhKey", 8)]),
+        );
+        types.insert(
+            "_RTL_RB_TREE",
+            type_layout(0x10, &[("Root", 0), ("Min", 8)]),
+        );
+        types.insert(
+            "_RTL_BALANCED_NODE",
+            type_layout(0x10, &[("Left", 0), ("Right", 8)]),
+        );
+        types.insert(
+            "_RTL_DYNAMIC_LOOKASIDE",
+            type_layout(0x80, &[("BucketCount", 8), ("Buckets", 0x40)]),
+        );
+        types.insert(
+            "_RTL_LOOKASIDE",
+            type_layout(0x40, &[("ListHead", 0), ("Size", 0x30)]),
+        );
+        types.insert(
+            "_SLIST_HEADER",
+            type_layout(0x10, &[("Alignment", 0), ("Region", 8)]),
+        );
+        types.insert(
+            "_POOL_HEADER",
+            type_layout(
+                0x10,
+                &[
+                    ("PreviousSize", 0),
+                    ("PoolIndex", 0),
+                    ("BlockSize", 2),
+                    ("PoolType", 2),
+                    ("PoolTag", 8),
+                ],
+            ),
+        );
+        types.insert(
+            "_HEAP_LARGE_ALLOC_DATA",
+            type_layout(
+                0x28,
+                &[
+                    ("TreeNode", 0),
+                    ("VirtualAddress", 0x18),
+                    ("AllocatedPages", 0x20),
+                ],
+            ),
+        );
+        types.insert(
+            "_POOL_TRACKER_BIG_PAGES",
+            type_layout(0x20, &[("Va", 0), ("Key", 8), ("NumberOfBytes", 0x10)]),
+        );
+        PoolLayout {
+            key: SessionKey {
+                kernel_base: K,
+                session: 1,
+            },
+            globals: [
+                ("ExPoolState", STATE),
+                ("RtlpHpHeapGlobals", GLOBALS),
+                ("PoolBigPageTable", BIG_TABLE_POINTER),
+                ("PoolBigPageTableSize", BIG_TABLE_COUNT),
+            ]
+            .into_iter()
+            .collect(),
+            types,
+        }
+    }
+
+    fn put(bytes: &mut BTreeMap<u64, u8>, address: u64, data: &[u8]) {
+        bytes.extend(
+            data.iter()
+                .enumerate()
+                .map(|(offset, byte)| (address + offset as u64, *byte)),
+        );
+    }
+
+    fn fill(bytes: &mut BTreeMap<u64, u8>, address: u64, size: usize) {
+        put(bytes, address, &vec![0; size]);
+    }
+
+    fn put_u16(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u16) {
+        put(bytes, address, &value.to_le_bytes());
+    }
+
+    fn put_u32(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u32) {
+        put(bytes, address, &value.to_le_bytes());
+    }
+
+    fn put_u64(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u64) {
+        put(bytes, address, &value.to_le_bytes());
+    }
+
+    fn pool_header(bytes: &mut BTreeMap<u64, u8>, address: u64, tag: &[u8; 4]) {
+        fill(bytes, address, 0x10);
+        put(bytes, address, &[1, 0, 4, 1]);
+        put(bytes, address + 8, tag);
+    }
+
+    fn synthetic_memory() -> SyntheticMemory {
+        let mut bytes = BTreeMap::new();
+        fill(&mut bytes, STATE, 0x100);
+        put_u32(&mut bytes, STATE, 1);
+        for heap_index in 0..4 {
+            put_u64(&mut bytes, STATE + 0x40 + heap_index * 8, HEAP);
+        }
+        fill(&mut bytes, GLOBALS, 0x10);
+        let heap_key = 0x55aa_1234_9876_0000;
+        let lfh_key = 0xa5c3_1357;
+        put_u64(&mut bytes, GLOBALS, heap_key);
+        put_u64(&mut bytes, GLOBALS + 8, lfh_key);
+        fill(&mut bytes, HEAP, 0x800);
+
+        let context = HEAP + 0x100;
+        let list_head = context;
+        put_u64(&mut bytes, list_head, SEGMENT);
+        put_u64(&mut bytes, context + 0x10, SEGMENT + 0x100 + 6 * 0x20);
+        put(&mut bytes, context + 0x20, &[12, 1]);
+        put_u64(&mut bytes, context + 0x28, !0xffffu64);
+
+        fill(&mut bytes, SEGMENT, 0x100);
+        put_u64(&mut bytes, SEGMENT, list_head);
+        put_u64(
+            &mut bytes,
+            SEGMENT + 0x20,
+            SEGMENT ^ context ^ GLOBALS ^ super::super::decode::PAGE_SEGMENT_SIGNATURE,
+        );
+        fill(&mut bytes, SEGMENT + 0x100, 16 * 0x20);
+        for (index, units, flags) in [
+            (1u64, 2u8, 0x09u8),
+            (3, 2, 0x0d),
+            (5, 1, 0x01),
+            (6, 1, 0x00),
+            (7, 1, 0x01),
+        ] {
+            let descriptor = SEGMENT + 0x100 + index * 0x20;
+            if flags & 1 != 0 {
+                put_u32(
+                    &mut bytes,
+                    descriptor,
+                    super::super::decode::DESCRIPTOR_TREE_SIGNATURE,
+                );
+            }
+            put(&mut bytes, descriptor + 0x18, &[flags]);
+            put(&mut bytes, descriptor + 0x1f, &[units]);
+        }
+
+        let lfh = SEGMENT + 0x1000;
+        fill(&mut bytes, lfh, 0x20);
+        let decoded_offsets = u32::from(0x40u16) | (u32::from(0x40u16) << 16);
+        put_u32(
+            &mut bytes,
+            lfh,
+            decoded_offsets ^ lfh_key as u32 ^ (lfh >> 12) as u32,
+        );
+        put_u16(&mut bytes, lfh + 4, 4);
+        put(&mut bytes, lfh + 8, &[0x49]);
+        fill(&mut bytes, lfh + 0x40, 0x100);
+        pool_header(&mut bytes, lfh + 0x40, b"LFH!");
+        pool_header(&mut bytes, lfh + 0x80, b"LFHC");
+        pool_header(&mut bytes, lfh + 0xc0, b"LFHF");
+        pool_header(&mut bytes, lfh + 0x100, b"LFH2");
+
+        let vs = SEGMENT + 0x3000;
+        fill(&mut bytes, vs, 0x2000);
+        put_u16(&mut bytes, vs, 0x2bed ^ 2);
+        put_u16(&mut bytes, vs + 2, 2);
+        let first_chunk = vs + 0xfe0;
+        let cached_chunk = first_chunk + 0x40;
+        let free_chunk = cached_chunk + 0x40;
+        for (address, allocated) in [
+            (first_chunk, true),
+            (cached_chunk, false),
+            (free_chunk, false),
+        ] {
+            let decoded = (4u64 << 16) | (u64::from(allocated) << 48);
+            put_u64(&mut bytes, address, decoded ^ address ^ heap_key);
+        }
+        pool_header(&mut bytes, first_chunk + 0x20, b"VS!!");
+        let vs_context = HEAP + 0x300;
+        put_u64(&mut bytes, vs_context, free_chunk + 8);
+        put_u64(&mut bytes, free_chunk + 8, 0);
+        put_u64(&mut bytes, free_chunk + 16, 0);
+        let delay_head = vs_context + 0x10;
+        put_u16(&mut bytes, delay_head, 1);
+        put_u64(&mut bytes, delay_head + 8, cached_chunk + 0x20);
+        put_u64(&mut bytes, cached_chunk + 0x20, 0);
+
+        put_u64(&mut bytes, HEAP + 0x500, DYNAMIC_LOOKASIDE);
+        fill(&mut bytes, DYNAMIC_LOOKASIDE, 0x80);
+        put_u32(&mut bytes, DYNAMIC_LOOKASIDE + 8, 1);
+        let lookaside_chunk = free_chunk + 0x40;
+        let decoded = 4u64 << 16;
+        put_u64(
+            &mut bytes,
+            lookaside_chunk,
+            decoded ^ lookaside_chunk ^ heap_key,
+        );
+        let lookaside_head = DYNAMIC_LOOKASIDE + 0x40;
+        put_u16(&mut bytes, lookaside_head, 1);
+        put_u64(&mut bytes, lookaside_head + 8, lookaside_chunk + 0x20);
+        put_u64(&mut bytes, lookaside_chunk + 0x20, 0);
+        put_u32(&mut bytes, lookaside_head + 0x30, 0x40);
+
+        fill(&mut bytes, SEGMENT + 0x5000, 0x1000);
+        pool_header(&mut bytes, SEGMENT + 0x5000, b"SEGM");
+        fill(&mut bytes, SEGMENT + 0x6000, 0x1000);
+        fill(&mut bytes, SEGMENT + 0x7000, 0x800);
+        pool_header(&mut bytes, SEGMENT + 0x7000, b"SPRS");
+
+        let large_tree = HEAP + 0x400;
+        put_u64(&mut bytes, large_tree, (LARGE_META ^ large_tree) | 1);
+        fill(&mut bytes, LARGE_META, 0x28);
+        put_u64(&mut bytes, LARGE_META + 0x18, LARGE_VA | 0x1800);
+        put_u64(&mut bytes, LARGE_META + 0x20, (2u64 << 12) | 0x5a5);
+        fill(&mut bytes, LARGE_VA, 0x2000);
+        put_u64(&mut bytes, BIG_TABLE_POINTER, BIG_TABLE);
+        put_u64(&mut bytes, BIG_TABLE_COUNT, 4);
+        fill(&mut bytes, BIG_TABLE, 4 * 0x20);
+        let first = super::super::decode::big_page_hash(LARGE_VA, 4).unwrap();
+        let adjacent = (first + 1) % 4;
+        let entry = BIG_TABLE + adjacent as u64 * 0x20;
+        put_u64(&mut bytes, entry, LARGE_VA);
+        put(&mut bytes, entry + 8, b"BIG!");
+        put_u64(&mut bytes, entry + 0x10, 0x1800);
+
+        SyntheticMemory {
+            bytes,
+            holes: vec![(SEGMENT + 0x7800, SEGMENT + 0x8000)],
+        }
+    }
+
+    #[test]
+    fn test_pool_snapshot_walks_all_backends() {
+        let memory = synthetic_memory();
+        let layout = synthetic_layout();
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1024,
+        };
+        let snapshot = walker.walk().unwrap();
+        for backend in [
+            PoolBackend::Lfh,
+            PoolBackend::Vs,
+            PoolBackend::Segment,
+            PoolBackend::Large,
+        ] {
+            assert!(
+                snapshot.spans.iter().any(|span| span.backend == backend),
+                "missing {backend:?}"
+            );
+        }
+        assert!(snapshot.spans.iter().any(|span| span.pool_kind.is_paged()));
+        assert!(snapshot.spans.iter().any(|span| {
+            span.raw_tag == u32::from_le_bytes(*b"LFH!") && span.state == PoolState::Allocated
+        }));
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Vs && span.state == PoolState::CachedFree
+        }));
+        assert!(
+            snapshot
+                .spans
+                .iter()
+                .filter(|span| span.backend == PoolBackend::Vs)
+                .all(|span| span.size_class == 0x40)
+        );
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Segment && span.state == PoolState::ReusableFree
+        }));
+        assert!(
+            snapshot
+                .spans
+                .iter()
+                .any(|span| span.state == PoolState::Unreadable)
+        );
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Vs && span.header_address == SEGMENT + 0x4000
+        }));
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Large
+                && span.raw_tag == u32::from_le_bytes(*b"BIG!")
+                && span.size == 0x1800
+        }));
+        assert!(
+            snapshot
+                .diagnostics
+                .iter()
+                .any(|message| { message.contains("per-session paged heaps are not included") })
+        );
+        assert!(
+            snapshot
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("only committed through"))
+        );
+
+        let mut table = vec![0u8; 4 * 24];
+        let address = K + 0xb0_0000;
+        let first = super::super::decode::big_page_hash(address, 4).unwrap();
+        let second = ((first + 1) % 4) * 24;
+        table[second..second + 8].copy_from_slice(&address.to_le_bytes());
+        table[second + 8..second + 12].copy_from_slice(b"NEXT");
+        table[second + 12..second + 20].copy_from_slice(&0x7000u64.to_le_bytes());
+        assert_eq!(
+            walker.lookup_big_page(&table, 24, address),
+            Some((u32::from_le_bytes(*b"NEXT"), 0x7000))
+        );
+    }
+}

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1512,12 +1512,17 @@ mod tests {
     struct SyntheticMemory {
         bytes: BTreeMap<u64, u8>,
         holes: Vec<(u64, u64)>,
+    }
+
+    struct ShortMemory;
+
+    struct BigPageMemory {
+        table: Vec<u8>,
+        count: usize,
         read_calls: Cell<usize>,
         interrupt_checks: Cell<usize>,
         interrupt_after_checks: Option<usize>,
     }
-
-    struct ShortMemory;
 
     impl PoolMemory for ShortMemory {
         fn read_exact(&self, _address: u64, _size: usize) -> Result<Vec<u8>, SnapshotError> {
@@ -1533,9 +1538,46 @@ mod tests {
         }
     }
 
-    impl PoolMemory for SyntheticMemory {
+    impl PoolMemory for BigPageMemory {
         fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
             self.read_calls.set(self.read_calls.get() + 1);
+            if address == BIG_TABLE_POINTER && size == 8 {
+                return Ok(BIG_TABLE.to_le_bytes().to_vec());
+            }
+            if address == BIG_TABLE_COUNT && size == 8 {
+                return Ok((self.count as u64).to_le_bytes().to_vec());
+            }
+            let offset = address
+                .checked_sub(BIG_TABLE)
+                .and_then(|value| usize::try_from(value).ok());
+            if let Some(bytes) = offset
+                .and_then(|offset| offset.checked_add(size).map(|end| (offset, end)))
+                .and_then(|(offset, end)| self.table.get(offset..end))
+            {
+                return Ok(bytes.to_vec());
+            }
+            Err(SnapshotError::Read {
+                address,
+                size,
+                source: Box::new(std::io::Error::other("sparse big-page memory")),
+            })
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            let checks = self.interrupt_checks.get();
+            self.interrupt_checks.set(checks + 1);
+            Ok(self
+                .interrupt_after_checks
+                .is_some_and(|limit| checks >= limit))
+        }
+    }
+
+    impl PoolMemory for SyntheticMemory {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
             (0..size)
                 .map(|offset| {
                     self.bytes
@@ -1564,11 +1606,7 @@ mod tests {
         }
 
         fn interrupted(&self) -> Result<bool, SnapshotError> {
-            let checks = self.interrupt_checks.get();
-            self.interrupt_checks.set(checks + 1);
-            Ok(self
-                .interrupt_after_checks
-                .is_some_and(|limit| checks >= limit))
+            Ok(false)
         }
     }
 
@@ -1918,34 +1956,30 @@ mod tests {
         SyntheticMemory {
             bytes,
             holes: vec![(SEGMENT + 0x7800, SEGMENT + 0x8000)],
+        }
+    }
+
+    fn big_page_memory(address: u64, count: usize, collision_distance: usize) -> BigPageMemory {
+        let mut table = vec![0; count * 0x20];
+        let first = super::super::decode::big_page_hash(address, count).unwrap();
+        for distance in 0..collision_distance {
+            let index = (first + distance) % count;
+            let offset = index * 0x20;
+            table[offset..offset + 8]
+                .copy_from_slice(&(address + (distance as u64 + 1) * 0x10_0000).to_le_bytes());
+        }
+        let index = (first + collision_distance) % count;
+        let offset = index * 0x20;
+        table[offset..offset + 8].copy_from_slice(&address.to_le_bytes());
+        table[offset + 8..offset + 12].copy_from_slice(b"BTCH");
+        table[offset + 0x10..offset + 0x18].copy_from_slice(&0x9000u64.to_le_bytes());
+        BigPageMemory {
+            table,
+            count,
             read_calls: Cell::new(0),
             interrupt_checks: Cell::new(0),
             interrupt_after_checks: None,
         }
-    }
-
-    fn configure_big_page_probe(
-        memory: &mut SyntheticMemory,
-        address: u64,
-        count: usize,
-        collision_distance: usize,
-    ) {
-        put_u64(&mut memory.bytes, BIG_TABLE_COUNT, count as u64);
-        fill(&mut memory.bytes, BIG_TABLE, count * 0x20);
-        let first = super::super::decode::big_page_hash(address, count).unwrap();
-        for distance in 0..collision_distance {
-            let index = (first + distance) % count;
-            put_u64(
-                &mut memory.bytes,
-                BIG_TABLE + index as u64 * 0x20,
-                address + (distance as u64 + 1) * 0x10_0000,
-            );
-        }
-        let index = (first + collision_distance) % count;
-        let entry = BIG_TABLE + index as u64 * 0x20;
-        put_u64(&mut memory.bytes, entry, address);
-        put(&mut memory.bytes, entry + 8, b"BTCH");
-        put_u64(&mut memory.bytes, entry + 0x10, 0x9000);
     }
 
     #[test]
@@ -2033,9 +2067,8 @@ mod tests {
 
     #[test]
     fn test_big_page_lookup_batches_collision_chain() {
-        let mut memory = synthetic_memory();
+        let memory = big_page_memory(LARGE_VA, 512, 300);
         let layout = synthetic_layout();
-        configure_big_page_probe(&mut memory, LARGE_VA, 512, 300);
         let reads_before = memory.read_calls.get();
         let mut diagnostics = Vec::new();
 
@@ -2049,9 +2082,8 @@ mod tests {
 
     #[test]
     fn test_big_page_lookup_honors_interrupt_between_batches() {
-        let mut memory = synthetic_memory();
+        let mut memory = big_page_memory(LARGE_VA, 512, 300);
         let layout = synthetic_layout();
-        configure_big_page_probe(&mut memory, LARGE_VA, 512, 300);
         memory.interrupt_after_checks = Some(1);
 
         assert!(matches!(

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -953,15 +953,6 @@ fn discover_large_allocations(
     let Ok(tree_offset) = layout.field("_SEGMENT_HEAP", "LargeAllocMetadata") else {
         return Ok(());
     };
-    let tree_address = heap_address + tree_offset as u64;
-    let nodes = tree_nodes(
-        memory,
-        layout,
-        tree_address,
-        traversal_limit,
-        "large-allocation tree",
-        &mut discovery.diagnostics,
-    )?;
     let Ok(large) = layout.type_layout("_HEAP_LARGE_ALLOC_DATA") else {
         return Ok(());
     };
@@ -974,6 +965,15 @@ fn discover_large_allocations(
     let Ok(pages_offset) = layout.field("_HEAP_LARGE_ALLOC_DATA", "AllocatedPages") else {
         return Ok(());
     };
+    let tree_address = heap_address + tree_offset as u64;
+    let nodes = tree_nodes(
+        memory,
+        layout,
+        tree_address,
+        traversal_limit,
+        "large-allocation tree",
+        &mut discovery.diagnostics,
+    )?;
     for node in nodes {
         let allocation_address = node.saturating_sub(tree_node as u64);
         let allocation = match guarded_read(memory, allocation_address, large.size as usize) {
@@ -1042,10 +1042,9 @@ fn lookup_big_page_target(
     address: u64,
     diagnostics: &mut Vec<String>,
 ) -> Result<Option<(u32, u64)>, SnapshotError> {
-    let table_pointer_address = *layout
-        .globals
-        .get("PoolBigPageTable")
-        .ok_or_else(|| missing_layout("PoolBigPageTable"))?;
+    let Some(&table_pointer_address) = layout.globals.get("PoolBigPageTable") else {
+        return Ok(None);
+    };
     let table = match scalar(memory, table_pointer_address, 8) {
         Ok(value) => value,
         Err(error) => {
@@ -1053,10 +1052,9 @@ fn lookup_big_page_target(
             return Ok(None);
         }
     };
-    let size_address = *layout
-        .globals
-        .get("PoolBigPageTableSize")
-        .ok_or_else(|| missing_layout("PoolBigPageTableSize"))?;
+    let Some(&size_address) = layout.globals.get("PoolBigPageTableSize") else {
+        return Ok(None);
+    };
     let count = match scalar(memory, size_address, 8).or_else(|_| scalar(memory, size_address, 4)) {
         Ok(value) => value as usize,
         Err(error) => {
@@ -1068,11 +1066,19 @@ fn lookup_big_page_target(
         diagnostics.push(format!("rejecting implausible big-page table size {count}"));
         return Ok(None);
     }
-    let entry = layout.type_layout("_POOL_TRACKER_BIG_PAGES")?;
+    let Ok(entry) = layout.type_layout("_POOL_TRACKER_BIG_PAGES") else {
+        return Ok(None);
+    };
     let entry_size = entry.size as usize;
-    let va_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Va")?;
-    let tag_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "Key")?;
-    let size_offset = layout.field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes")?;
+    let Ok(va_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Va") else {
+        return Ok(None);
+    };
+    let Ok(tag_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "Key") else {
+        return Ok(None);
+    };
+    let Ok(size_offset) = layout.field("_POOL_TRACKER_BIG_PAGES", "NumberOfBytes") else {
+        return Ok(None);
+    };
     let mut probes = big_page_probe(address, count).ok_or_else(|| SnapshotError::InvalidData {
         detail: format!("invalid big-page table size {count}"),
     })?;
@@ -2087,6 +2093,48 @@ mod tests {
             walker.lookup_big_page(&table, 24, address),
             Some((u32::from_le_bytes(*b"NEXT"), 0x7000))
         );
+    }
+
+    #[test]
+    fn test_snapshot_skips_missing_optional_large_layout() {
+        let memory = synthetic_memory();
+        let mut layout = synthetic_layout();
+        layout.types.remove("_HEAP_LARGE_ALLOC_DATA");
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1024,
+        };
+
+        let snapshot = walker.walk().unwrap();
+
+        for backend in [PoolBackend::Lfh, PoolBackend::Vs, PoolBackend::Segment] {
+            assert!(snapshot.spans.iter().any(|span| span.backend == backend));
+        }
+        assert!(
+            snapshot
+                .spans
+                .iter()
+                .all(|span| span.backend != PoolBackend::Large)
+        );
+    }
+
+    #[test]
+    fn test_large_snapshot_falls_back_without_big_page_layout() {
+        let memory = synthetic_memory();
+        let mut layout = synthetic_layout();
+        layout.types.remove("_POOL_TRACKER_BIG_PAGES");
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1024,
+        };
+
+        let snapshot = walker.walk().unwrap();
+
+        assert!(snapshot.spans.iter().any(|span| {
+            span.backend == PoolBackend::Large && span.raw_tag == 0 && span.size == 0x2000
+        }));
     }
 
     #[test]

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -8,7 +8,10 @@ use super::decode::{
     decode_vs_sizes, lfh_bitmap_state, read_u16, read_u32, read_u64,
     valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
-use super::{HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState, layout::PoolLayout};
+use super::{
+    HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState,
+    layout::{LayoutError, PoolLayout},
+};
 
 type SnapshotSource = Box<dyn std::error::Error + Send + Sync>;
 
@@ -37,8 +40,11 @@ pub(crate) enum SnapshotError {
         valid_base: u64,
         valid_size: usize,
     },
-    #[error("snapshot layout lookup failed: {detail}")]
-    Layout { detail: String },
+    #[error("snapshot layout lookup failed: {source}")]
+    Layout {
+        #[source]
+        source: LayoutError,
+    },
     #[error("pool snapshot interrupted by Ctrl+C")]
     Interrupted,
     #[error("interrupt-status query failed: {source}")]
@@ -50,10 +56,14 @@ pub(crate) enum SnapshotError {
     InvalidData { detail: String },
 }
 
-impl From<String> for SnapshotError {
-    fn from(detail: String) -> Self {
-        Self::Layout { detail }
+impl From<LayoutError> for SnapshotError {
+    fn from(source: LayoutError) -> Self {
+        Self::Layout { source }
     }
+}
+
+fn missing_layout(item: impl Into<String>) -> SnapshotError {
+    LayoutError::Missing { item: item.into() }.into()
 }
 
 #[derive(Debug, Clone)]
@@ -145,7 +155,12 @@ fn guarded_read(
 fn scalar(memory: &impl PoolMemory, address: u64, size: usize) -> Result<u64, SnapshotError> {
     let bytes = guarded_read(memory, address, size)?;
     match size {
-        1 => Ok(bytes[0] as u64),
+        1 => bytes
+            .first()
+            .map(|&byte| byte as u64)
+            .ok_or_else(|| SnapshotError::InvalidData {
+                detail: "short u8".into(),
+            }),
         2 => Ok(
             u16::from_le_bytes(bytes.try_into().map_err(|_| SnapshotError::InvalidData {
                 detail: "short u16".into(),
@@ -329,13 +344,10 @@ fn discover_pool_regions(
     layout: &PoolLayout,
     traversal_limit: usize,
 ) -> Result<Discovery, SnapshotError> {
-    let state_address =
-        *layout
-            .globals
-            .get("ExPoolState")
-            .ok_or_else(|| SnapshotError::Layout {
-                detail: "missing ExPoolState".into(),
-            })?;
+    let state_address = *layout
+        .globals
+        .get("ExPoolState")
+        .ok_or_else(|| missing_layout("ExPoolState"))?;
     let state = layout.type_layout("_EX_POOL_HEAP_MANAGER_STATE")?;
     let node = layout.type_layout("_EX_HEAP_POOL_NODE")?;
     let number_offset = layout.field("_EX_POOL_HEAP_MANAGER_STATE", "NumberOfPools")?;
@@ -406,13 +418,10 @@ fn discover_pool_regions(
         }
     }
 
-    let globals_address =
-        *layout
-            .globals
-            .get("RtlpHpHeapGlobals")
-            .ok_or_else(|| SnapshotError::Layout {
-                detail: "missing RtlpHpHeapGlobals".into(),
-            })?;
+    let globals_address = *layout
+        .globals
+        .get("RtlpHpHeapGlobals")
+        .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
     let heap_key = scalar(
         memory,
         globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "HeapKey")? as u64,
@@ -747,13 +756,10 @@ fn discover_segment_context(
         let signature = read_u64(&segment_header, signature_offset)
             .or_else(|| read_u32(&segment_header, signature_offset).map(u64::from))
             .unwrap_or(0);
-        let heap_globals =
-            *layout
-                .globals
-                .get("RtlpHpHeapGlobals")
-                .ok_or_else(|| SnapshotError::Layout {
-                    detail: "missing RtlpHpHeapGlobals".into(),
-                })?;
+        let heap_globals = *layout
+            .globals
+            .get("RtlpHpHeapGlobals")
+            .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
         if !valid_page_segment_signature(signature, segment_address, context_address, heap_globals)
         {
             discovery.diagnostics.push(format!(
@@ -1036,13 +1042,10 @@ fn lookup_big_page_target(
     address: u64,
     diagnostics: &mut Vec<String>,
 ) -> Result<Option<(u32, u64)>, SnapshotError> {
-    let table_pointer_address =
-        *layout
-            .globals
-            .get("PoolBigPageTable")
-            .ok_or_else(|| SnapshotError::Layout {
-                detail: "missing PoolBigPageTable".into(),
-            })?;
+    let table_pointer_address = *layout
+        .globals
+        .get("PoolBigPageTable")
+        .ok_or_else(|| missing_layout("PoolBigPageTable"))?;
     let table = match scalar(memory, table_pointer_address, 8) {
         Ok(value) => value,
         Err(error) => {
@@ -1050,13 +1053,10 @@ fn lookup_big_page_target(
             return Ok(None);
         }
     };
-    let size_address =
-        *layout
-            .globals
-            .get("PoolBigPageTableSize")
-            .ok_or_else(|| SnapshotError::Layout {
-                detail: "missing PoolBigPageTableSize".into(),
-            })?;
+    let size_address = *layout
+        .globals
+        .get("PoolBigPageTableSize")
+        .ok_or_else(|| missing_layout("PoolBigPageTableSize"))?;
     let count = match scalar(memory, size_address, 8).or_else(|_| scalar(memory, size_address, 4)) {
         Ok(value) => value as usize,
         Err(error) => {
@@ -1515,6 +1515,22 @@ mod tests {
         read_calls: Cell<usize>,
         interrupt_checks: Cell<usize>,
         interrupt_after_checks: Option<usize>,
+    }
+
+    struct ShortMemory;
+
+    impl PoolMemory for ShortMemory {
+        fn read_exact(&self, _address: u64, _size: usize) -> Result<Vec<u8>, SnapshotError> {
+            Ok(Vec::new())
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
     }
 
     impl PoolMemory for SyntheticMemory {
@@ -2054,5 +2070,11 @@ mod tests {
 
         let error = guarded_read(&memory, SEGMENT + 0x7800, 0x10).unwrap_err();
         assert!(matches!(error, SnapshotError::RegionValidation { .. }));
+
+        let error = scalar(&ShortMemory, 0x1000, 1).unwrap_err();
+        assert!(matches!(
+            error,
+            SnapshotError::InvalidData { detail } if detail == "short u8"
+        ));
     }
 }

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -729,6 +729,10 @@ fn discover_segment_context(
         .ok_or_else(|| SnapshotError::InvalidData {
             detail: "descriptor metadata size overflow".into(),
         })?;
+    let heap_globals = *layout
+        .globals
+        .get("RtlpHpHeapGlobals")
+        .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
     let mut entry = scalar(memory, list_head, 8)? & !0xf;
     let mut seen = HashSet::new();
     while entry != 0 && entry != list_head && seen.len() < traversal_limit {
@@ -756,10 +760,6 @@ fn discover_segment_context(
         let signature = read_u64(&segment_header, signature_offset)
             .or_else(|| read_u32(&segment_header, signature_offset).map(u64::from))
             .unwrap_or(0);
-        let heap_globals = *layout
-            .globals
-            .get("RtlpHpHeapGlobals")
-            .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
         if !valid_page_segment_signature(signature, segment_address, context_address, heap_globals)
         {
             discovery.diagnostics.push(format!(
@@ -1165,7 +1165,11 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         snapshot.diagnostics.extend(discovery.diagnostics);
         for region in discovery.regions {
             check_interrupted(self.memory)?;
-            self.walk_region(&region, &mut snapshot);
+            if region.backend == PoolBackend::Large {
+                self.walk_large(&region, &mut snapshot);
+            } else {
+                self.walk_region(&region, &mut snapshot);
+            }
         }
         snapshot
             .spans
@@ -1225,12 +1229,31 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             match region.backend {
                 PoolBackend::Lfh => self.walk_lfh(region, valid_base, &bytes, snapshot),
                 PoolBackend::Vs => self.walk_vs(region, valid_base, &bytes, snapshot),
-                PoolBackend::Segment | PoolBackend::Large => {
-                    self.walk_page_ranges(region, valid_base, &bytes, snapshot)
-                }
+                PoolBackend::Segment => self.walk_page_ranges(region, valid_base, &bytes, snapshot),
+                PoolBackend::Large => return,
             }
             cursor = valid_end;
         }
+    }
+
+    fn walk_large(&self, region: &PoolRegion, snapshot: &mut PoolSnapshot) {
+        if region.size == 0 {
+            return;
+        }
+        snapshot.spans.push(
+            self.base_span(
+                region,
+                region.address,
+                region.address,
+                region.size as u64,
+                region.known_tag.unwrap_or(0),
+                region
+                    .states
+                    .first()
+                    .copied()
+                    .unwrap_or(PoolState::Allocated),
+            ),
+        );
     }
 
     fn base_span(
@@ -1940,7 +1963,8 @@ mod tests {
         fill(&mut bytes, LARGE_META, 0x28);
         put_u64(&mut bytes, LARGE_META + 0x18, LARGE_VA | 0x1800);
         put_u64(&mut bytes, LARGE_META + 0x20, (2u64 << 12) | 0x5a5);
-        fill(&mut bytes, LARGE_VA, 0x2000);
+        // Large allocations are described entirely by allocator metadata; leave
+        // their payload absent so the walker cannot accidentally read it.
         put_u64(&mut bytes, BIG_TABLE_POINTER, BIG_TABLE);
         put_u64(&mut bytes, BIG_TABLE_COUNT, 4);
         fill(&mut bytes, BIG_TABLE, 4 * 0x20);
@@ -1985,6 +2009,7 @@ mod tests {
     #[test]
     fn test_pool_snapshot_walks_all_backends() {
         let memory = synthetic_memory();
+        assert!(!memory.bytes.contains_key(&LARGE_VA));
         let layout = synthetic_layout();
         let walker = SnapshotWalker {
             memory: &memory,

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -176,6 +176,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
             traversal_limit: 1_000_000,
         }
         .walk()
+        .map_err(|error| error.to_string())
     })?;
 
     if let Some(address) = command.address {

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -1,0 +1,360 @@
+use std::ffi::{CStr, c_void};
+use std::mem::ManuallyDrop;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG, E_UNEXPECTED, S_OK};
+use windows::Win32::System::Diagnostics::Debug::Extensions::{
+    DEBUG_STATUS_BREAK, DEBUG_STATUS_NO_DEBUGGEE,
+};
+use windows::core::{HRESULT, IUnknown, Interface, PCSTR};
+
+use crate::dbgeng::DebugEngine;
+use crate::pool::decode::parse_tag;
+use crate::pool::index::SnapshotCache;
+use crate::pool::layout::{LayoutCache, SessionKey};
+use crate::pool::render::{RenderOptions, render_pool_map};
+use crate::pool::snapshot::SnapshotWalker;
+
+const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
+const DEBUG_NOTIFY_SESSION_ACTIVE: u32 = 0x0000_0000;
+const DEBUG_NOTIFY_SESSION_INACTIVE: u32 = 0x0000_0001;
+const DEBUG_NOTIFY_SESSION_ACCESSIBLE: u32 = 0x0000_0002;
+const DEBUG_NOTIFY_SESSION_INACCESSIBLE: u32 = 0x0000_0003;
+
+static SESSION_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+fn snapshots() -> &'static SnapshotCache {
+    static CACHE: OnceLock<SnapshotCache> = OnceLock::new();
+    CACHE.get_or_init(SnapshotCache::default)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PoolFilter {
+    Paged,
+    NonPaged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PoolCommand {
+    tag: Option<u32>,
+    filter: Option<PoolFilter>,
+    refresh: bool,
+    address: Option<u64>,
+}
+
+fn usage() -> &'static str {
+    "Usage: !win_kexp.poolmap -tag <1..4 ASCII bytes> [-paged|-nonpaged] [-refresh]\n       !win_kexp.poolmap <address> [-refresh]\n"
+}
+
+fn parse_address(text: &str) -> Option<u64> {
+    let compact = text.replace('`', "");
+    let digits = compact.strip_prefix("0x").unwrap_or(&compact);
+    (!digits.is_empty())
+        .then(|| u64::from_str_radix(digits, 16).ok())
+        .flatten()
+}
+
+fn parse_args(args: &str) -> Result<PoolCommand, String> {
+    let mut tag = None;
+    let mut filter = None;
+    let mut refresh = false;
+    let mut address = None;
+    let tokens: Vec<_> = args.split_ascii_whitespace().collect();
+    let mut index = 0;
+    while index < tokens.len() {
+        match tokens[index] {
+            "-tag" => {
+                index += 1;
+                let text = tokens
+                    .get(index)
+                    .ok_or_else(|| "-tag requires 1..4 ASCII bytes".to_string())?;
+                if tag.is_some() {
+                    return Err("-tag may be specified only once".into());
+                }
+                tag = Some(
+                    parse_tag(text)
+                        .ok_or_else(|| "tag must contain 1..4 ASCII bytes".to_string())?,
+                );
+            }
+            "-paged" => {
+                if filter.replace(PoolFilter::Paged).is_some() {
+                    return Err("-paged and -nonpaged are mutually exclusive".into());
+                }
+            }
+            "-nonpaged" => {
+                if filter.replace(PoolFilter::NonPaged).is_some() {
+                    return Err("-paged and -nonpaged are mutually exclusive".into());
+                }
+            }
+            "-refresh" => refresh = true,
+            value if !value.starts_with('-') && address.is_none() => {
+                address =
+                    Some(parse_address(value).ok_or_else(|| format!("invalid address `{value}`"))?);
+            }
+            value => return Err(format!("unrecognized argument `{value}`")),
+        }
+        index += 1;
+    }
+    if tag.is_none() && address.is_none() {
+        return Err("a tag or address is required".into());
+    }
+    if tag.is_some() && address.is_some() {
+        return Err("use either -tag or an address, not both".into());
+    }
+    Ok(PoolCommand {
+        tag,
+        filter,
+        refresh,
+        address,
+    })
+}
+
+fn with_engine<T>(
+    client: *mut c_void,
+    action: impl FnOnce(&DebugEngine) -> T,
+) -> Result<T, String> {
+    if client.is_null() {
+        return Err("WinDbg supplied a null debug client".into());
+    }
+    // The callback borrows this COM pointer. ManuallyDrop prevents Release on the
+    // command-supplied reference; casts performed by DebugEngine own their references.
+    let unknown = ManuallyDrop::new(unsafe { IUnknown::from_raw(client) });
+    let engine =
+        DebugEngine::try_from_windbg_client(&unknown).map_err(|error| error.to_string())?;
+    Ok(action(&engine))
+}
+
+fn args_string(args: PCSTR) -> Result<String, String> {
+    if args.is_null() {
+        return Ok(String::new());
+    }
+    Ok(unsafe { CStr::from_ptr(args.0.cast()) }
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
+    let command = parse_args(args)?;
+    if !engine
+        .is_kernel_target()
+        .map_err(|error| error.to_string())?
+    {
+        return Err("poolmap requires a kernel target".into());
+    }
+    let status = engine
+        .execution_status()
+        .map_err(|error| error.to_string())?;
+    if status == DEBUG_STATUS_NO_DEBUGGEE {
+        return Err("no accessible target is attached".into());
+    }
+    if status != DEBUG_STATUS_BREAK {
+        return Err("target is running; break in before taking a pool snapshot".into());
+    }
+    let processor = engine.processor_type().map_err(|error| error.to_string())?;
+    if processor != IMAGE_FILE_MACHINE_AMD64 {
+        return Err(format!(
+            "pool walking supports x64 targets only (machine {processor:#x})"
+        ));
+    }
+    let kernel_base = engine.kernel_base().map_err(|error| error.to_string())?;
+    let generation = SESSION_GENERATION.load(Ordering::Acquire);
+    let key = SessionKey {
+        kernel_base,
+        session: generation,
+    };
+    let layout = LayoutCache::global()
+        .get_or_resolve(engine, key)
+        .map_err(|error| error.to_string())?;
+    let index = snapshots().get_or_refresh(generation, command.refresh, || {
+        SnapshotWalker {
+            memory: engine,
+            layout: &layout,
+            traversal_limit: 1_000_000,
+        }
+        .walk()
+    })?;
+
+    if let Some(address) = command.address {
+        let detail = index
+            .spans
+            .iter()
+            .find(|span| address >= span.usable_address && address < span.end())
+            .map(|span| {
+                format!(
+                    "{address:#x}: {} {:#x}+{:#x} tag `{}` {:?} {:?}\n",
+                    if span.state == crate::pool::PoolState::Allocated {
+                        "allocation"
+                    } else {
+                        "hole"
+                    },
+                    span.usable_address,
+                    span.size,
+                    span.display_tag,
+                    span.pool_kind,
+                    span.backend
+                )
+            })
+            .unwrap_or_else(|| format!("{address:#x} is not in the cached pool snapshot\n"));
+        engine.output(&detail).map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+
+    let mut filtered = index.clone();
+    if let Some(filter) = command.filter {
+        filtered.spans.retain(|span| match filter {
+            PoolFilter::Paged => span.pool_kind.is_paged(),
+            PoolFilter::NonPaged => !span.pool_kind.is_paged(),
+        });
+        // Rebuild postings after retaining spans while keeping their local context.
+        let snapshot = crate::pool::PoolSnapshot {
+            spans: filtered.spans,
+            diagnostics: filtered.diagnostics,
+            complete: true,
+        };
+        filtered = crate::pool::PoolIndex::build(snapshot);
+    }
+    for chunk in render_pool_map(
+        &filtered,
+        RenderOptions {
+            tag: command.tag,
+            dml: true,
+        },
+    ) {
+        engine
+            .output_dml(&chunk)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn command_hresult(client: *mut c_void, args: PCSTR, help_command: bool) -> HRESULT {
+    match catch_unwind(AssertUnwindSafe(|| {
+        let args = args_string(args)?;
+        with_engine(client, |engine| {
+            let result = if help_command {
+                engine.output(usage()).map_err(|error| error.to_string())
+            } else {
+                command_poolmap(engine, &args)
+            };
+            if let Err(message) = &result {
+                let _ = engine.output(&format!("win_kexp: {message}\n{}", usage()));
+            }
+            result
+        })?
+    })) {
+        Ok(Ok(())) => S_OK,
+        Ok(Err(message)) => {
+            if message.contains("argument")
+                || message.contains("tag")
+                || message.contains("address")
+                || message.contains("mutually exclusive")
+            {
+                E_INVALIDARG
+            } else {
+                E_FAIL
+            }
+        }
+        Err(_) => E_UNEXPECTED,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn DebugExtensionInitialize(
+    version: *mut u32,
+    flags: *mut u32,
+) -> HRESULT {
+    match catch_unwind(AssertUnwindSafe(|| {
+        if version.is_null() || flags.is_null() {
+            return E_INVALIDARG;
+        }
+        // DEBUG_EXTENSION_VERSION(1, 0); initialization performs no target access.
+        unsafe {
+            version.write(1 << 16);
+            flags.write(0);
+        }
+        S_OK
+    })) {
+        Ok(result) => result,
+        Err(_) => E_UNEXPECTED,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn DebugExtensionUninitialize() {
+    let _ = catch_unwind(AssertUnwindSafe(invalidate_session));
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn DebugExtensionNotify(notify: u32, _argument: u64) {
+    let _ = catch_unwind(AssertUnwindSafe(|| match notify {
+        DEBUG_NOTIFY_SESSION_ACTIVE | DEBUG_NOTIFY_SESSION_INACTIVE => invalidate_session(),
+        DEBUG_NOTIFY_SESSION_INACCESSIBLE => snapshots().invalidate(),
+        DEBUG_NOTIFY_SESSION_ACCESSIBLE => {}
+        _ => {}
+    }));
+}
+
+fn invalidate_session() {
+    SESSION_GENERATION.fetch_add(1, Ordering::AcqRel);
+    snapshots().invalidate();
+    LayoutCache::global().invalidate();
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn poolmap(client: *mut c_void, args: PCSTR) -> HRESULT {
+    command_hresult(client, args, false)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn help(client: *mut c_void, args: PCSTR) -> HRESULT {
+    command_hresult(client, args, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pool_extension_abi_and_args() {
+        let _initialize: unsafe extern "system" fn(*mut u32, *mut u32) -> HRESULT =
+            DebugExtensionInitialize;
+        let _uninitialize: unsafe extern "system" fn() = DebugExtensionUninitialize;
+        let _notify: unsafe extern "system" fn(u32, u64) = DebugExtensionNotify;
+        let _poolmap: unsafe extern "system" fn(*mut c_void, PCSTR) -> HRESULT = poolmap;
+        let _help: unsafe extern "system" fn(*mut c_void, PCSTR) -> HRESULT = help;
+
+        let mut version = 0;
+        let mut flags = 99;
+        assert_eq!(
+            unsafe { DebugExtensionInitialize(&mut version, &mut flags) },
+            S_OK
+        );
+        assert_eq!(version, 0x0001_0000);
+        assert_eq!(flags, 0);
+        assert_eq!(
+            unsafe { DebugExtensionInitialize(std::ptr::null_mut(), &mut flags) },
+            E_INVALIDARG
+        );
+
+        let command = parse_args("-tag Pipe -nonpaged -refresh").unwrap();
+        assert_eq!(command.tag, Some(u32::from_le_bytes(*b"Pipe")));
+        assert_eq!(command.filter, Some(PoolFilter::NonPaged));
+        assert!(command.refresh);
+        assert_eq!(
+            parse_args("fffff800`12345678").unwrap().address,
+            Some(0xffff_f800_1234_5678)
+        );
+        assert!(parse_args("-tag ABCDE").is_err());
+        assert!(parse_args("-tag Test -paged -nonpaged").is_err());
+
+        let before = SESSION_GENERATION.load(Ordering::Acquire);
+        unsafe { DebugExtensionNotify(DEBUG_NOTIFY_SESSION_INACTIVE, 0) };
+        assert!(SESSION_GENERATION.load(Ordering::Acquire) > before);
+        assert_eq!(
+            unsafe { poolmap(std::ptr::null_mut(), PCSTR::null()) },
+            E_FAIL
+        );
+    }
+}

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -141,6 +141,10 @@ fn args_string(args: PCSTR) -> Result<String, String> {
         .into_owned())
 }
 
+fn span_contains_address(span: &crate::pool::PoolSpan, address: u64) -> bool {
+    address >= span.header_address && address < span.end()
+}
+
 fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
     let command = parse_args(args)?;
     if !engine
@@ -183,7 +187,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
         let detail = index
             .spans
             .iter()
-            .find(|span| address >= span.usable_address && address < span.end())
+            .find(|span| span_contains_address(span, address))
             .map(|span| {
                 format!(
                     "{address:#x}: {} {:#x}+{:#x} tag `{}` {:?} {:?}\n",
@@ -356,6 +360,26 @@ mod tests {
             validate_pool_target(0xaa64),
             Err("pool walking supports x64 targets only (machine 0xaa64)".into())
         );
+
+        let mut span = crate::pool::PoolSpan::allocation(
+            0x1010,
+            0x20,
+            0,
+            crate::pool::PoolKind::Paged,
+            crate::pool::HeapIdentity {
+                pool_state: 1,
+                heap: 2,
+                special: false,
+            },
+            crate::pool::PoolBackend::Vs,
+        );
+        span.header_address = 0x1000;
+        assert!(span_contains_address(&span, 0x1000));
+        assert!(span_contains_address(&span, 0x100f));
+        assert!(span_contains_address(&span, 0x1010));
+        assert!(span_contains_address(&span, 0x102f));
+        assert!(!span_contains_address(&span, 0x0fff));
+        assert!(!span_contains_address(&span, 0x1030));
 
         let before = SESSION_GENERATION.load(Ordering::Acquire);
         unsafe { DebugExtensionNotify(DEBUG_NOTIFY_SESSION_INACTIVE, 0) };

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -141,10 +141,6 @@ fn args_string(args: PCSTR) -> Result<String, String> {
         .into_owned())
 }
 
-fn span_contains_address(span: &crate::pool::PoolSpan, address: u64) -> bool {
-    address >= span.header_address && address < span.end()
-}
-
 fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
     let command = parse_args(args)?;
     if !engine
@@ -187,7 +183,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
         let detail = index
             .spans
             .iter()
-            .find(|span| span_contains_address(span, address))
+            .find(|span| span.contains_address(address))
             .map(|span| {
                 format!(
                     "{address:#x}: {} {:#x}+{:#x} tag `{}` {:?} {:?}\n",
@@ -374,12 +370,12 @@ mod tests {
             crate::pool::PoolBackend::Vs,
         );
         span.header_address = 0x1000;
-        assert!(span_contains_address(&span, 0x1000));
-        assert!(span_contains_address(&span, 0x100f));
-        assert!(span_contains_address(&span, 0x1010));
-        assert!(span_contains_address(&span, 0x102f));
-        assert!(!span_contains_address(&span, 0x0fff));
-        assert!(!span_contains_address(&span, 0x1030));
+        assert!(span.contains_address(0x1000));
+        assert!(span.contains_address(0x100f));
+        assert!(span.contains_address(0x1010));
+        assert!(span.contains_address(0x102f));
+        assert!(!span.contains_address(0x0fff));
+        assert!(!span.contains_address(0x1030));
 
         let before = SESSION_GENERATION.load(Ordering::Acquire);
         unsafe { DebugExtensionNotify(DEBUG_NOTIFY_SESSION_INACTIVE, 0) };

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -56,6 +56,12 @@ fn parse_address(text: &str) -> Option<u64> {
         .flatten()
 }
 
+fn validate_pool_target(processor: u32) -> Result<(), String> {
+    (processor == IMAGE_FILE_MACHINE_AMD64)
+        .then_some(())
+        .ok_or_else(|| format!("pool walking supports x64 targets only (machine {processor:#x})"))
+}
+
 fn parse_args(args: &str) -> Result<PoolCommand, String> {
     let mut tag = None;
     let mut filter = None;
@@ -153,11 +159,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
         return Err("target is running; break in before taking a pool snapshot".into());
     }
     let processor = engine.processor_type().map_err(|error| error.to_string())?;
-    if processor != IMAGE_FILE_MACHINE_AMD64 {
-        return Err(format!(
-            "pool walking supports x64 targets only (machine {processor:#x})"
-        ));
-    }
+    validate_pool_target(processor)?;
     let kernel_base = engine.kernel_base().map_err(|error| error.to_string())?;
     let generation = SESSION_GENERATION.load(Ordering::Acquire);
     let key = SessionKey {
@@ -348,6 +350,11 @@ mod tests {
         );
         assert!(parse_args("-tag ABCDE").is_err());
         assert!(parse_args("-tag Test -paged -nonpaged").is_err());
+        assert_eq!(validate_pool_target(IMAGE_FILE_MACHINE_AMD64), Ok(()));
+        assert_eq!(
+            validate_pool_target(0xaa64),
+            Err("pool walking supports x64 targets only (machine 0xaa64)".into())
+        );
 
         let before = SESSION_GENERATION.load(Ordering::Acquire);
         unsafe { DebugExtensionNotify(DEBUG_NOTIFY_SESSION_INACTIVE, 0) };


### PR DESCRIPTION
## Summary

- add a loadable WinDbg extension with `!win_kexp.poolmap` and address-detail commands
- enumerate x64 paged, nonpaged, special, LFH, VS, segment, and large pool allocations from stopped-target snapshots
- resolve allocator globals, type sizes, and field offsets dynamically through kernel symbols
- index exact pool tags and spatial rows for fast heatmap and hole queries
- render DML and plain-text maps with allocator-aware geometry guidance
- document extension build, loading, usage, caching, and support boundaries

## Why

Pool investigation previously exposed only user-mode anonymous-pipe helpers. It had no stopped-target allocator walker or spatial view for examining reusable and cached holes around a selected kernel pool tag. This adds that workflow while keeping layouts version-flexible and treating corrupt or unreadable target metadata conservatively.

## Implementation notes

- LFH offsets, VS sizes, encoded RB-tree roots, packed large-allocation metadata, and big-page hashing are decoded with bounds and plausibility checks.
- Complete snapshots are cached by debugger session and invalidated on execution or session transitions.
- Pool walking is intentionally x64-only; existing ARM64 functionality remains buildable.
- Per-session paged heaps remain outside the initial scope and are reported diagnostically.

## Validation

- `cargo fmt --all -- --check`
- `cargo test` (12 passed)
- `cargo clippy --all-targets --all-features` (passes with one pre-existing `collapsible_if` warning in `src/process.rs`)
- `cargo build --lib --verbose`
- verified DLL exports: `DebugExtensionInitialize`, `DebugExtensionNotify`, `DebugExtensionUninitialize`, `help`, and `poolmap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WinDbg “pool map” extension (`!win_kexp.poolmap`) to inspect kernel pool allocations by 4-byte tag (1–4 byte ASCII forms) or by address, including `-paged`/`-nonpaged` filtering and `-refresh`.
  * Added heatmap-style rendering with optional DML output plus an “advice” section with nearby geometry and ranked hole details.

* **Documentation**
  * Expanded README with x64-only native build/load steps, command examples, tag encoding, and snapshot/caching semantics.

* **Bug Fixes**
  * Improved robustness and diagnostics for interrupted operations, partial/oversized reads, malformed output, and NUL-safe rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->