### PR TITLE
ci: post code-review findings as PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # write is required so /code-review --comment can publish inline PR feedback
       pull-requests: write
       issues: read
       id-token: write


### PR DESCRIPTION
## What

Addresses the Codex review comment on #66: the scheduled Claude review invoked `/code-review` without the `--comment` flag, so it completed the review inside the Actions run but left no feedback on the pull request.

## Changes

- Add `--comment` to the `/code-review` prompt in `.github/workflows/claude-code-review.yml` so findings are posted as inline PR comments where reviewers will see them.
- Bump the `pull-requests` permission from `read` to `write` so the action actually has permission to post those comments (without this, `--comment` would fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automated code reviews to create or update comments on pull requests.
  * Updated review requests to explicitly publish feedback as comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->