### PR TITLE
perf: cut the Miri job from ~15m to ~3m

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -15,7 +15,8 @@ on:
 concurrency:
   # A superseded push or PR update should cancel its predecessor. Without this every push to a
   # PR left its predecessor running to completion — five pushes to one PR meant five concurrent
-  # Miri runs, which for Miri is five times ~28 minutes of runner doing work nobody will read.
+  # Miri runs, which back when a run took ~28 minutes was most of an hour of runner time nobody
+  # would read. The run is far shorter now, but the reasoning does not depend on the duration.
   #
   # Manual dispatches are deliberately excluded. A dispatch shares `github.ref` with the
   # branch's own run, so a shared group would have the two cancel each other, and a repeat
@@ -41,9 +42,30 @@ jobs:
         run: |
           rustup toolchain install nightly --component miri,rust-src
           rustup override set nightly
+      # After the toolchain install, never before: rust-cache derives its key from the active
+      # rustc, so caching earlier would key everything on stable and restore the wrong artifacts.
+      # A nightly bump changes the key and rebuilds, which is what we want — the Miri sysroot in
+      # `cache-directories` is toolchain-specific and must never outlive the toolchain that
+      # produced it. Within one nightly this turns `cargo miri setup` into a no-op.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: miri
+          cache-directories: "~/AppData/Local/rust-lang/miri/cache"
+      - uses: taiki-e/install-action@nextest
       - name: Setup Miri sysroot
         run: cargo miri setup
+      # nextest, not `cargo miri test`, because libtest's threads all share one interpreter —
+      # Miri interleaves them rather than running them in parallel, so a multi-core runner buys
+      # nothing. nextest puts each test in its own process, which is real parallelism: 27.5s
+      # against 43.7s locally. The cost is ~1.3s of sysroot load per test process, so this is a
+      # win only while the suite is short; revisit if a single test starts to dominate again.
       - name: Run Miri
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-ignore-leaks"
-        run: cargo miri test --verbose
+        run: cargo miri nextest run
+      # nextest cannot run doctests, and ci.yml is on nextest too — without this step the crate's
+      # doctests would run nowhere in CI. It is ~0.3s on top of an already-built tree.
+      - name: Run Miri doctests
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-ignore-leaks"
+        run: cargo miri test --doc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ When touching this module, mind the `owns_session` invariant, the stdout-isolati
 Three workflows run on **Windows runners only**:
 - **ci.yml**: fmt check → build → `cargo nextest run` on both `windows-latest` (x64) and `windows-11-arm` (ARM64) with stable Rust
 - **coverage.yml**: grcov + LLVM instrumentation → Codecov upload
-- **miri.yml**: `cargo miri test` on nightly with `MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks"`
+- **miri.yml**: `cargo miri nextest run` on nightly with `MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks"`, plus a `cargo miri test --doc` step for the doctests nextest cannot run
 
 CI installs MASM/ARMASM tooling via `glslang/setup-masm` (`ci.yml` uses `@v1.4`, `coverage.yml` uses `@v1`, `miri.yml` uses `@v1.2`), so assemblers are always available there. Local builds without assemblers silently activate `shellcode_fallback`.
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1530,10 +1530,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        cell::Cell,
-        collections::{BTreeMap, HashMap},
-    };
+    use std::{cell::Cell, collections::HashMap};
 
     use super::*;
     use crate::pool::{
@@ -1556,18 +1553,23 @@ mod tests {
 
     /// Sparse synthetic memory, stored as coalesced contiguous runs.
     ///
-    /// Built from a byte-keyed `BTreeMap` — which is the natural way to *write* the fixture,
-    /// and cheap, since setup happens once — then frozen into runs for reading. The naive form
-    /// kept the map and did one `BTreeMap::get` per byte in `read_exact`; native runs absorbed
-    /// that, but under Miri every lookup is interpreted and borrow-checked, and the two pool
-    /// snapshot tests took 18m13s and 5m44s of a ~28 minute CI job. Runs turn each read into a
-    /// binary search plus a `memcpy`, with identical semantics: a byte is readable iff it was
-    /// written, so a read spanning a gap still fails.
+    /// Both the read and the write path are shaped to keep Miri off per-byte work, and the two
+    /// were found in separate rounds.
     ///
-    /// Measured, not assumed: those two tests together run in 366s here versus 731s with the
-    /// byte map, on the same machine — **2.0x**, not the order of magnitude the lookup count
-    /// suggests. Most of what remains is Miri interpreting the walk itself rather than the
-    /// fixture, so this is worth having but is not the whole story.
+    /// Reads resolve through a binary search over runs, not the `BTreeMap<u64, u8>` this began
+    /// as with one `get` per byte. Semantics are unchanged — a byte is readable iff it was
+    /// written, so a read spanning a gap still fails — and that was worth 2.0x.
+    ///
+    /// Writes go through [`Writes`], a log replayed in bulk, rather than building that byte map
+    /// at all. The read fix left the two pool snapshot tests at 398s and 369s of an 849s CI job,
+    /// and the second of them is three assertions over a fixture — so what remained was never
+    /// "Miri interpreting the walk", which is what the previous round of this comment concluded.
+    /// It was the ~22k `BTreeMap` inserts `fill`/`put` performed to build the fixture in the
+    /// first place, each a fully interpreted, borrow-checked trip through `NodeRef` and raw
+    /// pointers. Bulk `copy_from_slice` over a handful of runs is one Miri operation per write.
+    ///
+    /// Measured, not assumed: on one machine that second test alone took 178.4s before the
+    /// write fix; both tests together now take 6.1s.
     struct SyntheticMemory {
         /// `(start, bytes)` for each contiguous written range, sorted by `start` and never
         /// overlapping or abutting.
@@ -1575,18 +1577,49 @@ mod tests {
         holes: Vec<(u64, u64)>,
     }
 
+    /// The fixture's write log: `(address, bytes)` in the order written, later writes winning.
+    ///
+    /// A plain append-only `Vec`, one entry per `put`/`fill` call rather than per byte, so the
+    /// whole fixture is a few dozen pushes and bulk copies instead of ~22k `BTreeMap` inserts.
+    #[derive(Default)]
+    struct Writes(Vec<(u64, Vec<u8>)>);
+
     impl SyntheticMemory {
-        fn new(bytes: BTreeMap<u64, u8>, holes: Vec<(u64, u64)>) -> Self {
+        fn new(writes: Writes, holes: Vec<(u64, u64)>) -> Self {
+            // Extents first: merge every written interval that overlaps or abuts a neighbour,
+            // which yields exactly the runs the byte map used to produce by iterating in key
+            // order. Sorting is safe here because an extent carries no value to be overwritten.
+            let mut extents: Vec<(u64, u64)> = writes
+                .0
+                .iter()
+                .filter(|(_, data)| !data.is_empty())
+                .map(|(address, data)| (*address, address + data.len() as u64))
+                .collect();
+            extents.sort_unstable();
             let mut runs: Vec<(u64, Vec<u8>)> = Vec::new();
-            for (address, byte) in bytes {
+            for (start, end) in extents {
                 match runs.last_mut() {
-                    // `BTreeMap` iterates in key order, so a run extends whenever the next
-                    // address is the one after the last byte written.
-                    Some((start, data)) if *start + data.len() as u64 == address => {
-                        data.push(byte);
+                    Some((run_start, data)) if start <= *run_start + data.len() as u64 => {
+                        let len = (end - *run_start) as usize;
+                        // A contained write leaves the run as it is; only a write reaching past
+                        // the current end grows it.
+                        if len > data.len() {
+                            data.resize(len, 0);
+                        }
                     }
-                    _ => runs.push((address, vec![byte])),
+                    _ => runs.push((start, vec![0; (end - start) as usize])),
                 }
+            }
+            // Then replay in write order, so the last write to an address wins — the property
+            // that re-inserting into the byte map used to provide.
+            for (address, data) in writes.0.into_iter().filter(|(_, data)| !data.is_empty()) {
+                let index = runs
+                    .partition_point(|(start, _)| *start <= address)
+                    .checked_sub(1)
+                    .expect("every non-empty write contributed an extent");
+                let (start, run) = &mut runs[index];
+                let offset = (address - *start) as usize;
+                run[offset..offset + data.len()].copy_from_slice(&data);
             }
             Self { runs, holes }
         }
@@ -1889,27 +1922,23 @@ mod tests {
         }
     }
 
-    fn put(bytes: &mut BTreeMap<u64, u8>, address: u64, data: &[u8]) {
-        bytes.extend(
-            data.iter()
-                .enumerate()
-                .map(|(offset, byte)| (address + offset as u64, *byte)),
-        );
+    fn put(bytes: &mut Writes, address: u64, data: &[u8]) {
+        bytes.0.push((address, data.to_vec()));
     }
 
-    fn fill(bytes: &mut BTreeMap<u64, u8>, address: u64, size: usize) {
-        put(bytes, address, &vec![0; size]);
+    fn fill(bytes: &mut Writes, address: u64, size: usize) {
+        bytes.0.push((address, vec![0; size]));
     }
 
-    fn put_u16(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u16) {
+    fn put_u16(bytes: &mut Writes, address: u64, value: u16) {
         put(bytes, address, &value.to_le_bytes());
     }
 
-    fn put_u32(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u32) {
+    fn put_u32(bytes: &mut Writes, address: u64, value: u32) {
         put(bytes, address, &value.to_le_bytes());
     }
 
-    fn put_u64(bytes: &mut BTreeMap<u64, u8>, address: u64, value: u64) {
+    fn put_u64(bytes: &mut Writes, address: u64, value: u64) {
         put(bytes, address, &value.to_le_bytes());
     }
 
@@ -1917,14 +1946,14 @@ mod tests {
         (entry << 4) | 3
     }
 
-    fn pool_header(bytes: &mut BTreeMap<u64, u8>, address: u64, tag: &[u8; 4]) {
+    fn pool_header(bytes: &mut Writes, address: u64, tag: &[u8; 4]) {
         fill(bytes, address, 0x10);
         put(bytes, address, &[1, 0, 4, 1]);
         put(bytes, address + 8, tag);
     }
 
     fn synthetic_memory() -> SyntheticMemory {
-        let mut bytes = BTreeMap::new();
+        let mut bytes = Writes::default();
         fill(&mut bytes, STATE, 0x200);
         put_u32(&mut bytes, STATE, 1);
         for heap_index in 0..4 {


### PR DESCRIPTION
## Where the time went

`Miri` took 15m44s. The breakdown from run [30753548147](https://github.com/glslang/win-kexp/actions/runs/30753548147) is ~57s setup, ~33s compiling, and **848.8s interpreting tests** — so caching alone was never going to matter much.

Two tests owned 90% of the interpretation:

| Test | CI time |
|---|---|
| `test_pool_snapshot_walks_all_backends` | 398.5s |
| `test_snapshot_errors_preserve_category_and_source` | 368.8s |

The second is three assertions over a fixture. That is what located the problem: the cost had to be *building* `synthetic_memory()`, not walking the pool.

It built a `BTreeMap<u64, u8>` with **one entry per byte** — ~30 `fill`/`put` calls expanding to ~22k inserts. Free natively; under Miri each insert is a fully interpreted, borrow-checked trip through `BTreeMap`'s `NodeRef` and raw pointers.

Worth flagging: the previous round (c11e8df) fixed the *read* path and concluded the remainder was "Miri interpreting the walk itself". That was wrong, and the comment asserting it has been corrected rather than left to mislead.

## Changes

**`perf(pool)`** — writes are recorded as a log of `(address, bytes)`, one entry per call. `SyntheticMemory::new` merges the intervals once and replays with `copy_from_slice`, one bulk Miri operation per write. Semantics are unchanged and still load-bearing for these two tests: last-write-wins, abutting runs coalesce, a read spanning a gap still fails. The 150-line fixture body is untouched; only helper signatures change.

**`ci`** — `Swatinem/rust-cache` keyed *after* the toolchain install (so the key is nightly's, not stable's), carrying the Miri sysroot in `cache-directories`. And `cargo miri nextest run`: libtest's threads share one interpreter, so Miri interleaves rather than parallelizes them and a multi-core runner buys nothing — nextest gives each test its own process. A `cargo miri test --doc` step keeps the doctests, which nextest cannot run and which `ci.yml` (also on nextest) does not cover either.

## Measured

Same machine throughout:

| | Before | After |
|---|---|---|
| `test_snapshot_errors…` alone | 178.4s | — |
| Both heavy tests | — | 6.1s |
| Full Miri suite, `cargo miri test` | ~410s* | 43.7s |
| Full Miri suite, `cargo miri nextest run` | — | **25.8s** |

<sub>* scaled from CI; this machine runs ~2x faster than the GitHub runner.</sub>

Extrapolating, CI should land near **3 minutes**.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo build --verbose` OK
- `cargo nextest run` — 25 passed
- `cargo miri nextest run` — 24 passed, 25.8s
- `cargo miri test --doc` — 1 passed

One caveat I did not act on: `test_poolmap_heatmap_and_advice` is genuinely 21.8s in isolation, now the slowest test by a wide margin. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated validation for runtime compatibility, including separate coverage for standard tests and documentation examples.
  * Enhanced test setup reliability and efficiency when simulating memory writes.

* **Chores**
  * Added build caching to speed up continuous integration checks.
  * Updated development guidance to reflect the revised validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->