### PR TITLE
feat(dbgeng): add execute_command_bounded to interrupt runaway commands

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -674,9 +674,16 @@ impl DebugEngine {
             let _ = self.client.SetOutputCallbacks(None);
         }
 
+        let interrupted = fired.load(Ordering::SeqCst);
+        if interrupted {
+            // The watchdog may have raised `SetInterrupt` right as `Execute` finished (or fired
+            // once more before we joined it), leaving a Ctrl+Break *pending* that would abort the
+            // next command on its first interrupt poll. Drain it now via `GetInterrupt` so
+            // subsequent calls stay usable — the whole point of a bounded command.
+            let _ = self.interrupted();
+        }
         // A watchdog-forced interrupt makes `Execute` fail (or return partial output); that is
         // expected, so only propagate a genuine (non-interrupted) error.
-        let interrupted = fired.load(Ordering::SeqCst);
         if !interrupted {
             result.map_err(DbgEngError::CommandFailed)?;
         }

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -604,6 +604,96 @@ impl DebugEngine {
         Ok(String::from_utf8_lossy(&output_buffer).to_string())
     }
 
+    /// Like [`Self::execute_command`], but **bounded**: a watchdog thread `SetInterrupt`s the
+    /// engine after `timeout_ms` so a runaway command — most importantly a broad `s` memory
+    /// search — aborts and frees the single engine thread instead of pinning it (every later
+    /// call would otherwise block behind it). `SetInterrupt` is the one DbgEng call documented
+    /// as safe from another thread (see [`InterruptHandle`]); a long command polls for it
+    /// exactly as WinDbg's Ctrl+Break does.
+    ///
+    /// Returns whatever output was captured up to the interrupt; when the watchdog fires it
+    /// appends a short note and does **not** surface the resulting `Execute` error (the abort
+    /// is expected). `timeout_ms == 0` disables the watchdog (equivalent to `execute_command`).
+    pub fn execute_command_bounded(
+        &self,
+        command: &str,
+        timeout_ms: u32,
+    ) -> Result<String, DbgEngError> {
+        let cmd_c = CString::new(command).map_err(|_| DbgEngError::InvalidCommand)?;
+        let cmd = PCSTR::from_raw(cmd_c.as_ptr() as *const u8);
+
+        let mut output_buffer = Vec::<u8>::with_capacity(4096);
+        let output_callbacks = OutputCallbacks::new(&mut output_buffer);
+        let output_interface: IDebugOutputCallbacks = output_callbacks.into();
+        unsafe {
+            self.client
+                .SetOutputCallbacks(Some(&output_interface))
+                .map_err(DbgEngError::CommandFailed)?;
+        }
+
+        // Arm a watchdog that Ctrl+Breaks the engine after `timeout_ms` so a long `Execute`
+        // returns instead of hanging the engine thread. Mirrors `wait_for_event_bounded`.
+        let done = Arc::new(AtomicBool::new(false));
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = (timeout_ms > 0).then(|| {
+            let done_watch = Arc::clone(&done);
+            let fired_watch = Arc::clone(&fired);
+            let handle = InterruptHandle(self.control.as_raw());
+            let deadline = Duration::from_millis(timeout_ms as u64);
+            thread::spawn(move || {
+                let handle = handle; // move the whole (Send) handle, not just the raw field
+                let start = Instant::now();
+                loop {
+                    if done_watch.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    if start.elapsed() >= deadline
+                        && let Some(ctl) = unsafe { IDebugControl4::from_raw_borrowed(&handle.0) }
+                    {
+                        // Repeat in case a busy command swallows one interrupt.
+                        let _ = unsafe { ctl.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) };
+                        fired_watch.store(true, Ordering::SeqCst);
+                    }
+                    thread::sleep(Duration::from_millis(200));
+                }
+            })
+        });
+
+        let result = unsafe {
+            self.control
+                .Execute(DEBUG_OUTCTL_THIS_CLIENT, cmd, DEBUG_EXECUTE_ECHO)
+        };
+
+        done.store(true, Ordering::SeqCst);
+        if let Some(w) = watchdog {
+            let _ = w.join();
+        }
+
+        // Always detach the callbacks before `output_interface`/`output_buffer` drop.
+        unsafe {
+            let _ = self.client.SetOutputCallbacks(None);
+        }
+
+        // A watchdog-forced interrupt makes `Execute` fail (or return partial output); that is
+        // expected, so only propagate a genuine (non-interrupted) error.
+        let interrupted = fired.load(Ordering::SeqCst);
+        if !interrupted {
+            result.map_err(DbgEngError::CommandFailed)?;
+        }
+
+        let mut out = String::from_utf8_lossy(&output_buffer).to_string();
+        if interrupted {
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str(&format!(
+                "[win-kexp] command interrupted after {timeout_ms} ms (Ctrl+Break) — it was \
+                 taking too long. Scope it (e.g. a bounded memory range) and retry."
+            ));
+        }
+        Ok(out)
+    }
+
     /// Waits for the target to break
     pub fn wait_for_event(&self, timeout_ms: u32) -> Result<(), DbgEngError> {
         let result = unsafe { self.control.WaitForEvent(0, timeout_ms) };


### PR DESCRIPTION
## What

`execute_command` runs `IDebugControl::Execute` synchronously with no interrupt, so a command that doesn't return on its own — most importantly a broad `s` memory search — **pins the single engine thread indefinitely**, and every subsequent call blocks behind it. (Downstream, `windbg-mcp` hit exactly this: an unbounded `s` scan wedged the engine, and the only recovery was to kill and reconnect the server.)

## Change

Adds **`execute_command_bounded(command, timeout_ms)`**, which arms the same `InterruptHandle` / `SetInterrupt` watchdog already used by `wait_for_event_bounded`: after `timeout_ms` a watchdog thread Ctrl+Breaks the engine so a long `Execute` returns instead of hanging the thread (a long command polls for the interrupt exactly as WinDbg's Ctrl+Break does). It returns whatever output was captured up to the interrupt, appends a short note, and does not surface the expected abort error. `timeout_ms == 0` disables the watchdog (equivalent to `execute_command`).

Non-breaking — `execute_command` is untouched; callers opt in.

## Testing

- `cargo fmt --all --check`, `cargo build`, `cargo test` clean (25 tests).
- `cargo clippy` is clean for this change; the single `collapsible_if` warning is pre-existing in `src/process.rs` (unrelated, surfaced only by newer clippy).
- Runtime behavior mirrors the proven `wait_for_event_bounded` watchdog; a live-engine interrupt test needs a real target and isn't part of the unit suite.

## Follow-up

`windbg-mcp` will adopt this: pin bump + route the raw `execute` / `dx` command paths through `execute_command_bounded` with a timeout just under its own per-call timeout, so a runaway search self-aborts instead of wedging the session (companion to glslang/windbg-mcp#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
