### PR TITLE
perf(pool): escape DML into one buffer, not one String per char

### DIFF
--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -21,17 +21,25 @@ struct RowKey {
     size_class: u32,
 }
 
+/// Escapes the five XML metacharacters DML inherits.
+///
+/// One buffer, not one `String` per character. The per-character form heap-allocated once for
+/// every `char` of every cell command — ~26 allocations per rendered cell — which is invisible
+/// natively but was most of what Miri paid for here, since it tracks every allocation. Rendering
+/// 180 cells as DML went from 8.9s to 3.4s under Miri on this change alone.
 pub(crate) fn escape_dml(text: &str) -> String {
-    text.chars()
-        .map(|character| match character {
-            '&' => "&amp;".to_string(),
-            '<' => "&lt;".to_string(),
-            '>' => "&gt;".to_string(),
-            '"' => "&quot;".to_string(),
-            '\'' => "&apos;".to_string(),
-            _ => character.to_string(),
-        })
-        .collect()
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
 }
 
 fn kind_name(kind: PoolKind) -> &'static str {


### PR DESCRIPTION
Follow-up to #78. With the pool snapshot fixture fixed there, `test_poolmap_heatmap_and_advice` became the slowest test in the Miri suite and — under nextest's per-test processes — the critical path for the whole job's wall clock.

## Measuring before guessing

#78 showed what happens when you reason about Miri cost by reading for suspects, so I instrumented the test's phases instead:

| Phase | Before | After |
|---|---|---|
| build index (5 spans) | 56ms | 59ms |
| render plain + asserts | 468ms | 469ms |
| render DML + asserts | 472ms | 288ms |
| oversized-cells block | 6.20s | 5.98s |
| build 180 spans | 1.33s | 1.27s |
| **render 180 spans as DML** | **8.93s** | **3.42s** |
| final chunk asserts | 2.34s | 2.30s |

8.93s for 180 cells is ~50ms per cell — far past what two `format!` calls explain.

## Cause

```rust
text.chars().map(|c| match c { ... _ => c.to_string() }).collect()
```

`escape_dml` gave every `char` its own heap-allocated `String`. That is ~26 allocations per cell command, and Miri tracks every allocation — so a module of entirely safe string handling was the most expensive thing in the suite. Writing into one pre-sized buffer is also a straight improvement natively (one allocation instead of N); it was simply never visible there.

## Result

- `test_poolmap_heatmap_and_advice`: **21.8s → 15.7s**
- Miri suite under nextest: **25.8s → 19.6s**

## What I deliberately did not do

The remaining ~15.7s is inherent to what the test verifies: exercising the chunking path requires generating more than `OUTPUT_CHUNK` (7500) bytes of DML, and Miri interprets every character. The `repeat(200)` and 180-span fixtures sit at roughly 2x the threshold; trimming them toward ~1.1x would cut several more seconds but spends the headroom that keeps `assert!(chunks.len() > 1)` meaningful. That is a judgment call about test robustness, not a straightforward win, so I left it — happy to do it if you want the seconds.

`PoolIndex::build` was checked for quadratic behaviour on the way past; it is O(n log n).

## Verification

- `cargo fmt --all -- --check` clean
- `cargo nextest run` — 25 passed
- `cargo miri nextest run` — 24 passed, 19.9s
- `cargo miri test --doc` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)