### PR TITLE
test(dbgeng): measure the interrupt-drain assumption behind #69

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1430,18 +1430,27 @@ mod tests {
     ///
     /// Ignored: needs a live target, which CI has no way to provide. See the note above these
     /// tests on why they must not run in parallel.
-    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 get_interrupt`
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 test_get_interrupt`
     #[cfg(not(miri))]
     #[test]
     #[ignore = "needs a live debuggee; run manually with --ignored"]
-    fn get_interrupt_drain_semantics() {
+    fn test_get_interrupt_drain_semantics() {
         let e = DebugEngine::new();
         e.launch_process("cmd.exe /c exit").expect("launch failed");
+
+        // Asserted, not just printed: this test is the record the production drain rests on,
+        // so an engine that stopped clearing — or started counting — has to fail here rather
+        // than quietly print a different vector on a manual run.
+        const DRAINS_ON_FIRST_POLL: [bool; 5] = [true, false, false, false, false];
 
         // One request in.
         unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
         let polls: Vec<bool> = (0..5).map(|_| e.interrupted().unwrap()).collect();
         println!("after 1x SetInterrupt, five GetInterrupt polls: {polls:?}");
+        assert_eq!(
+            polls, DRAINS_ON_FIRST_POLL,
+            "GetInterrupt no longer clears the pending request on this engine"
+        );
 
         // Several requests in, since the watchdog re-fires every 200ms while past its
         // deadline: does one poll clear them all, or one each?
@@ -1450,22 +1459,30 @@ mod tests {
         }
         let polls: Vec<bool> = (0..5).map(|_| e.interrupted().unwrap()).collect();
         println!("after 3x SetInterrupt, five GetInterrupt polls: {polls:?}");
+        assert_eq!(
+            polls, DRAINS_ON_FIRST_POLL,
+            "repeated SetInterrupt now accumulates; one drain no longer suffices"
+        );
 
         let _ = e.end_session();
     }
 
     /// Forces the exact race the drain targets, which ordinary timing almost never hits: a
     /// `SetInterrupt` landing *after* `Execute` has returned, leaving a Ctrl+Break pending
-    /// with no command running. Measures both halves of the assumption — that a pending
-    /// interrupt really does abort the next command, and that draining it really does
-    /// prevent that.
+    /// with no command running.
+    ///
+    /// Named for what it measures, not for a result: on the engine tested a stale interrupt
+    /// does **not** abort the next command, short or long, so only the drained case is
+    /// asserted. The undrained case prints its observation rather than asserting one, because
+    /// pinning it down would encode "stale interrupts are harmless" as a requirement — the
+    /// opposite of what this test exists to keep watching.
     ///
     /// Ignored: needs a live target; see the note above these tests.
-    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 pending_interrupt`
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 test_stale_interrupt`
     #[cfg(not(miri))]
     #[test]
     #[ignore = "needs a live debuggee; run manually with --ignored"]
-    fn a_pending_interrupt_aborts_the_next_command_unless_drained() {
+    fn test_stale_interrupt_effect_on_the_next_command() {
         let e = DebugEngine::new();
         e.launch_process("cmd.exe /c exit").expect("launch failed");
 
@@ -1546,28 +1563,42 @@ mod tests {
     /// aborted by a Ctrl+Break left pending behind it.
     ///
     /// Ignored: needs a live target; see the note above these tests.
-    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 next_command`
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 test_next_command`
     #[cfg(not(miri))]
     #[test]
     #[ignore = "needs a live debuggee; run manually with --ignored"]
-    fn next_command_survives_a_bounded_timeout() {
+    fn test_next_command_survives_a_bounded_timeout() {
         let e = DebugEngine::new();
         e.launch_process("cmd.exe /c exit").expect("launch failed");
 
         // A deliberately runaway command. Note a broad `s` search does *not* work here: it
         // skips unmapped ranges, so even `L?0x7fffffffff` returns almost immediately. A tight
         // `.for` in the expression evaluator is genuinely CPU-bound and interruptible.
+        //
+        // At ~4.7s per 0x40000 iterations (measured), 0x1000000 runs for minutes untouched.
+        const TIMEOUT_MS: u32 = 1_500;
+        let started = Instant::now();
         let out = e
             .execute_command_bounded(
                 ".for (r $t0 = 0; @$t0 < 0x1000000; r $t0 = @$t0 + 1) { }",
-                1_500,
+                TIMEOUT_MS,
             )
             .expect("bounded command should return, not error");
-        let cut_short = out.contains("interrupted after");
-        println!("bounded command cut short by watchdog: {cut_short}");
+        let elapsed = started.elapsed();
+        println!("bounded command returned after {elapsed:?}");
+
+        // Proof of interruption has to be the clock, not the diagnostic note: that note is
+        // appended whenever the watchdog *attempted* `SetInterrupt`, so a `SetInterrupt` the
+        // engine ignored would still produce it, and this test would then pass while
+        // exercising nothing. Minutes of work returning in seconds cannot be anything else.
         assert!(
-            cut_short,
-            "search finished early — pick a longer-running probe"
+            elapsed < Duration::from_secs(30),
+            "command ran {elapsed:?} — the watchdog did not cut it short, so the rest of this \
+             test would prove nothing"
+        );
+        assert!(
+            out.contains("interrupted after"),
+            "no interruption note despite an early return"
         );
 
         // The command under test. If a stale interrupt survived, this aborts instead.

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1414,6 +1414,24 @@ mod tests {
         // DebugEngine's Drop impl will handle cleanup and detach
     }
 
+    /// Reads a debugger pseudo-register (`$t0`, …) as a number, via `? <expr>` — whose output
+    /// is `Evaluate expression: <decimal> = <hex>`. Used to observe how far an interrupted
+    /// command actually got, which is engine state rather than a timing inference.
+    #[cfg(not(miri))]
+    fn read_pseudo_register(e: &DebugEngine, expr: &str) -> u64 {
+        let out = e
+            .execute_command(&format!("? @{expr}"))
+            .unwrap_or_else(|err| panic!("evaluating {expr} failed: {err}"));
+        let tail = out
+            .split("Evaluate expression: ")
+            .nth(1)
+            .unwrap_or_else(|| panic!("unexpected `?` output for {expr}: {out:?}"));
+        let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
+        digits
+            .parse()
+            .unwrap_or_else(|_| panic!("no value in `?` output for {expr}: {out:?}"))
+    }
+
     // The `#[ignore]`d tests below each drive a real debuggee, and MUST be run with
     // `--test-threads=1`. dbgeng.dll holds one debuggee session per *process*, so two of them
     // running concurrently in the same test binary fight over the same session and fail in
@@ -1503,8 +1521,19 @@ mod tests {
         }
 
         // Drained: stage the same race, consume it, then run the same command.
+        //
+        // The drain's return value is asserted, not discarded. `Execute` resets the request
+        // itself, so if the staged interrupt never registered — or `GetInterrupt` errored —
+        // the `version` below would still succeed and this case would pass while draining
+        // nothing. The assertion is what makes it the *drained* case rather than a second
+        // undrained one, and it has to stand on its own here: this test is documented as
+        // runnable by name, without `test_get_interrupt_drain_semantics` to catch it first.
         unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
-        let _ = e.interrupted();
+        assert!(
+            e.interrupted().expect("GetInterrupt failed"),
+            "staged interrupt was not pending — nothing was drained, so the case below is not \
+             the drained one it claims to be"
+        );
         let drained = e.execute_command("version");
         match &drained {
             Ok(out) => println!(
@@ -1573,32 +1602,36 @@ mod tests {
 
         // A deliberately runaway command. Note a broad `s` search does *not* work here: it
         // skips unmapped ranges, so even `L?0x7fffffffff` returns almost immediately. A tight
-        // `.for` in the expression evaluator is genuinely CPU-bound and interruptible.
-        //
-        // At ~4.7s per 0x40000 iterations (measured), 0x1000000 runs for minutes untouched.
+        // `.for` in the expression evaluator is genuinely CPU-bound and interruptible, and it
+        // leaves its progress behind in `$t0` — which is what proves the interruption below.
+        const ITERATIONS: u64 = 0x100_0000;
         const TIMEOUT_MS: u32 = 1_500;
         let started = Instant::now();
         let out = e
             .execute_command_bounded(
-                ".for (r $t0 = 0; @$t0 < 0x1000000; r $t0 = @$t0 + 1) { }",
+                &format!(".for (r $t0 = 0; @$t0 < 0x{ITERATIONS:x}; r $t0 = @$t0 + 1) {{ }}"),
                 TIMEOUT_MS,
             )
             .expect("bounded command should return, not error");
         let elapsed = started.elapsed();
-        println!("bounded command returned after {elapsed:?}");
 
-        // Proof of interruption has to be the clock, not the diagnostic note: that note is
-        // appended whenever the watchdog *attempted* `SetInterrupt`, so a `SetInterrupt` the
-        // engine ignored would still produce it, and this test would then pass while
-        // exercising nothing. Minutes of work returning in seconds cannot be anything else.
+        // Proof of interruption is the loop counter, not the clock and not the diagnostic
+        // note. The note is appended whenever the watchdog *attempted* `SetInterrupt`, so an
+        // interrupt the engine ignored still produces it. A wall-clock bound is no better: it
+        // has to be picked for this host, and on a faster machine or a cheaper `.for` the loop
+        // could finish naturally inside the bound, passing both checks while the watchdog did
+        // nothing. `$t0` is host-independent — short of `ITERATIONS`, the loop did not finish.
+        let t0 = read_pseudo_register(&e, "$t0");
+        println!("bounded command returned after {elapsed:?}, $t0 = {t0} of {ITERATIONS}");
+        assert!(t0 > 0, "loop never started; $t0 = {t0}");
         assert!(
-            elapsed < Duration::from_secs(30),
-            "command ran {elapsed:?} — the watchdog did not cut it short, so the rest of this \
-             test would prove nothing"
+            t0 < ITERATIONS,
+            "loop ran to completion ($t0 = {t0}) — the watchdog did not cut it short, so the \
+             rest of this test would prove nothing"
         );
         assert!(
             out.contains("interrupted after"),
-            "no interruption note despite an early return"
+            "no interruption note despite a loop that stopped short"
         );
 
         // The command under test. If a stale interrupt survived, this aborts instead.

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1576,27 +1576,42 @@ mod tests {
         const LONG_ITERS: u64 = 0x4_0000;
         let long = format!(".for (r $t0 = 0; @$t0 < 0x{LONG_ITERS:x}; r $t0 = @$t0 + 1) {{ }}");
 
+        // Seed `$t0` with a value the loop cannot produce before *each* run. The loop's own
+        // `r $t0 = 0` initializer is part of the command, so an abort landing before it leaves
+        // `$t0` holding `LONG_ITERS` from the previous run — which would read as "completed"
+        // and report the immediate abort, the very case this probe exists to catch, as "did
+        // NOT abort". Seeding makes "never started" its own observable value.
+        const UNSTARTED: u64 = 0xDEAD_BEEF;
+        let seed = format!("r $t0 = 0x{UNSTARTED:x}");
+
+        e.execute_command(&seed).expect("seeding $t0 failed");
         let clean_start = Instant::now();
         e.execute_command(&long).expect("long command failed");
         let clean = clean_start.elapsed();
         let clean_t0 = read_pseudo_register(&e, "$t0");
+        assert_eq!(
+            clean_t0, LONG_ITERS,
+            "the uninterrupted run did not complete — the probe is broken, not the engine"
+        );
 
+        e.execute_command(&seed).expect("seeding $t0 failed");
         unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
         let stale_start = Instant::now();
         let stale = e.execute_command(&long);
         let stale_elapsed = stale_start.elapsed();
-        let stale_t0 = read_pseudo_register(&e, "$t0");
+        let stale_t0 = read_pseudo_register_opt(&e, "$t0");
         let stale_result = if stale.is_ok() { "Ok" } else { "Err" };
         println!("long command, clean:           {clean:?} (t0={clean_t0} of {LONG_ITERS})");
         println!(
-            "long command, stale interrupt: {stale_elapsed:?} (t0={stale_t0} of {LONG_ITERS}, {stale_result})"
+            "long command, stale interrupt: {stale_elapsed:?} (t0={stale_t0:?} of {LONG_ITERS}, {stale_result})"
         );
         println!(
             "  -> stale interrupt {} the long command",
-            if stale_t0 < LONG_ITERS {
-                "ABORTED"
-            } else {
-                "did NOT abort"
+            match stale_t0 {
+                None => "gave no readable $t0 after",
+                Some(UNSTARTED) => "ABORTED, before the loop even started,",
+                Some(t0) if t0 < LONG_ITERS => "ABORTED mid-loop",
+                _ => "did NOT abort",
             }
         );
         let _ = e.interrupted();

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -729,9 +729,24 @@ impl DebugEngine {
         let interrupted = fired.load(Ordering::SeqCst);
         if interrupted {
             // The watchdog may have raised `SetInterrupt` right as `Execute` finished (or fired
-            // once more before we joined it), leaving a Ctrl+Break *pending* that would abort the
-            // next command on its first interrupt poll. Drain it now via `GetInterrupt` so
-            // subsequent calls stay usable — the whole point of a bounded command.
+            // once more before we joined it), leaving a Ctrl+Break pending with no command
+            // running. Consume it via `GetInterrupt`, which does clear the pending flag.
+            //
+            // Retained as insurance, not as a fix for an observed bug. Measured against dbgeng
+            // 10.0.26100.1 on a user-mode target (see the `#[ignore]`d tests below, which are
+            // the record): `GetInterrupt` clears the flag, and the flag is a flag rather than a
+            // counter — three `SetInterrupt`s still take one poll to clear. But a pending
+            // interrupt did *not* abort a following command in any case tried, short or long:
+            // a `version` produced byte-identical output drained and undrained, and a 38s
+            // interrupt-polling `.for` ran to completion either way (37.94s vs 37.91s). The
+            // engine appears to reset the request when `Execute` begins a command, which is
+            // also how WinDbg behaves — a Ctrl+Break pressed while idle does not kill the next
+            // command you type.
+            //
+            // So this is a no-op on the engine it was measured against. It costs one call on an
+            // already-exceptional path, the behaviour is undocumented by Microsoft and may vary
+            // by engine version, and the live-kernel path was not measured — which is why it
+            // stays rather than being deleted on the strength of one environment.
             let _ = self.interrupted();
         }
         // A watchdog-forced interrupt makes `Execute` fail (or return partial output); that is
@@ -1397,6 +1412,173 @@ mod tests {
         println!("Debug engine created successfully");
 
         // DebugEngine's Drop impl will handle cleanup and detach
+    }
+
+    // The `#[ignore]`d tests below each drive a real debuggee, and MUST be run with
+    // `--test-threads=1`. dbgeng.dll holds one debuggee session per *process*, so two of them
+    // running concurrently in the same test binary fight over the same session and fail in
+    // ways that look like engine bugs. Individually they pass under the default harness; as a
+    // group they do not.
+    //
+    // They are ignored rather than gated on an env var because CI has no target to give them
+    // on any platform, so there is no configuration in which they would run there.
+
+    /// Probes whether `GetInterrupt` *consumes* a pending `SetInterrupt`, which
+    /// [`DebugEngine::execute_command_bounded`]'s stale-interrupt drain assumes. DbgEng
+    /// documents `GetInterrupt` as a check (S_OK requested / S_FALSE not); whether it also
+    /// clears is not documented, so it is measured rather than assumed.
+    ///
+    /// Ignored: needs a live target, which CI has no way to provide. See the note above these
+    /// tests on why they must not run in parallel.
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 get_interrupt`
+    #[cfg(not(miri))]
+    #[test]
+    #[ignore = "needs a live debuggee; run manually with --ignored"]
+    fn get_interrupt_drain_semantics() {
+        let e = DebugEngine::new();
+        e.launch_process("cmd.exe /c exit").expect("launch failed");
+
+        // One request in.
+        unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
+        let polls: Vec<bool> = (0..5).map(|_| e.interrupted().unwrap()).collect();
+        println!("after 1x SetInterrupt, five GetInterrupt polls: {polls:?}");
+
+        // Several requests in, since the watchdog re-fires every 200ms while past its
+        // deadline: does one poll clear them all, or one each?
+        for _ in 0..3 {
+            unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
+        }
+        let polls: Vec<bool> = (0..5).map(|_| e.interrupted().unwrap()).collect();
+        println!("after 3x SetInterrupt, five GetInterrupt polls: {polls:?}");
+
+        let _ = e.end_session();
+    }
+
+    /// Forces the exact race the drain targets, which ordinary timing almost never hits: a
+    /// `SetInterrupt` landing *after* `Execute` has returned, leaving a Ctrl+Break pending
+    /// with no command running. Measures both halves of the assumption — that a pending
+    /// interrupt really does abort the next command, and that draining it really does
+    /// prevent that.
+    ///
+    /// Ignored: needs a live target; see the note above these tests.
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 pending_interrupt`
+    #[cfg(not(miri))]
+    #[test]
+    #[ignore = "needs a live debuggee; run manually with --ignored"]
+    fn a_pending_interrupt_aborts_the_next_command_unless_drained() {
+        let e = DebugEngine::new();
+        e.launch_process("cmd.exe /c exit").expect("launch failed");
+
+        // Baseline: what a healthy `version` looks like.
+        let baseline = e.execute_command("version").expect("baseline failed");
+        assert!(baseline.to_lowercase().contains("version"));
+
+        // Undrained: stage the race, then run a command.
+        unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
+        let undrained = e.execute_command("version");
+        match &undrained {
+            Ok(out) => println!(
+                "undrained next command: Ok, {} bytes, looks normal: {}",
+                out.len(),
+                out.to_lowercase().contains("version")
+            ),
+            Err(err) => println!("undrained next command: Err({err})"),
+        }
+
+        // Drained: stage the same race, consume it, then run the same command.
+        unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
+        let _ = e.interrupted();
+        let drained = e.execute_command("version");
+        match &drained {
+            Ok(out) => println!(
+                "drained   next command: Ok, {} bytes, looks normal: {}",
+                out.len(),
+                out.to_lowercase().contains("version")
+            ),
+            Err(err) => println!("drained   next command: Err({err})"),
+        }
+
+        // A short command like `version` may simply never poll for the interrupt. The case
+        // that matters is a *long* next command, which does — if a stale Ctrl+Break aborts
+        // that, the drain is load-bearing; if not, it is a no-op.
+        let long = ".for (r $t0 = 0; @$t0 < 0x40000; r $t0 = @$t0 + 1) { }";
+        let clean_start = Instant::now();
+        let _ = e.execute_command(long).expect("long command failed");
+        let clean = clean_start.elapsed();
+
+        unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
+        let stale_start = Instant::now();
+        let stale = e.execute_command(long);
+        let stale_elapsed = stale_start.elapsed();
+        println!(
+            "long command: clean {:?}, with a stale interrupt pending {:?} ({})",
+            clean,
+            stale_elapsed,
+            match &stale {
+                Ok(_) => "Ok",
+                Err(_) => "Err",
+            }
+        );
+        println!(
+            "  -> stale interrupt {} the long command",
+            if stale_elapsed < clean / 2 {
+                "ABORTED"
+            } else {
+                "did NOT abort"
+            }
+        );
+        let _ = e.interrupted();
+
+        // Only the drained case is asserted; the undrained one is the measurement.
+        assert!(
+            drained
+                .expect("drained command errored")
+                .to_lowercase()
+                .contains("version"),
+            "draining should leave the next command fully usable"
+        );
+
+        let _ = e.end_session();
+    }
+
+    /// The behaviour the drain exists to protect, end to end: after a bounded command is
+    /// cut short by its watchdog, the *next* command must run normally rather than being
+    /// aborted by a Ctrl+Break left pending behind it.
+    ///
+    /// Ignored: needs a live target; see the note above these tests.
+    /// `cargo test --lib -- --ignored --nocapture --test-threads=1 next_command`
+    #[cfg(not(miri))]
+    #[test]
+    #[ignore = "needs a live debuggee; run manually with --ignored"]
+    fn next_command_survives_a_bounded_timeout() {
+        let e = DebugEngine::new();
+        e.launch_process("cmd.exe /c exit").expect("launch failed");
+
+        // A deliberately runaway command. Note a broad `s` search does *not* work here: it
+        // skips unmapped ranges, so even `L?0x7fffffffff` returns almost immediately. A tight
+        // `.for` in the expression evaluator is genuinely CPU-bound and interruptible.
+        let out = e
+            .execute_command_bounded(
+                ".for (r $t0 = 0; @$t0 < 0x1000000; r $t0 = @$t0 + 1) { }",
+                1_500,
+            )
+            .expect("bounded command should return, not error");
+        let cut_short = out.contains("interrupted after");
+        println!("bounded command cut short by watchdog: {cut_short}");
+        assert!(
+            cut_short,
+            "search finished early — pick a longer-running probe"
+        );
+
+        // The command under test. If a stale interrupt survived, this aborts instead.
+        let after = e.execute_command("version").expect("next command errored");
+        println!("--- next command output ---\n{after}\n---");
+        assert!(
+            after.to_lowercase().contains("version"),
+            "next command produced no real output — stale interrupt aborted it"
+        );
+
+        let _ = e.end_session();
     }
 }
 

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1415,21 +1415,27 @@ mod tests {
     }
 
     /// Reads a debugger pseudo-register (`$t0`, …) as a number, via `? <expr>` — whose output
-    /// is `Evaluate expression: <decimal> = <hex>`. Used to observe how far an interrupted
-    /// command actually got, which is engine state rather than a timing inference.
+    /// is `Evaluate expression: <decimal> = <hex>`. `None` when no value came back.
+    ///
+    /// Fallible rather than panicking, because a read that fails is one of the outcomes these
+    /// tests are here to observe: on an engine where a stale interrupt aborts the next
+    /// command, this read can *be* that next command. Panicking would crash out of the
+    /// measurement instead of recording it.
+    #[cfg(not(miri))]
+    fn read_pseudo_register_opt(e: &DebugEngine, expr: &str) -> Option<u64> {
+        let out = e.execute_command(&format!("? @{expr}")).ok()?;
+        let tail = out.split("Evaluate expression: ").nth(1)?;
+        let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
+        digits.parse().ok()
+    }
+
+    /// [`read_pseudo_register_opt`] for call sites where a failed read means the test's own
+    /// setup is broken rather than an observation — reading `$t0` after a command that is
+    /// asserted to have run, for instance.
     #[cfg(not(miri))]
     fn read_pseudo_register(e: &DebugEngine, expr: &str) -> u64 {
-        let out = e
-            .execute_command(&format!("? @{expr}"))
-            .unwrap_or_else(|err| panic!("evaluating {expr} failed: {err}"));
-        let tail = out
-            .split("Evaluate expression: ")
-            .nth(1)
-            .unwrap_or_else(|| panic!("unexpected `?` output for {expr}: {out:?}"));
-        let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
-        digits
-            .parse()
-            .unwrap_or_else(|_| panic!("no value in `?` output for {expr}: {out:?}"))
+        read_pseudo_register_opt(e, expr)
+            .unwrap_or_else(|| panic!("could not read {expr} from the engine"))
     }
 
     /// Runs a command and reports whether it actually *took effect*, by having it stamp a
@@ -1441,19 +1447,26 @@ mod tests {
     /// `output.contains("version")` therefore matches the echo alone and passes even when the
     /// command was aborted immediately after being echoed, which is precisely the failure
     /// these tests exist to catch.
+    ///
+    /// Every step is fallible and none of them panic. The clear below is itself a command, so
+    /// on an engine where a stale interrupt does abort the next one, *this* is the command it
+    /// aborts — panicking there would take out the measurement the caller is in the middle of,
+    /// and the undrained case could never report the very behaviour it exists to report. A
+    /// probe that cannot run at all is caught instead by the caller's baseline assertion,
+    /// taken before anything is staged.
     #[cfg(not(miri))]
     fn command_took_effect(e: &DebugEngine, sentinel: u64) -> bool {
         // Clear first, so a value left by an earlier probe cannot pass for a fresh one.
-        e.execute_command("r $t1 = 0").expect("clearing $t1 failed");
-        if read_pseudo_register(e, "$t1") != 0 {
-            panic!("$t1 did not clear; the probe itself is unreliable here");
+        if e.execute_command("r $t1 = 0").is_err() || read_pseudo_register_opt(e, "$t1") != Some(0)
+        {
+            return false;
         }
         if e.execute_command(&format!("r $t1 = 0x{sentinel:x}"))
             .is_err()
         {
             return false;
         }
-        read_pseudo_register(e, "$t1") == sentinel
+        read_pseudo_register_opt(e, "$t1") == Some(sentinel)
     }
 
     // The `#[ignore]`d tests below each drive a real debuggee, and MUST be run with

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1432,6 +1432,30 @@ mod tests {
             .unwrap_or_else(|_| panic!("no value in `?` output for {expr}: {out:?}"))
     }
 
+    /// Runs a command and reports whether it actually *took effect*, by having it stamp a
+    /// sentinel into `$t1` and reading it back.
+    ///
+    /// Substring-matching the captured output cannot answer this. `execute_command` passes
+    /// `DEBUG_EXECUTE_ECHO`, so DbgEng echoes the command text into the output buffer before
+    /// running it, and [`OutputCallbacks`] appends every chunk unfiltered — a check like
+    /// `output.contains("version")` therefore matches the echo alone and passes even when the
+    /// command was aborted immediately after being echoed, which is precisely the failure
+    /// these tests exist to catch.
+    #[cfg(not(miri))]
+    fn command_took_effect(e: &DebugEngine, sentinel: u64) -> bool {
+        // Clear first, so a value left by an earlier probe cannot pass for a fresh one.
+        e.execute_command("r $t1 = 0").expect("clearing $t1 failed");
+        if read_pseudo_register(e, "$t1") != 0 {
+            panic!("$t1 did not clear; the probe itself is unreliable here");
+        }
+        if e.execute_command(&format!("r $t1 = 0x{sentinel:x}"))
+            .is_err()
+        {
+            return false;
+        }
+        read_pseudo_register(e, "$t1") == sentinel
+    }
+
     // The `#[ignore]`d tests below each drive a real debuggee, and MUST be run with
     // `--test-threads=1`. dbgeng.dll holds one debuggee session per *process*, so two of them
     // running concurrently in the same test binary fight over the same session and fail in
@@ -1504,21 +1528,16 @@ mod tests {
         let e = DebugEngine::new();
         e.launch_process("cmd.exe /c exit").expect("launch failed");
 
-        // Baseline: what a healthy `version` looks like.
-        let baseline = e.execute_command("version").expect("baseline failed");
-        assert!(baseline.to_lowercase().contains("version"));
+        // Baseline: the probe reports a healthy engine before anything is staged.
+        assert!(
+            command_took_effect(&e, 0xBA5E),
+            "baseline command did not take effect; the probe is broken, not the engine"
+        );
 
         // Undrained: stage the race, then run a command.
         unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
-        let undrained = e.execute_command("version");
-        match &undrained {
-            Ok(out) => println!(
-                "undrained next command: Ok, {} bytes, looks normal: {}",
-                out.len(),
-                out.to_lowercase().contains("version")
-            ),
-            Err(err) => println!("undrained next command: Err({err})"),
-        }
+        let undrained = command_took_effect(&e, 0xA11);
+        println!("undrained next command took effect: {undrained}");
 
         // Drained: stage the same race, consume it, then run the same command.
         //
@@ -1534,40 +1553,34 @@ mod tests {
             "staged interrupt was not pending — nothing was drained, so the case below is not \
              the drained one it claims to be"
         );
-        let drained = e.execute_command("version");
-        match &drained {
-            Ok(out) => println!(
-                "drained   next command: Ok, {} bytes, looks normal: {}",
-                out.len(),
-                out.to_lowercase().contains("version")
-            ),
-            Err(err) => println!("drained   next command: Err({err})"),
-        }
+        let drained = command_took_effect(&e, 0xB22);
+        println!("drained   next command took effect: {drained}");
 
         // A short command like `version` may simply never poll for the interrupt. The case
         // that matters is a *long* next command, which does — if a stale Ctrl+Break aborts
         // that, the drain is load-bearing; if not, it is a no-op.
-        let long = ".for (r $t0 = 0; @$t0 < 0x40000; r $t0 = @$t0 + 1) { }";
+        // Whether it *finished* is read from `$t0`, not inferred from the clock.
+        const LONG_ITERS: u64 = 0x4_0000;
+        let long = format!(".for (r $t0 = 0; @$t0 < 0x{LONG_ITERS:x}; r $t0 = @$t0 + 1) {{ }}");
+
         let clean_start = Instant::now();
-        let _ = e.execute_command(long).expect("long command failed");
+        e.execute_command(&long).expect("long command failed");
         let clean = clean_start.elapsed();
+        let clean_t0 = read_pseudo_register(&e, "$t0");
 
         unsafe { e.control.SetInterrupt(DEBUG_INTERRUPT_ACTIVE) }.expect("SetInterrupt failed");
         let stale_start = Instant::now();
-        let stale = e.execute_command(long);
+        let stale = e.execute_command(&long);
         let stale_elapsed = stale_start.elapsed();
+        let stale_t0 = read_pseudo_register(&e, "$t0");
+        let stale_result = if stale.is_ok() { "Ok" } else { "Err" };
+        println!("long command, clean:           {clean:?} (t0={clean_t0} of {LONG_ITERS})");
         println!(
-            "long command: clean {:?}, with a stale interrupt pending {:?} ({})",
-            clean,
-            stale_elapsed,
-            match &stale {
-                Ok(_) => "Ok",
-                Err(_) => "Err",
-            }
+            "long command, stale interrupt: {stale_elapsed:?} (t0={stale_t0} of {LONG_ITERS}, {stale_result})"
         );
         println!(
             "  -> stale interrupt {} the long command",
-            if stale_elapsed < clean / 2 {
+            if stale_t0 < LONG_ITERS {
                 "ABORTED"
             } else {
                 "did NOT abort"
@@ -1575,12 +1588,9 @@ mod tests {
         );
         let _ = e.interrupted();
 
-        // Only the drained case is asserted; the undrained one is the measurement.
+        // Only the drained case is asserted; the undrained ones are the measurement.
         assert!(
-            drained
-                .expect("drained command errored")
-                .to_lowercase()
-                .contains("version"),
+            drained,
             "draining should leave the next command fully usable"
         );
 
@@ -1634,12 +1644,13 @@ mod tests {
             "no interruption note despite a loop that stopped short"
         );
 
-        // The command under test. If a stale interrupt survived, this aborts instead.
-        let after = e.execute_command("version").expect("next command errored");
-        println!("--- next command output ---\n{after}\n---");
+        // The command under test. If a stale interrupt survived, this aborts instead — so the
+        // check has to be that it *took effect*, not that its text came back. `Execute` echoes
+        // the command into the output buffer before running it, which makes any substring
+        // check against the command name pass on the echo alone.
         assert!(
-            after.to_lowercase().contains("version"),
-            "next command produced no real output — stale interrupt aborted it"
+            command_took_effect(&e, 0x5A5E),
+            "next command did not take effect — a stale interrupt aborted it"
         );
 
         let _ = e.end_session();


### PR DESCRIPTION
Refs #69. Verification, not a behaviour change — the answer turned out to be "the assumption holds, but the bug it guards against doesn't reproduce."

## What #69 asked

#68 drains a pending interrupt with `GetInterrupt` after a bounded command's watchdog fires, assuming `GetInterrupt` *consumes* the request. Microsoft documents it as a check (S_OK requested / S_FALSE not) and says nothing about clearing, so #69 asked for measurement rather than assumption.

All measured against **dbgeng 10.0.26100.1, user-mode target**.

## 1. `GetInterrupt` does clear — and the state is a flag, not a counter

```
after 1x SetInterrupt, five GetInterrupt polls: [true, false, false, false, false]
after 3x SetInterrupt, five GetInterrupt polls: [true, false, false, false, false]
```

The first result answers the issue. The second answers a related worry I had going in — that the watchdog re-firing every 200 ms while past its deadline could queue several interrupts and outlast a single drain. It can't: they collapse into one flag, and one poll clears it.

## 2. The hazard does not reproduce

| probe | drained | undrained |
|---|---|---|
| `version` (short) | Ok, 2858 bytes | Ok, 2858 bytes — byte-identical |
| interrupt-polling `.for` (long) | 4.70s, ran to completion | 4.71s, ran to completion |

And with the drain **deleted entirely**, the end-to-end test passed 5/5, so ordinary timing doesn't hit the race either.

The engine appears to reset the request when `Execute` begins a command. That is also how WinDbg behaves: a Ctrl+Break pressed while idle does not kill the next command you type.

## 3. So the drain stays, but its comment changes

The old comment asserted a mechanism — "leaving a Ctrl+Break *pending* that would abort the next command on its first interrupt poll". On this engine that does not happen, so the comment now records what was measured instead of claiming a hazard.

Kept rather than deleted because it costs one call on an already-exceptional path, the behaviour is undocumented and may vary by engine version, and **the live-kernel path was not measured**. Deleting on the strength of one environment is the worse bet. The evidence is in the tests if someone later wants to remove it.

## Tests

Three `#[ignore]`d tests carry the evidence. They **must** run with `--test-threads=1`:

```
cargo test --lib -- --ignored --nocapture --test-threads=1
```

dbgeng holds one debuggee session per *process*, so run concurrently in one test binary they fight over the same session and fail in ways that look like engine bugs — individually they pass, as a group they don't. That is documented above them, since the obvious invocation is the broken one.

Ignored rather than env-gated because CI has no target to give them on any platform, so there's no configuration where they'd run there.

## Not covered: live-kernel targets

**Findings 1 and 2 should carry over.** They are properties of engine-local state: `SetInterrupt`
records a request inside dbgeng.dll and `GetInterrupt` reads and clears it, with nothing crossing
to the target. Target type has no obvious way to change that.

**Finding 3 is the one to re-measure** — and not for the reason this PR first gave. I cited
`wait_for_event_bounded`'s note that `SetInterrupt` cannot cancel a wait still establishing a KD
link. That limitation is scoped to link *establishment* and says nothing about behaviour once the
link is up, so it was never valid grounds for doubting these results.

The real reason is that on a live kernel `DEBUG_INTERRUPT_ACTIVE` is not purely an engine flag:
with the target running it becomes a break-in request carried over the KD wire. Two consequences,
both of which survive the link being established:

- **The hazard changes shape.** The risk is less "the next command aborts" than "the next `g`
  breaks in immediately", because a break-in can be outstanding *toward the target* rather than
  sitting in the engine.
- **The drain may be weaker there, not stronger.** `GetInterrupt` clears the engine's flag, which
  may not recall a break-in already on the wire. That argues for keeping the drain and measuring
  it, rather than deleting it on user-mode evidence.

No kernel target was available: this host is not booted for local kernel debugging
(`AttachKernel(DEBUG_ATTACH_LOCAL_KERNEL)` → `0x80004001`) and there is no KDNET VM. Folded into
#73's hardware session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of pending interrupts during time-limited debugging commands.
  - Enhanced recovery when a command is interrupted by a watchdog timeout, helping subsequent commands run reliably.

- **Tests**
  - Added coverage for interrupt draining, the effects of pending interrupts on later commands, and recovery after interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->