### PR TITLE
ci: cancel superseded runs, and halve the Miri fixture's cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  # A superseded push or PR update should cancel its predecessor. Without this every push to a
+  # PR left its predecessor running to completion — five pushes to one PR meant five concurrent
+  # ci runs, which for Miri is five times ~28 minutes of runner doing work nobody will read.
+  #
+  # Manual dispatches are deliberately excluded. A dispatch shares `github.ref` with the
+  # branch's own run, so a shared group would have the two cancel each other, and a repeat
+  # dispatch would kill the run someone had just asked for. Keying dispatches by run id gives
+  # each one a group of its own: never cancelled, never cancelling.
+  group: ci-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,18 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  # A superseded push or PR update should cancel its predecessor. Without this every push to a
+  # PR left its predecessor running to completion — five pushes to one PR meant five concurrent
+  # coverage runs, which for Miri is five times ~28 minutes of runner doing work nobody will read.
+  #
+  # Manual dispatches are deliberately excluded. A dispatch shares `github.ref` with the
+  # branch's own run, so a shared group would have the two cancel each other, and a repeat
+  # dispatch would kill the run someone had just asked for. Keying dispatches by run id gives
+  # each one a group of its own: never cancelled, never cancelling.
+  group: coverage-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -12,6 +12,18 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  # A superseded push or PR update should cancel its predecessor. Without this every push to a
+  # PR left its predecessor running to completion — five pushes to one PR meant five concurrent
+  # Miri runs, which for Miri is five times ~28 minutes of runner doing work nobody will read.
+  #
+  # Manual dispatches are deliberately excluded. A dispatch shares `github.ref` with the
+  # branch's own run, so a shared group would have the two cancel each other, and a repeat
+  # dispatch would kill the run someone had just asked for. Keying dispatches by run id gives
+  # each one a group of its own: never cancelled, never cancelling.
+  group: miri-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1554,9 +1554,57 @@ mod tests {
     const LARGE_VA: u64 = K + 0x90_0000;
     const BIG_TABLE: u64 = K + 0xa0_0000;
 
+    /// Sparse synthetic memory, stored as coalesced contiguous runs.
+    ///
+    /// Built from a byte-keyed `BTreeMap` — which is the natural way to *write* the fixture,
+    /// and cheap, since setup happens once — then frozen into runs for reading. The naive form
+    /// kept the map and did one `BTreeMap::get` per byte in `read_exact`; native runs absorbed
+    /// that, but under Miri every lookup is interpreted and borrow-checked, and the two pool
+    /// snapshot tests took 18m13s and 5m44s of a ~28 minute CI job. Runs turn each read into a
+    /// binary search plus a `memcpy`, with identical semantics: a byte is readable iff it was
+    /// written, so a read spanning a gap still fails.
+    ///
+    /// Measured, not assumed: those two tests together run in 366s here versus 731s with the
+    /// byte map, on the same machine — **2.0x**, not the order of magnitude the lookup count
+    /// suggests. Most of what remains is Miri interpreting the walk itself rather than the
+    /// fixture, so this is worth having but is not the whole story.
     struct SyntheticMemory {
-        bytes: BTreeMap<u64, u8>,
+        /// `(start, bytes)` for each contiguous written range, sorted by `start` and never
+        /// overlapping or abutting.
+        runs: Vec<(u64, Vec<u8>)>,
         holes: Vec<(u64, u64)>,
+    }
+
+    impl SyntheticMemory {
+        fn new(bytes: BTreeMap<u64, u8>, holes: Vec<(u64, u64)>) -> Self {
+            let mut runs: Vec<(u64, Vec<u8>)> = Vec::new();
+            for (address, byte) in bytes {
+                match runs.last_mut() {
+                    // `BTreeMap` iterates in key order, so a run extends whenever the next
+                    // address is the one after the last byte written.
+                    Some((start, data)) if *start + data.len() as u64 == address => {
+                        data.push(byte);
+                    }
+                    _ => runs.push((address, vec![byte])),
+                }
+            }
+            Self { runs, holes }
+        }
+
+        /// The run containing `address`, if any.
+        fn run_at(&self, address: u64) -> Option<&(u64, Vec<u8>)> {
+            let index = self
+                .runs
+                .partition_point(|(start, _)| *start <= address)
+                .checked_sub(1)?;
+            let run = &self.runs[index];
+            (address < run.0 + run.1.len() as u64).then_some(run)
+        }
+
+        /// Whether a single byte was written — the fixture's own sanity checks ask this.
+        fn contains(&self, address: u64) -> bool {
+            self.run_at(address).is_some()
+        }
     }
 
     struct ShortMemory;
@@ -1626,18 +1674,18 @@ mod tests {
 
     impl PoolMemory for SyntheticMemory {
         fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
-            (0..size)
-                .map(|offset| {
-                    self.bytes
-                        .get(&(address + offset as u64))
-                        .copied()
-                        .ok_or_else(|| SnapshotError::Read {
-                            address,
-                            size,
-                            source: Box::new(std::io::Error::other("sparse synthetic memory")),
-                        })
-                })
-                .collect()
+            let unreadable = || SnapshotError::Read {
+                address,
+                size,
+                source: Box::new(std::io::Error::other("sparse synthetic memory")),
+            };
+            let (start, data) = self.run_at(address).ok_or_else(unreadable)?;
+            let offset = (address - start) as usize;
+            // One run must cover the whole read: runs never abut, so a read that runs off the
+            // end of one has hit a gap, exactly as the per-byte lookup used to report.
+            data.get(offset..offset + size)
+                .map(<[u8]>::to_vec)
+                .ok_or_else(unreadable)
         }
 
         fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
@@ -2017,10 +2065,7 @@ mod tests {
         put(&mut bytes, entry + 8, b"BIG!");
         put_u64(&mut bytes, entry + 0x10, 0x1800);
 
-        SyntheticMemory {
-            bytes,
-            holes: vec![(SEGMENT + 0x7800, SEGMENT + 0x8000)],
-        }
+        SyntheticMemory::new(bytes, vec![(SEGMENT + 0x7800, SEGMENT + 0x8000)])
     }
 
     fn big_page_memory(address: u64, count: usize, collision_distance: usize) -> BigPageMemory {
@@ -2049,7 +2094,7 @@ mod tests {
     #[test]
     fn test_pool_snapshot_walks_all_backends() {
         let memory = synthetic_memory();
-        assert!(!memory.bytes.contains_key(&LARGE_VA));
+        assert!(!memory.contains(LARGE_VA));
         let layout = synthetic_layout();
         let walker = SnapshotWalker {
             memory: &memory,


### PR DESCRIPTION
Two independent fixes to the same problem: the Miri job takes ~28 minutes and nothing was reclaiming that time.

## 1. Cancel superseded runs

No win-kexp workflow had a `concurrency` group, so every push to a PR left its predecessor running to completion. Five pushes to #74 meant five concurrent ~28 minute Miri runs, all but the last producing a result nobody would read — and it is why two CI watches on that PR expired without ever settling.

`ci`, `coverage` and `miri` now cancel their predecessors, following the pattern already in windbg-mcp, including its carve-out for `workflow_dispatch` — a dispatch shares `github.ref` with the branch's own run, so a shared group would have the two cancel each other.

The two `claude*` workflows are deliberately left alone: cancelling a review mid-flight only loses the review, and they are not where the runner time goes.

## 2. Make the fixture cheaper to read

Profiled from the job's own log timestamps rather than guessed:

| step | time |
|---|---|
| toolchain install | 53 s |
| `cargo miri setup` | 27 s |
| compilation inside `cargo miri test` | **24 s** |
| interpreting 24 tests | **~25 min** |

and within those tests:

| test | duration |
|---|---|
| `test_pool_snapshot_walks_all_backends` | 18 m 13 s |
| `test_snapshot_errors_preserve_category_and_source` | 5 m 44 s |
| the other 22 combined | ~70 s |

`SyntheticMemory` stored one `BTreeMap` entry per byte, and `read_exact` did one lookup per byte. Under Miri each of those is interpreted and borrow-checked.

It now freezes the byte map into coalesced contiguous runs once, so a read is a binary search plus a `memcpy`. **Semantics are unchanged** — runs never abut, so a read spanning a gap still fails exactly as the per-byte version did. The builders keep writing into a `BTreeMap`, which is the clearest way to express them and costs nothing at setup.

### What it actually buys

Measured on one machine, before and after, rather than comparing a local run to a CI run:

| fixture | those two tests |
|---|---|
| byte-keyed `BTreeMap` | 731 s |
| coalesced runs | 366 s |

**2.0x.** Worth having, but well short of what the lookup count suggests — most of what remains is Miri interpreting the pool walk itself, not the fixture. Expect the job around 16 minutes rather than 28.

I had estimated "~28 min becomes ~4" before measuring. That was wrong, and the corrected figure is recorded in the code comment too, so the next person sizing this work starts from the measurement rather than the guess.

### What is explicitly *not* here

Adding `Swatinem/rust-cache` to `miri.yml`. `ci.yml` has it, so copying it across looks obviously right — but compilation is 24 seconds of a 25 minute step, so it would buy nothing.

## Testing

All 25 native tests pass; `cargo fmt --check` and clippy clean (the one warning is pre-existing in `src/process.rs`). The Miri run on this PR is itself the end-to-end check of the second half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
