### PR TITLE
pool: typed query API, and make the walker work on Windows 26100

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -155,6 +155,14 @@ pub struct RunToResult {
 /// process, so per-engine identity plus a bump on release covers every case.
 static NEXT_TARGET_IDENTITY: AtomicU64 = AtomicU64::new(1);
 
+/// The identity every *borrowed* engine shares.
+///
+/// A borrowed WinDbg client is wrapped afresh for each extension command, so giving each
+/// wrapper its own identity would miss the caches on every invocation — repeating the full
+/// pool walk and leaking a layout entry each time. Those hosts deliver session
+/// notifications instead, which is what invalidates their caches.
+const BORROWED_TARGET_IDENTITY: u64 = 0;
+
 fn next_target_identity() -> u64 {
     NEXT_TARGET_IDENTITY.fetch_add(1, Ordering::Relaxed)
 }
@@ -215,6 +223,11 @@ impl DebugEngine {
         // We opened this session, so we own its teardown.
         let mut engine = Self::from_client_interface(client);
         engine.owns_session = true;
+        // Only an engine that opened its own session gets a distinct identity: it is
+        // long-lived, and a host may hold several against targets that share a kernel base.
+        engine
+            .target_identity
+            .store(next_target_identity(), Ordering::Release);
         engine
     }
 
@@ -266,7 +279,7 @@ impl DebugEngine {
             // Default to "borrowed": constructors that wrap an existing WinDbg client
             // go through here, and only `new()` (which calls `DebugCreate`) sets this.
             owns_session: false,
-            target_identity: AtomicU64::new(next_target_identity()),
+            target_identity: AtomicU64::new(BORROWED_TARGET_IDENTITY),
             deferred_inputs: Mutex::new(Vec::new()),
         }
     }
@@ -297,7 +310,7 @@ impl DebugEngine {
             dataspaces,
             symbols,
             owns_session: false,
-            target_identity: AtomicU64::new(next_target_identity()),
+            target_identity: AtomicU64::new(BORROWED_TARGET_IDENTITY),
             deferred_inputs: Mutex::new(Vec::new()),
         })
     }

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1,5 +1,5 @@
 use std::ffi::CString;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -149,6 +149,16 @@ pub struct RunToResult {
     pub output: String,
 }
 
+/// Hands out a fresh identity for every engine, and again whenever one releases its
+/// target. Caches that ask "is this still the same target?" cannot use the kernel base
+/// alone — two dumps from one boot share it — and dbgeng holds one debuggee session per
+/// process, so per-engine identity plus a bump on release covers every case.
+static NEXT_TARGET_IDENTITY: AtomicU64 = AtomicU64::new(1);
+
+fn next_target_identity() -> u64 {
+    NEXT_TARGET_IDENTITY.fetch_add(1, Ordering::Relaxed)
+}
+
 pub struct DebugEngine {
     client: IDebugClient6,
     control: IDebugControl4,
@@ -158,6 +168,8 @@ pub struct DebugEngine {
     /// responsible for ending it on `Drop`. False when wrapping a borrowed WinDbg
     /// client, so going out of scope can't stop the host's active session.
     owns_session: bool,
+    /// Identifies the target this engine currently holds; see [`next_target_identity`].
+    target_identity: AtomicU64,
     /// Input buffers handed to DbgEng by a *deferred* call — `CreateProcessWide`, which
     /// spawns at the next `WaitForEvent` and reads the command line then, and the kernel
     /// connection string, whose link is likewise established during the wait.
@@ -254,6 +266,7 @@ impl DebugEngine {
             // Default to "borrowed": constructors that wrap an existing WinDbg client
             // go through here, and only `new()` (which calls `DebugCreate`) sets this.
             owns_session: false,
+            target_identity: AtomicU64::new(next_target_identity()),
             deferred_inputs: Mutex::new(Vec::new()),
         }
     }
@@ -284,8 +297,18 @@ impl DebugEngine {
             dataspaces,
             symbols,
             owns_session: false,
+            target_identity: AtomicU64::new(next_target_identity()),
             deferred_inputs: Mutex::new(Vec::new()),
         })
+    }
+
+    /// A value that identifies the target this engine currently holds.
+    ///
+    /// Changes when the engine is replaced *or* when it releases its target, so a cache
+    /// keyed on it cannot serve data gathered from a previous target. The kernel base is
+    /// not sufficient on its own: two dumps from the same boot share it.
+    pub fn target_identity(&self) -> u64 {
+        self.target_identity.load(Ordering::Acquire)
     }
 
     pub fn read_memory(&self, address: u64, size: usize) -> Result<Vec<u8>, DbgEngError> {
@@ -1193,6 +1216,10 @@ impl DebugEngine {
     /// Ends the current debug session without destroying the client, so it can be
     /// reused for another target.
     pub fn end_session(&self) -> Result<(), DbgEngError> {
+        // The target is going away, so anything cached against it must not be reused for
+        // whatever this engine holds next.
+        self.target_identity
+            .store(next_target_identity(), Ordering::Release);
         // A live kernel left halted (at a break) and detached *passively* stays FROZEN —
         // one CPU halted, the rest spinning — because a passive detach never tells the
         // target to run. Resume it and actively detach instead, leaving it running.

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -155,14 +155,6 @@ pub struct RunToResult {
 /// process, so per-engine identity plus a bump on release covers every case.
 static NEXT_TARGET_IDENTITY: AtomicU64 = AtomicU64::new(1);
 
-/// The identity every *borrowed* engine shares.
-///
-/// A borrowed WinDbg client is wrapped afresh for each extension command, so giving each
-/// wrapper its own identity would miss the caches on every invocation — repeating the full
-/// pool walk and leaking a layout entry each time. Those hosts deliver session
-/// notifications instead, which is what invalidates their caches.
-const BORROWED_TARGET_IDENTITY: u64 = 0;
-
 fn next_target_identity() -> u64 {
     NEXT_TARGET_IDENTITY.fetch_add(1, Ordering::Relaxed)
 }
@@ -271,6 +263,11 @@ impl DebugEngine {
             .cast::<IDebugSymbols3>()
             .expect("[-] Failed to get debug symbols interface");
 
+        // Derived from the client rather than a counter: a borrowed engine is wrapped
+        // afresh per extension command, so a per-wrapper counter would miss the caches
+        // every time — while a shared constant would collide across two programmatic
+        // hosts holding unrelated targets that happen to share a kernel base.
+        let identity = client.as_raw() as u64;
         Self {
             client,
             control,
@@ -279,7 +276,7 @@ impl DebugEngine {
             // Default to "borrowed": constructors that wrap an existing WinDbg client
             // go through here, and only `new()` (which calls `DebugCreate`) sets this.
             owns_session: false,
-            target_identity: AtomicU64::new(BORROWED_TARGET_IDENTITY),
+            target_identity: AtomicU64::new(identity),
             deferred_inputs: Mutex::new(Vec::new()),
         }
     }
@@ -304,13 +301,14 @@ impl DebugEngine {
                 operation: "querying IDebugSymbols3".into(),
                 source,
             })?;
+        let identity = client.as_raw() as u64;
         Ok(Self {
             client,
             control,
             dataspaces,
             symbols,
             owns_session: false,
-            target_identity: AtomicU64::new(BORROWED_TARGET_IDENTITY),
+            target_identity: AtomicU64::new(identity),
             deferred_inputs: Mutex::new(Vec::new()),
         })
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -10,13 +10,15 @@ pub(crate) mod layout;
 pub(crate) mod render;
 pub(crate) mod snapshot;
 
+pub mod query;
+
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
 
 /// Exact allocator identity.  Values are deliberately not collapsed into just
 /// paged/nonpaged because crossing one of these boundaries creates false holes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum PoolKind {
+pub enum PoolKind {
     NonPagedExecutable,
     NonPagedNx,
     Paged,
@@ -28,7 +30,7 @@ pub(crate) enum PoolKind {
 }
 
 impl PoolKind {
-    pub(crate) fn is_paged(self) -> bool {
+    pub fn is_paged(self) -> bool {
         matches!(
             self,
             Self::Paged | Self::PrototypePaged | Self::SpecialPaged | Self::SpecialPrototypePaged
@@ -37,7 +39,7 @@ impl PoolKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum PoolBackend {
+pub enum PoolBackend {
     Lfh,
     Vs,
     Segment,
@@ -45,7 +47,7 @@ pub(crate) enum PoolBackend {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum PoolState {
+pub enum PoolState {
     Allocated,
     ReusableFree,
     CachedFree,
@@ -53,14 +55,14 @@ pub(crate) enum PoolState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) struct HeapIdentity {
+pub struct HeapIdentity {
     pub pool_state: u64,
     pub heap: u64,
     pub special: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PoolSpan {
+pub struct PoolSpan {
     pub header_address: u64,
     pub usable_address: u64,
     pub size: u64,
@@ -76,11 +78,11 @@ pub(crate) struct PoolSpan {
 }
 
 impl PoolSpan {
-    pub(crate) fn end(&self) -> u64 {
+    pub fn end(&self) -> u64 {
         self.usable_address.saturating_add(self.size)
     }
 
-    pub(crate) fn contains_address(&self, address: u64) -> bool {
+    pub fn contains_address(&self, address: u64) -> bool {
         address >= self.header_address && address < self.end()
     }
 

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -388,7 +388,7 @@ mod tests {
     /// must authenticate, or the walk rejects every segment on one build family or the
     /// other and reports an empty pool instead of an error.
     #[test]
-    fn page_segment_signature_accepts_both_build_families() {
+    fn test_page_segment_signature_accepts_both_build_families() {
         let segment = 0xffff_8c8f_0d60_0000;
         let context = 0xffff_8c8f_0d10_0140;
         let heap_key = 0x44c4_da45_347b_5d48;

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -96,13 +96,27 @@ pub(crate) fn decode_descriptor_at(
     decode_descriptor(unit_size | (flags << 24))
 }
 
+/// Whether a `_HEAP_PAGE_SEGMENT.Signature` authenticates the segment.
+///
+/// Two mixes exist in the wild and both are accepted, because rejecting a segment is not a
+/// soft failure — it discards every chunk inside it, and rejecting *all* segments makes the
+/// walk quietly return an empty pool:
+///
+/// * older builds fold [`PAGE_SEGMENT_SIGNATURE`] into the mix;
+/// * **Windows 26100** dropped it, leaving `segment ^ context ^ heap_key`.
+///
+/// Accepting either is safe: both are exact 64-bit comparisons against values derived from
+/// the segment's own address and the per-boot heap key, so a false accept is not a practical
+/// risk. Verified on Server 26100.32995, where two independent segments matched the
+/// constant-free form exactly and the constant-bearing form not at all.
 pub(crate) fn valid_page_segment_signature(
     signature: u64,
     segment: u64,
     context: u64,
     heap_key: u64,
 ) -> bool {
-    signature == segment ^ context ^ heap_key ^ PAGE_SEGMENT_SIGNATURE
+    let mixed = segment ^ context ^ heap_key;
+    signature == mixed ^ PAGE_SEGMENT_SIGNATURE || signature == mixed
 }
 
 pub(crate) fn valid_descriptor_tree_signature(signature: u32) -> bool {
@@ -368,6 +382,37 @@ mod tests {
                 .pool_index,
             3
         );
+    }
+
+    /// Windows 26100 dropped the constant from the page-segment signature mix. Both forms
+    /// must authenticate, or the walk rejects every segment on one build family or the
+    /// other and reports an empty pool instead of an error.
+    #[test]
+    fn page_segment_signature_accepts_both_build_families() {
+        let segment = 0xffff_8c8f_0d60_0000;
+        let context = 0xffff_8c8f_0d10_0140;
+        let heap_key = 0x44c4_da45_347b_5d48;
+        let mixed = segment ^ context ^ heap_key;
+
+        // Pre-26100: the constant is folded in.
+        assert!(valid_page_segment_signature(
+            mixed ^ PAGE_SEGMENT_SIGNATURE,
+            segment,
+            context,
+            heap_key
+        ));
+        // 26100: it is not. These are the real values read off Server 26100.32995.
+        assert_eq!(mixed, 0x44c4_da45_340b_5c08);
+        assert!(valid_page_segment_signature(
+            mixed, segment, context, heap_key
+        ));
+        // Anything else is still rejected.
+        assert!(!valid_page_segment_signature(
+            mixed ^ 1,
+            segment,
+            context,
+            heap_key
+        ));
     }
 
     #[test]

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -24,6 +24,11 @@ pub(crate) struct PoolIndex {
     pub spans: Vec<PoolSpan>,
     pub postings: HashMap<u32, Vec<usize>>,
     pub diagnostics: Vec<String>,
+    /// Whether the walk covered everything it set out to. Carried through from
+    /// [`PoolSnapshot`] because a walk can end incomplete *without* emitting a
+    /// diagnostic — `walk_vs` clears it when a readable region stops mid-chunk — and a
+    /// caller that sees only counts and diagnostics would read that as a healthy result.
+    pub complete: bool,
     row_postings: HashMap<RowIdentity, Vec<usize>>,
     span_rows: Vec<RowIdentity>,
 }
@@ -71,6 +76,7 @@ impl PoolIndex {
             spans: snapshot.spans,
             postings,
             diagnostics: snapshot.diagnostics,
+            complete: snapshot.complete,
             row_postings,
             span_rows,
         }
@@ -168,7 +174,11 @@ impl PoolIndex {
 
 #[derive(Debug, Clone)]
 struct CachedSnapshot {
-    session: u64,
+    /// The full target identity, not just the generation counter. The generation alone
+    /// is only bumped by debugger session notifications, which a purely programmatic
+    /// host never receives — so a snapshot taken against one target could otherwise be
+    /// handed back for another, silently describing memory that no longer exists.
+    key: super::layout::SessionKey,
     index: PoolIndex,
 }
 
@@ -180,7 +190,7 @@ pub(crate) struct SnapshotCache {
 impl SnapshotCache {
     pub(crate) fn get_or_refresh<F>(
         &self,
-        session: u64,
+        key: super::layout::SessionKey,
         refresh: bool,
         build: F,
     ) -> Result<PoolIndex, String>
@@ -194,7 +204,7 @@ impl SnapshotCache {
         }
         if !refresh
             && let Some(cached) = self.entry.lock().unwrap().as_ref()
-            && cached.session == session
+            && cached.key == key
         {
             return Ok(cached.index.clone());
         }
@@ -203,7 +213,7 @@ impl SnapshotCache {
         let index = PoolIndex::build(snapshot);
         if complete {
             *self.entry.lock().unwrap() = Some(CachedSnapshot {
-                session,
+                key,
                 index: index.clone(),
             });
         } else {
@@ -281,20 +291,26 @@ mod tests {
         assert_eq!(contextual.context_for_tag(tag), vec![0, 1, 2, 3, 4]);
         assert_eq!(contextual.successor(2), None);
 
+        // Distinct targets, not just distinct generations: the cache keys on the whole
+        // SessionKey so a snapshot cannot outlive the target it described.
+        let session = |value: u64| super::super::layout::SessionKey {
+            kernel_base: 0x1000,
+            session: value,
+        };
         let cache = SnapshotCache::default();
         let builds = AtomicUsize::new(0);
         let make = || {
             builds.fetch_add(1, Ordering::SeqCst);
             Ok(snapshot.clone())
         };
-        cache.get_or_refresh(7, false, make).unwrap();
-        cache.get_or_refresh(7, false, make).unwrap();
+        cache.get_or_refresh(session(7), false, make).unwrap();
+        cache.get_or_refresh(session(7), false, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 1);
-        cache.get_or_refresh(7, true, make).unwrap();
+        cache.get_or_refresh(session(7), true, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 2);
         cache.invalidate();
-        cache.get_or_refresh(7, false, make).unwrap();
-        cache.get_or_refresh(8, false, make).unwrap();
+        cache.get_or_refresh(session(7), false, make).unwrap();
+        cache.get_or_refresh(session(8), false, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 4);
 
         let incomplete_builds = AtomicUsize::new(0);
@@ -305,20 +321,26 @@ mod tests {
             Ok(value)
         };
         cache.invalidate();
-        cache.get_or_refresh(9, false, make_incomplete).unwrap();
-        cache.get_or_refresh(9, false, make_incomplete).unwrap();
+        cache
+            .get_or_refresh(session(9), false, make_incomplete)
+            .unwrap();
+        cache
+            .get_or_refresh(session(9), false, make_incomplete)
+            .unwrap();
         assert_eq!(incomplete_builds.load(Ordering::SeqCst), 2);
 
         cache.invalidate();
-        cache.get_or_refresh(10, false, make).unwrap();
-        cache.get_or_refresh(10, true, make_incomplete).unwrap();
-        cache.get_or_refresh(10, false, make).unwrap();
+        cache.get_or_refresh(session(10), false, make).unwrap();
+        cache
+            .get_or_refresh(session(10), true, make_incomplete)
+            .unwrap();
+        cache.get_or_refresh(session(10), false, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 6);
         assert_eq!(incomplete_builds.load(Ordering::SeqCst), 3);
 
-        let failed_refresh = cache.get_or_refresh(10, true, || Err("interrupted".into()));
+        let failed_refresh = cache.get_or_refresh(session(10), true, || Err("interrupted".into()));
         assert_eq!(failed_refresh.unwrap_err(), "interrupted");
-        cache.get_or_refresh(10, false, make).unwrap();
+        cache.get_or_refresh(session(10), false, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 7);
     }
 }

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -296,6 +296,7 @@ mod tests {
         let session = |value: u64| super::super::layout::SessionKey {
             kernel_base: 0x1000,
             session: value,
+            target: 1,
         };
         let cache = SnapshotCache::default();
         let builds = AtomicUsize::new(0);
@@ -342,5 +343,18 @@ mod tests {
         assert_eq!(failed_refresh.unwrap_err(), "interrupted");
         cache.get_or_refresh(session(10), false, make).unwrap();
         assert_eq!(builds.load(Ordering::SeqCst), 7);
+        // Two targets sharing a kernel base *and* generation — two dumps from one boot,
+        // or a restarted session — must not share a cached snapshot. Nothing bumps the
+        // generation for a purely programmatic host, so the target identity is the only
+        // thing that tells them apart.
+        cache.invalidate();
+        let same_base = |target: u64| super::super::layout::SessionKey {
+            kernel_base: 0x1000,
+            session: 1,
+            target,
+        };
+        cache.get_or_refresh(same_base(100), false, make).unwrap();
+        cache.get_or_refresh(same_base(101), false, make).unwrap();
+        assert_eq!(builds.load(Ordering::SeqCst), 9);
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -106,12 +106,13 @@ const TYPES: &[TypeSpec] = &[
             ("TreeSignature", &["TreeSignature"]),
         ],
     },
+    // Deliberately no *required* fields. The VS free-chunk state lives inside this
+    // struct on older builds, and from Windows 26100 it moved into a separately
+    // addressed _HEAP_VS_AFFINITY_SLOT. Both shapes are resolved optionally below;
+    // requiring either one here would refuse to walk half the world.
     TypeSpec {
         name: "_HEAP_VS_CONTEXT",
-        fields: &[
-            ("FreeChunkTree", &["FreeChunkTree"]),
-            ("DelayFreeContext", &["DelayFreeContext"]),
-        ],
+        fields: &[],
     },
     TypeSpec {
         name: "_HEAP_VS_DELAY_FREE_CONTEXT",
@@ -174,6 +175,22 @@ const TYPES: &[TypeSpec] = &[
 ];
 
 const OPTIONAL_TYPES: &[TypeSpec] = &[
+    // Windows 26100+: the VS free-chunk tree, subsegment list and delay-free list moved
+    // out of _HEAP_VS_CONTEXT into one of these per-affinity slots. Absent on older
+    // builds, where the same state is inline in the context.
+    TypeSpec {
+        name: "_HEAP_VS_AFFINITY_SLOT",
+        fields: &[
+            ("VsContext", &["VsContext"]),
+            ("FreeChunkTree", &["FreeChunkTree"]),
+            ("DelayFreeContext", &["DelayFreeContext"]),
+        ],
+    },
+    // One entry per affinity; SlotRef locates the slot itself.
+    TypeSpec {
+        name: "_HEAP_VS_SLOT_MAP",
+        fields: &[("SlotRef", &["SlotRef"])],
+    },
     TypeSpec {
         name: "_RTL_DYNAMIC_LOOKASIDE",
         fields: &[("BucketCount", &["BucketCount"]), ("Buckets", &["Buckets"])],
@@ -214,6 +231,17 @@ const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
         &["AffinitySlots", "AffinitizedInfoArrays"],
     ),
     ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
+    // Legacy (pre-26100) in-context VS state.
+    ("_HEAP_VS_CONTEXT", "FreeChunkTree", &["FreeChunkTree"]),
+    (
+        "_HEAP_VS_CONTEXT",
+        "DelayFreeContext",
+        &["DelayFreeContext"],
+    ),
+    // 26100+: locate the affinity slots. Both are self-relative to the VS context and
+    // scaled by 64 bytes; the slot map holds AffinityMask + 1 entries.
+    ("_HEAP_VS_CONTEXT", "SlotMapRef", &["SlotMapRef"]),
+    ("_HEAP_VS_CONTEXT", "AffinityMask", &["AffinityMask"]),
 ];
 
 const GLOBALS: &[(&str, &[&str])] = &[

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -10,6 +10,10 @@ use crate::dbgeng::{DbgEngError, DebugEngine};
 pub(crate) struct SessionKey {
     pub kernel_base: u64,
     pub session: u64,
+    /// Which target this is, from [crate::dbgeng::DebugEngine::target_identity].
+    /// The kernel base does not distinguish two dumps from the same boot, and the
+    /// generation only moves on debugger notifications a programmatic host never gets.
+    pub target: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -490,6 +494,7 @@ mod tests {
         SessionKey {
             kernel_base: 0xffff_f800_0000_0000,
             session: 7,
+            target: 1,
         }
     }
 

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -191,6 +191,7 @@ pub(crate) fn prepare_index(
     let key = SessionKey {
         kernel_base: engine.kernel_base()?,
         session: generation(),
+        target: engine.target_identity(),
     };
     let layout = LayoutCache::global()
         .get_or_resolve(engine, key)
@@ -262,20 +263,28 @@ fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood
         .spans
         .iter()
         .position(|span| span.contains_address(address))?;
-    // Use the index's own adjacency rather than "the next entry in the vector": matching
-    // only the heap would report a span from a different backend, a different subsegment,
-    // or across unreadable space as though it bordered this chunk. It does not, and for
-    // grooming analysis that is exactly the wrong thing to be told.
+    // Two conditions, and both are needed. `predecessor`/`successor` enforce allocator
+    // identity — same heap, backend and subsegment, neither side unreadable — which a bare
+    // "next entry in the vector" check does not.
+    //
+    // On top of that the spans must actually touch. The allocator leaves slack wherever a
+    // block would straddle a page, and `walk_lfh` omits that slot, so two spans can pass
+    // the identity check with a gap between them. Reporting those as bordering would
+    // misstate the very geometry this API exists to describe.
+    let chunk = index.spans[position].clone();
+    let touching = |left: &PoolSpan, right: &PoolSpan| left.end() == right.header_address;
     Some(PoolNeighbourhood {
         previous: index
             .predecessor(position)
             .and_then(|previous| index.spans.get(previous))
+            .filter(|previous| touching(previous, &chunk))
             .cloned(),
         next: index
             .successor(position)
             .and_then(|next| index.spans.get(next))
+            .filter(|next| touching(&chunk, next))
             .cloned(),
-        chunk: index.spans[position].clone(),
+        chunk,
     })
 }
 
@@ -428,6 +437,24 @@ mod tests {
         assert_eq!(found.chunk.display_tag, "Bbbb");
         assert_eq!(found.previous.unwrap().display_tag, "Aaaa");
         assert_eq!(found.next.unwrap().display_tag, "Cccc");
+    }
+
+    /// Allocator slack separates these two: `walk_lfh` omits a slot that would straddle a
+    /// page, so spans can share every allocator identity and still not touch. Reporting
+    /// them as bordering would misstate the grooming geometry this API exists to describe.
+    #[test]
+    fn test_neighbours_must_actually_touch() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
+            // 0x1100..0x1200 is slack the allocator skipped.
+            allocation(0x1200, 0x100, b"Bbbb", PoolKind::NonPagedNx, 1),
+        ]);
+        let found = neighbourhood_at(&index, 0x1250).expect("address is covered");
+        assert_eq!(found.chunk.display_tag, "Bbbb");
+        assert!(
+            found.previous.is_none(),
+            "slack between spans must not count as bordering"
+        );
     }
 
     #[test]

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -1,0 +1,491 @@
+//! Public, typed queries over the pool walker.
+//!
+//! The walker itself is reached two ways: interactively through the
+//! `!win_kexp.poolmap` extension command, and programmatically through this module
+//! by a host that already owns a [`DebugEngine`] (windbg-mcp does exactly that).
+//! Both go through [`prepare_index`], so the validation rules, the layout cache and
+//! the snapshot cache cannot drift apart between the two entry points.
+//!
+//! Everything here returns typed values — [`PoolSpan`]s, not rendered text — because
+//! the programmatic caller re-serializes them (as JSON, say) and scraping the DML the
+//! extension prints would be lossy and brittle.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use thiserror::Error;
+use windows::Win32::System::Diagnostics::Debug::Extensions::{
+    DEBUG_STATUS_BREAK, DEBUG_STATUS_NO_DEBUGGEE,
+};
+
+use super::decode::parse_tag;
+use super::index::{PoolIndex, SnapshotCache};
+use super::layout::{LayoutCache, SessionKey};
+use super::snapshot::SnapshotWalker;
+use super::{PoolSpan, PoolState};
+use crate::dbgeng::{DbgEngError, DebugEngine};
+
+const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
+
+/// Bumped whenever the debugger tells us the session changed, and whenever a caller
+/// forces a refresh. Both caches key on it, so a stale walk can never outlive the
+/// target it described.
+static SESSION_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn generation() -> u64 {
+    SESSION_GENERATION.load(Ordering::Acquire)
+}
+
+/// Invalidate every cached view. Called on debugger session transitions.
+pub(crate) fn bump_generation() {
+    SESSION_GENERATION.fetch_add(1, Ordering::AcqRel);
+}
+
+pub(crate) fn snapshots() -> &'static SnapshotCache {
+    static CACHE: std::sync::OnceLock<SnapshotCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(SnapshotCache::default)
+}
+
+/// Drop every cached view of the target: the generation, the snapshot and the layout.
+///
+/// Called when the debugger reports a session transition. Both the extension command
+/// and the programmatic API read through these caches, so this has to clear all three
+/// together — keeping a layout resolved against a kernel base that has since changed
+/// would silently mis-decode every header.
+pub(crate) fn invalidate_session() {
+    bump_generation();
+    snapshots().invalidate();
+    LayoutCache::global().invalidate();
+}
+
+/// Why a pool query could not be answered.
+///
+/// These are deliberately distinct variants rather than one string: a caller needs to
+/// tell "you are pointed at the wrong kind of target" (never going to work) from
+/// "the target is running" (break in and retry).
+#[derive(Debug, Error)]
+pub enum PoolQueryError {
+    #[error("pool queries require a kernel target")]
+    NotKernelTarget,
+
+    #[error("no accessible target is attached")]
+    NoDebuggee,
+
+    #[error("target is running; break in before taking a pool snapshot")]
+    TargetRunning,
+
+    #[error("pool walking supports x64 targets only (machine {machine:#x})")]
+    UnsupportedArchitecture { machine: u32 },
+
+    #[error("tag must contain 1..4 ASCII bytes")]
+    InvalidTag,
+
+    #[error("resolving pool layout failed: {0}")]
+    Layout(String),
+
+    #[error("walking the pool failed: {0}")]
+    Walk(String),
+
+    #[error(transparent)]
+    Engine(#[from] DbgEngError),
+}
+
+/// Restrict results to one side of the paged/nonpaged split.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolPageFilter {
+    Paged,
+    NonPaged,
+}
+
+/// A chunk plus the allocations either side of it.
+///
+/// The neighbours are the point: judging a use-after-free or a grooming attempt means
+/// asking what now sits where the victim used to, and what borders it.
+#[derive(Debug, Clone)]
+pub struct PoolNeighbourhood {
+    pub chunk: PoolSpan,
+    pub previous: Option<PoolSpan>,
+    pub next: Option<PoolSpan>,
+}
+
+/// Coarse totals for a snapshot, for callers that want a census rather than a list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolTagSummary {
+    pub display_tag: String,
+    pub raw_tag: u32,
+    pub allocations: usize,
+    pub total_bytes: u64,
+    pub paged_allocations: usize,
+    pub nonpaged_allocations: usize,
+}
+
+/// What the walk itself managed, independent of any particular query.
+///
+/// Exists so an empty answer can say *why* it is empty. A caller that asked for a tag and
+/// got nothing needs to distinguish "the pool genuinely holds no such chunk" from "the walk
+/// reached almost none of the pool" — those look identical without the walk's own diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolSnapshotReport {
+    pub total_chunks: usize,
+    pub allocated_chunks: usize,
+    pub diagnostics: Vec<String>,
+}
+
+/// Summarises the cached snapshot: how much was walked, and what the walk could not do.
+pub fn snapshot_report(
+    engine: &DebugEngine,
+    refresh: bool,
+) -> Result<PoolSnapshotReport, PoolQueryError> {
+    let index = prepare_index(engine, refresh)?;
+    Ok(report_of(&index))
+}
+
+fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
+    PoolSnapshotReport {
+        total_chunks: index.spans.len(),
+        allocated_chunks: index
+            .spans
+            .iter()
+            .filter(|span| span.state == PoolState::Allocated)
+            .count(),
+        diagnostics: index.diagnostics.clone(),
+    }
+}
+
+/// Validate the target, resolve the layout, and take (or reuse) a pool snapshot.
+///
+/// `refresh` forces a fresh walk; otherwise a snapshot cached for this session is
+/// reused, because walking every pool page is far too expensive to repeat per query.
+pub(crate) fn prepare_index(
+    engine: &DebugEngine,
+    refresh: bool,
+) -> Result<PoolIndex, PoolQueryError> {
+    if !engine.is_kernel_target()? {
+        return Err(PoolQueryError::NotKernelTarget);
+    }
+    let status = engine.execution_status()?;
+    if status == DEBUG_STATUS_NO_DEBUGGEE {
+        return Err(PoolQueryError::NoDebuggee);
+    }
+    if status != DEBUG_STATUS_BREAK {
+        return Err(PoolQueryError::TargetRunning);
+    }
+    let machine = engine.processor_type()?;
+    if machine != IMAGE_FILE_MACHINE_AMD64 {
+        return Err(PoolQueryError::UnsupportedArchitecture { machine });
+    }
+
+    if refresh {
+        bump_generation();
+    }
+    let session = generation();
+    let key = SessionKey {
+        kernel_base: engine.kernel_base()?,
+        session,
+    };
+    let layout = LayoutCache::global()
+        .get_or_resolve(engine, key)
+        .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
+
+    snapshots()
+        .get_or_refresh(session, refresh, || {
+            SnapshotWalker {
+                memory: engine,
+                layout: &layout,
+                traversal_limit: 1_000_000,
+            }
+            .walk()
+            .map_err(|error| error.to_string())
+        })
+        .map_err(PoolQueryError::Walk)
+}
+
+/// Every *allocated* chunk carrying `tag` (1..4 ASCII bytes, e.g. `"Tgsm"`).
+///
+/// Only allocated chunks are indexed by tag: a freed chunk's tag is not reliably
+/// preserved by the allocator, so returning "freed chunks with this tag" would be
+/// inventing information. Use [`chunk_at`] to ask about a specific freed address.
+pub fn find_tag(
+    engine: &DebugEngine,
+    tag: &str,
+    filter: Option<PoolPageFilter>,
+    refresh: bool,
+) -> Result<Vec<PoolSpan>, PoolQueryError> {
+    let raw_tag = parse_tag(tag).ok_or(PoolQueryError::InvalidTag)?;
+    let index = prepare_index(engine, refresh)?;
+    Ok(collect_tag(&index, raw_tag, filter))
+}
+
+fn collect_tag(index: &PoolIndex, raw_tag: u32, filter: Option<PoolPageFilter>) -> Vec<PoolSpan> {
+    index
+        .postings
+        .get(&raw_tag)
+        .into_iter()
+        .flatten()
+        .filter_map(|&position| index.spans.get(position))
+        .filter(|span| match filter {
+            None => true,
+            Some(PoolPageFilter::Paged) => span.pool_kind.is_paged(),
+            Some(PoolPageFilter::NonPaged) => !span.pool_kind.is_paged(),
+        })
+        .cloned()
+        .collect()
+}
+
+/// The chunk containing `address`, with its immediate neighbours.
+///
+/// `Ok(None)` means the address is not covered by the snapshot at all — a different
+/// answer from "it is a free hole", which comes back as a chunk whose
+/// [`PoolState`] is not `Allocated`.
+pub fn chunk_at(
+    engine: &DebugEngine,
+    address: u64,
+    refresh: bool,
+) -> Result<Option<PoolNeighbourhood>, PoolQueryError> {
+    let index = prepare_index(engine, refresh)?;
+    Ok(neighbourhood_at(&index, address))
+}
+
+fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood> {
+    let position = index
+        .spans
+        .iter()
+        .position(|span| span.contains_address(address))?;
+    // Neighbours are only meaningful within the same heap; spans are sorted by
+    // (heap, address), so a differing heap means we walked off the end of this one.
+    let chunk = index.spans[position].clone();
+    let same_heap = |candidate: &PoolSpan| candidate.heap == chunk.heap;
+    Some(PoolNeighbourhood {
+        previous: position
+            .checked_sub(1)
+            .and_then(|prev| index.spans.get(prev))
+            .filter(|span| same_heap(span))
+            .cloned(),
+        next: index
+            .spans
+            .get(position + 1)
+            .filter(|span| same_heap(span))
+            .cloned(),
+        chunk,
+    })
+}
+
+/// A per-tag census of the snapshot, heaviest consumer first.
+///
+/// This is the structured answer to the question `!poolused` renders as text, but
+/// taken from our own walk, so it stays consistent with [`find_tag`] and [`chunk_at`].
+pub fn tag_census(
+    engine: &DebugEngine,
+    refresh: bool,
+) -> Result<Vec<PoolTagSummary>, PoolQueryError> {
+    let index = prepare_index(engine, refresh)?;
+    Ok(summarize_tags(&index))
+}
+
+fn summarize_tags(index: &PoolIndex) -> Vec<PoolTagSummary> {
+    let mut summaries: std::collections::HashMap<u32, PoolTagSummary> =
+        std::collections::HashMap::new();
+    for span in index
+        .spans
+        .iter()
+        .filter(|span| span.state == PoolState::Allocated)
+    {
+        let entry = summaries
+            .entry(span.raw_tag)
+            .or_insert_with(|| PoolTagSummary {
+                display_tag: span.display_tag.clone(),
+                raw_tag: span.raw_tag,
+                allocations: 0,
+                total_bytes: 0,
+                paged_allocations: 0,
+                nonpaged_allocations: 0,
+            });
+        entry.allocations += 1;
+        entry.total_bytes = entry.total_bytes.saturating_add(span.size);
+        if span.pool_kind.is_paged() {
+            entry.paged_allocations += 1;
+        } else {
+            entry.nonpaged_allocations += 1;
+        }
+    }
+    let mut census: Vec<_> = summaries.into_values().collect();
+    census.sort_by(|left, right| {
+        right
+            .total_bytes
+            .cmp(&left.total_bytes)
+            .then_with(|| left.display_tag.cmp(&right.display_tag))
+    });
+    census
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::{HeapIdentity, PoolBackend, PoolKind};
+
+    fn heap(id: u64) -> HeapIdentity {
+        HeapIdentity {
+            pool_state: id,
+            heap: id,
+            special: false,
+        }
+    }
+
+    fn index_of(spans: Vec<PoolSpan>) -> PoolIndex {
+        PoolIndex::build(crate::pool::PoolSnapshot {
+            spans,
+            diagnostics: Vec::new(),
+            complete: true,
+        })
+    }
+
+    fn allocation(
+        address: u64,
+        size: u64,
+        tag: &[u8; 4],
+        kind: PoolKind,
+        heap_id: u64,
+    ) -> PoolSpan {
+        PoolSpan::allocation(
+            address,
+            size,
+            u32::from_le_bytes(*tag),
+            kind,
+            heap(heap_id),
+            PoolBackend::Lfh,
+        )
+    }
+
+    #[test]
+    fn unsupported_architecture_names_the_machine() {
+        // The extension used to own this check; the message is load-bearing for the
+        // E_INVALIDARG/E_FAIL mapping, so pin it here now that it lives in the API.
+        assert_eq!(
+            PoolQueryError::UnsupportedArchitecture { machine: 0xaa64 }.to_string(),
+            "pool walking supports x64 targets only (machine 0xaa64)"
+        );
+    }
+
+    #[test]
+    fn find_tag_returns_only_matching_allocations() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+            allocation(0x2000, 0x40, b"Tfub", PoolKind::Paged, 1),
+            allocation(0x3000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+        ]);
+        let found = collect_tag(&index, u32::from_le_bytes(*b"Tgsm"), None);
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().all(|span| span.display_tag == "Tgsm"));
+    }
+
+    #[test]
+    fn page_filter_splits_paged_from_nonpaged() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x68, b"Tsst", PoolKind::NonPagedNx, 1),
+            allocation(0x2000, 0x40, b"Tsst", PoolKind::Paged, 1),
+        ]);
+        let raw = u32::from_le_bytes(*b"Tsst");
+        assert_eq!(
+            collect_tag(&index, raw, Some(PoolPageFilter::NonPaged)).len(),
+            1
+        );
+        assert_eq!(
+            collect_tag(&index, raw, Some(PoolPageFilter::Paged)).len(),
+            1
+        );
+        assert_eq!(collect_tag(&index, raw, None).len(), 2);
+    }
+
+    #[test]
+    fn unknown_tag_yields_no_matches() {
+        let index = index_of(vec![allocation(
+            0x1000,
+            0x68,
+            b"Tgsm",
+            PoolKind::NonPagedNx,
+            1,
+        )]);
+        assert!(collect_tag(&index, u32::from_le_bytes(*b"zzzz"), None).is_empty());
+    }
+
+    #[test]
+    fn chunk_lookup_reports_neighbours_within_one_heap() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
+            allocation(0x1100, 0x100, b"Bbbb", PoolKind::NonPagedNx, 1),
+            allocation(0x1200, 0x100, b"Cccc", PoolKind::NonPagedNx, 1),
+        ]);
+        let found = neighbourhood_at(&index, 0x1180).expect("address is covered");
+        assert_eq!(found.chunk.display_tag, "Bbbb");
+        assert_eq!(found.previous.unwrap().display_tag, "Aaaa");
+        assert_eq!(found.next.unwrap().display_tag, "Cccc");
+    }
+
+    #[test]
+    fn neighbours_do_not_cross_a_heap_boundary() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
+            allocation(0x1100, 0x100, b"Bbbb", PoolKind::NonPagedNx, 2),
+        ]);
+        // Spans sort by (heap, address), so these are adjacent in the vector but
+        // belong to different heaps — reporting them as neighbours would be a lie.
+        let found = neighbourhood_at(&index, 0x1150).expect("address is covered");
+        assert_eq!(found.chunk.display_tag, "Bbbb");
+        assert!(found.previous.is_none());
+    }
+
+    #[test]
+    fn address_outside_every_span_is_not_found() {
+        let index = index_of(vec![allocation(
+            0x1000,
+            0x100,
+            b"Aaaa",
+            PoolKind::NonPagedNx,
+            1,
+        )]);
+        assert!(neighbourhood_at(&index, 0x9999).is_none());
+    }
+
+    /// The case that motivated the report: a walk that reached nothing must still hand
+    /// back its reasons, or an empty result is indistinguishable from an empty pool.
+    #[test]
+    fn an_empty_walk_still_reports_why() {
+        let index = PoolIndex::build(crate::pool::PoolSnapshot {
+            spans: Vec::new(),
+            diagnostics: vec!["cannot read pool node 0 heap 2".into()],
+            complete: false,
+        });
+        let report = report_of(&index);
+        assert_eq!(report.total_chunks, 0);
+        assert_eq!(report.allocated_chunks, 0);
+        assert_eq!(report.diagnostics, vec!["cannot read pool node 0 heap 2"]);
+    }
+
+    #[test]
+    fn a_report_counts_allocated_separately_from_total() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+            allocation(0x1100, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+        ]);
+        let report = report_of(&index);
+        assert_eq!(report.total_chunks, 2);
+        assert_eq!(report.allocated_chunks, 2);
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn census_totals_by_tag_and_sorts_by_bytes() {
+        let index = index_of(vec![
+            allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+            allocation(0x1100, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
+            allocation(0x1200, 0x400, b"Tfub", PoolKind::Paged, 1),
+        ]);
+        let census = summarize_tags(&index);
+        assert_eq!(census[0].display_tag, "Tfub");
+        assert_eq!(census[0].total_bytes, 0x400);
+        assert_eq!(census[0].paged_allocations, 1);
+        assert_eq!(census[1].display_tag, "Tgsm");
+        assert_eq!(census[1].allocations, 2);
+        assert_eq!(census[1].total_bytes, 0xd0);
+        assert_eq!(census[1].nonpaged_allocations, 2);
+    }
+}

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_architecture_names_the_machine() {
+    fn test_unsupported_architecture_names_the_machine() {
         // The extension used to own this check; the message is load-bearing for the
         // E_INVALIDARG/E_FAIL mapping, so pin it here now that it lives in the API.
         assert_eq!(
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn find_tag_returns_only_matching_allocations() {
+    fn test_find_tag_returns_only_matching_allocations() {
         let index = index_of(vec![
             allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
             allocation(0x2000, 0x40, b"Tfub", PoolKind::Paged, 1),
@@ -378,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    fn page_filter_splits_paged_from_nonpaged() {
+    fn test_page_filter_splits_paged_from_nonpaged() {
         let index = index_of(vec![
             allocation(0x1000, 0x68, b"Tsst", PoolKind::NonPagedNx, 1),
             allocation(0x2000, 0x40, b"Tsst", PoolKind::Paged, 1),
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tag_yields_no_matches() {
+    fn test_unknown_tag_yields_no_matches() {
         let index = index_of(vec![allocation(
             0x1000,
             0x68,
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn chunk_lookup_reports_neighbours_within_one_heap() {
+    fn test_chunk_lookup_reports_neighbours_within_one_heap() {
         let index = index_of(vec![
             allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
             allocation(0x1100, 0x100, b"Bbbb", PoolKind::NonPagedNx, 1),
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn neighbours_do_not_cross_a_heap_boundary() {
+    fn test_neighbours_do_not_cross_a_heap_boundary() {
         let index = index_of(vec![
             allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
             allocation(0x1100, 0x100, b"Bbbb", PoolKind::NonPagedNx, 2),
@@ -434,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn address_outside_every_span_is_not_found() {
+    fn test_address_outside_every_span_is_not_found() {
         let index = index_of(vec![allocation(
             0x1000,
             0x100,
@@ -448,7 +448,7 @@ mod tests {
     /// The case that motivated the report: a walk that reached nothing must still hand
     /// back its reasons, or an empty result is indistinguishable from an empty pool.
     #[test]
-    fn an_empty_walk_still_reports_why() {
+    fn test_empty_walk_still_reports_why() {
         let index = PoolIndex::build(crate::pool::PoolSnapshot {
             spans: Vec::new(),
             diagnostics: vec!["cannot read pool node 0 heap 2".into()],
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn a_report_counts_allocated_separately_from_total() {
+    fn test_report_counts_allocated_separately_from_total() {
         let index = index_of(vec![
             allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
             allocation(0x1100, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn census_totals_by_tag_and_sorts_by_bytes() {
+    fn test_census_totals_by_tag_and_sorts_by_bytes() {
         let index = index_of(vec![
             allocation(0x1000, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),
             allocation(0x1100, 0x68, b"Tgsm", PoolKind::NonPagedNx, 1),

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -193,8 +193,12 @@ pub(crate) fn prepare_index(
         session: generation(),
         target: engine.target_identity(),
     };
+    // Layouts describe the *image*, not which target instance is loaded, so they are keyed
+    // without `target`. Including it inserted an entry per engine and per `end_session`
+    // that nothing ever pruned — the same unbounded growth removed above for `refresh`.
+    let layout_key = SessionKey { target: 0, ..key };
     let layout = LayoutCache::global()
-        .get_or_resolve(engine, key)
+        .get_or_resolve(engine, layout_key)
         .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
 
     // Keyed on the whole `SessionKey`: a programmatic host receives no session
@@ -272,7 +276,17 @@ fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood
     // the identity check with a gap between them. Reporting those as bordering would
     // misstate the very geometry this API exists to describe.
     let chunk = index.spans[position].clone();
-    let touching = |left: &PoolSpan, right: &PoolSpan| left.end() == right.header_address;
+    // Contiguity is only meaningful where `end()` and the next span's `header_address`
+    // measure the same boundary. LFH and Segment spans report `header_address ==
+    // usable_address`, so they do. A VS span carries a chunk header between the two, so the
+    // comparison is off by its width and would reject *every* genuine VS neighbour. The gap
+    // this guards against — a slot the allocator skipped because it would straddle a page —
+    // only arises in LFH, so restricting the check there loses nothing.
+    let touching = |left: &PoolSpan, right: &PoolSpan| {
+        let comparable = left.header_address == left.usable_address
+            && right.header_address == right.usable_address;
+        !comparable || left.end() == right.header_address
+    };
     Some(PoolNeighbourhood {
         previous: index
             .predecessor(position)

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -127,6 +127,12 @@ pub struct PoolTagSummary {
 pub struct PoolSnapshotReport {
     pub total_chunks: usize,
     pub allocated_chunks: usize,
+    /// Whether the walk covered everything it set out to.
+    ///
+    /// Not implied by an empty `diagnostics`: a walk can end incomplete without saying
+    /// anything — `walk_vs` clears it when a readable region stops mid-chunk. A caller
+    /// that wants to reject partial results has to consult this, not the diagnostics.
+    pub complete: bool,
     pub diagnostics: Vec<String>,
 }
 
@@ -147,6 +153,7 @@ fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
             .iter()
             .filter(|span| span.state == PoolState::Allocated)
             .count(),
+        complete: index.complete,
         diagnostics: index.diagnostics.clone(),
     }
 }
@@ -174,20 +181,25 @@ pub(crate) fn prepare_index(
         return Err(PoolQueryError::UnsupportedArchitecture { machine });
     }
 
-    if refresh {
-        bump_generation();
-    }
-    let session = generation();
+    // Deliberately *not* bumping the generation on refresh. The generation is part of
+    // `SessionKey`, which keys the layout cache — bumping it per refresh would re-resolve
+    // every PDB symbol and leak a fresh cache entry each time, so a long-lived host that
+    // refreshes regularly would accumulate layouts without bound and pay the symbol
+    // latency over and over. The snapshot cache takes `refresh` directly and invalidates
+    // itself; the generation only has to move when the *target* changes, which is what
+    // `invalidate_session` is for.
     let key = SessionKey {
         kernel_base: engine.kernel_base()?,
-        session,
+        session: generation(),
     };
     let layout = LayoutCache::global()
         .get_or_resolve(engine, key)
         .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
 
+    // Keyed on the whole `SessionKey`: a programmatic host receives no session
+    // notifications, so the generation alone would let a snapshot outlive its target.
     snapshots()
-        .get_or_refresh(session, refresh, || {
+        .get_or_refresh(key, refresh, || {
             SnapshotWalker {
                 memory: engine,
                 layout: &layout,
@@ -250,22 +262,20 @@ fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood
         .spans
         .iter()
         .position(|span| span.contains_address(address))?;
-    // Neighbours are only meaningful within the same heap; spans are sorted by
-    // (heap, address), so a differing heap means we walked off the end of this one.
-    let chunk = index.spans[position].clone();
-    let same_heap = |candidate: &PoolSpan| candidate.heap == chunk.heap;
+    // Use the index's own adjacency rather than "the next entry in the vector": matching
+    // only the heap would report a span from a different backend, a different subsegment,
+    // or across unreadable space as though it bordered this chunk. It does not, and for
+    // grooming analysis that is exactly the wrong thing to be told.
     Some(PoolNeighbourhood {
-        previous: position
-            .checked_sub(1)
-            .and_then(|prev| index.spans.get(prev))
-            .filter(|span| same_heap(span))
+        previous: index
+            .predecessor(position)
+            .and_then(|previous| index.spans.get(previous))
             .cloned(),
         next: index
-            .spans
-            .get(position + 1)
-            .filter(|span| same_heap(span))
+            .successor(position)
+            .and_then(|next| index.spans.get(next))
             .cloned(),
-        chunk,
+        chunk: index.spans[position].clone(),
     })
 }
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1302,6 +1302,16 @@ pub(crate) struct SnapshotWalker<'a, M> {
     pub traversal_limit: usize,
 }
 
+/// Where a special-pool block sits, and whether that could be corroborated.
+struct SpecialPlacement {
+    usable: u64,
+    size: u64,
+    /// The size could not be confirmed, so `size` is a conservative upper bound covering
+    /// the rest of the page rather than the allocation's real length. Callers must not
+    /// treat it as a measurement — it inflates byte totals if they do.
+    approximate: bool,
+}
+
 /// The byte Driver Verifier fills unused special-pool space with.
 const SPECIAL_POOL_FILL: u8 = 0xfd;
 
@@ -1330,7 +1340,7 @@ fn special_pool_placement(
     requested: u64,
     header_size: u64,
     page_bytes: &[u8],
-) -> (u64, u64) {
+) -> SpecialPlacement {
     let available = page_bytes.len() as u64;
     let aligned = requested.next_multiple_of(16);
     if requested != 0 && available == PAGE_SIZE && aligned + header_size <= PAGE_SIZE {
@@ -1339,10 +1349,18 @@ fn special_pool_placement(
             .iter()
             .all(|byte| *byte == SPECIAL_POOL_FILL)
         {
-            return (page + PAGE_SIZE - aligned, requested);
+            return SpecialPlacement {
+                usable: page + PAGE_SIZE - aligned,
+                size: requested,
+                approximate: false,
+            };
         }
     }
-    (page + header_size, available.saturating_sub(header_size))
+    SpecialPlacement {
+        usable: page + header_size,
+        size: available.saturating_sub(header_size),
+        approximate: true,
+    }
 }
 
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
@@ -1537,12 +1555,25 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             // An untagged page is not an allocation. Freed special-pool pages are
             // unmapped rather than zeroed, so anything readable here should carry a tag.
             if header.tag != 0 {
-                let (usable, size) = special_pool_placement(
+                let placement = special_pool_placement(
                     page,
                     u64::from(header.previous_size),
                     header_size,
                     page_bytes,
                 );
+                // Say so when the size is a bound rather than a measurement. Otherwise a
+                // conservative page-sized range is indistinguishable from a real
+                // allocation: `tag_census` would fold it into `total_bytes` — reporting a
+                // 0x68 block as 0xff0 — while the report still claimed to be complete.
+                if placement.approximate {
+                    snapshot.diagnostics.push(format!(
+                        "special-pool page {page:#x} tag `{}`: size not corroborated by the \
+                         fill pattern; reporting the rest of the page as an upper bound",
+                        super::decode::display_tag(header.tag)
+                    ));
+                    snapshot.complete = false;
+                }
+                let (usable, size) = (placement.usable, placement.size);
                 snapshot.spans.push(self.base_span(
                     region,
                     page,
@@ -1938,6 +1969,7 @@ mod tests {
             key: crate::pool::layout::SessionKey {
                 kernel_base: 0,
                 session: 1,
+                target: 1,
             },
             globals: HashMap::new(),
             types,
@@ -2020,6 +2052,7 @@ mod tests {
             key: crate::pool::layout::SessionKey {
                 kernel_base: 0,
                 session: 1,
+                target: 1,
             },
             globals: HashMap::new(),
             types: HashMap::new(),
@@ -2032,6 +2065,12 @@ mod tests {
     }
 
     const SPECIAL_PAGE: u64 = 0xffff_8c8f_13a0_2000;
+
+    /// `(usable, size, approximate)` — flattened so the assertions below stay readable and
+    /// so every case states whether the size was corroborated or merely bounded.
+    fn placed(placement: SpecialPlacement) -> (u64, u64, bool) {
+        (placement.usable, placement.size, placement.approximate)
+    }
 
     /// A special-pool page holding a block of `requested` bytes: header, then Verifier
     /// fill, then the block itself pushed against the page end.
@@ -2049,13 +2088,23 @@ mod tests {
     #[test]
     fn test_special_pool_block_is_pushed_against_the_page_end() {
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &special_page(0x68, 0x10)),
-            (SPECIAL_PAGE + 0xf90, 0x68)
+            placed(special_pool_placement(
+                SPECIAL_PAGE,
+                0x68,
+                0x10,
+                &special_page(0x68, 0x10)
+            )),
+            (SPECIAL_PAGE + 0xf90, 0x68, false)
         );
         // Already a multiple of 16: no rounding, block ends exactly at the page end.
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &special_page(0x40, 0x10)),
-            (SPECIAL_PAGE + 0xfc0, 0x40)
+            placed(special_pool_placement(
+                SPECIAL_PAGE,
+                0x40,
+                0x10,
+                &special_page(0x40, 0x10)
+            )),
+            (SPECIAL_PAGE + 0xfc0, 0x40, false)
         );
     }
 
@@ -2068,14 +2117,14 @@ mod tests {
         // The page really holds 0x140 bytes of data; the header claims 0x40.
         let page = special_page(0x140, 0x10);
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &page),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10),
+            placed(special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true),
             "a truncated PreviousSize must fall back, not report a block at the page end"
         );
         // Sanity: told the truth, the same page resolves precisely.
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x140, 0x10, &page),
-            (SPECIAL_PAGE + 0xec0, 0x140)
+            placed(special_pool_placement(SPECIAL_PAGE, 0x140, 0x10, &page)),
+            (SPECIAL_PAGE + 0xec0, 0x140, false)
         );
     }
 
@@ -2088,8 +2137,8 @@ mod tests {
         page[0x10..0x78].fill(0x41); // block immediately after the header
         page[0x78..].fill(SPECIAL_POOL_FILL); // fill trails it
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &page),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
+            placed(special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
         );
     }
 
@@ -2097,13 +2146,13 @@ mod tests {
     fn test_special_pool_falls_back_when_the_size_is_untrustworthy() {
         let page = special_page(0x68, 0x10);
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0, 0x10, &page),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
+            placed(special_pool_placement(SPECIAL_PAGE, 0, 0x10, &page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
         );
         // A request that cannot share the page with its own header is not believable.
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, PAGE_SIZE, 0x10, &page),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
+            placed(special_pool_placement(SPECIAL_PAGE, PAGE_SIZE, 0x10, &page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
         );
     }
 
@@ -2113,8 +2162,8 @@ mod tests {
     fn test_special_pool_fallback_respects_the_readable_length() {
         let partial = vec![SPECIAL_POOL_FILL; 0x200];
         assert_eq!(
-            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &partial),
-            (SPECIAL_PAGE + 0x10, 0x1f0)
+            placed(special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &partial)),
+            (SPECIAL_PAGE + 0x10, 0x1f0, true)
         );
     }
     use crate::pool::{
@@ -2493,6 +2542,7 @@ mod tests {
             key: SessionKey {
                 kernel_base: K,
                 session: 1,
+                target: 1,
             },
             globals: [
                 ("ExPoolState", STATE),

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1803,7 +1803,7 @@ mod tests {
     /// Server 26100. So the straddling slot must be skipped **silently** — it is ordinary
     /// layout, and reporting it once cost ~11.6k diagnostics on an idle machine.
     #[test]
-    fn a_page_straddling_lfh_slot_is_skipped_without_complaint() {
+    fn test_page_straddling_lfh_slot_is_skipped_without_complaint() {
         // Slot 0 at 0x1f80 spans 0x1f80..0x2080 and crosses; slot 1 at 0x2080 does not.
         let region = lfh_region(0x1f80, 0x100);
         let memory = FlatMemory::new(0x1f80, 0x200);
@@ -1950,7 +1950,7 @@ mod tests {
     /// Pre-26100: the tree is inline in the context, so there is exactly one root and no
     /// slot map is consulted at all.
     #[test]
-    fn vs_roots_reads_the_legacy_in_context_shape() {
+    fn test_vs_roots_reads_the_legacy_in_context_shape() {
         let memory = FlatMemory::new(VS_CONTEXT, 0x100);
         let mut diagnostics = Vec::new();
         let roots = vs_roots(&memory, &vs_layout(false), VS_CONTEXT, &mut diagnostics);
@@ -1963,7 +1963,7 @@ mod tests {
 
     /// 26100: `slot = VsContext + (SlotRef << 6)`, and entries routinely share a slot.
     #[test]
-    fn vs_roots_walks_the_affinity_slots_and_dedups_them() {
+    fn test_vs_roots_walks_the_affinity_slots_and_dedups_them() {
         let memory = affinity_fixture();
         let mut diagnostics = Vec::new();
         let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
@@ -1977,7 +1977,7 @@ mod tests {
     /// A slot whose back-pointer names a different context is not this context's slot.
     /// Trusting it would aim the tree walk at unrelated but readable memory.
     #[test]
-    fn vs_roots_rejects_a_slot_whose_back_pointer_disagrees() {
+    fn test_vs_roots_rejects_a_slot_whose_back_pointer_disagrees() {
         let memory = affinity_fixture();
         let mut diagnostics = Vec::new();
         let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
@@ -1988,7 +1988,7 @@ mod tests {
 
     /// A zero `SlotMapRef` would alias the context itself; refuse rather than walk it.
     #[test]
-    fn vs_roots_refuses_an_implausible_slot_map() {
+    fn test_vs_roots_refuses_an_implausible_slot_map() {
         let mut memory = affinity_fixture();
         memory.put_u16(VS_CONTEXT, 0);
         let mut diagnostics = Vec::new();
@@ -2001,7 +2001,7 @@ mod tests {
     /// Neither shape resolving is a reportable condition, not a silently empty walk — that
     /// ambiguity is exactly what made the 26100 breakage so hard to see.
     #[test]
-    fn vs_roots_reports_when_neither_shape_resolves() {
+    fn test_vs_roots_reports_when_neither_shape_resolves() {
         let memory = FlatMemory::new(VS_CONTEXT, 0x100);
         let layout = PoolLayout {
             key: crate::pool::layout::SessionKey {
@@ -2022,7 +2022,7 @@ mod tests {
     /// page+0xf90, not page+0xf98. Rounding the request up to 16 is what makes the
     /// difference, and getting it wrong reports an address 8 bytes into the block.
     #[test]
-    fn special_pool_block_is_pushed_against_the_page_end_with_16_byte_rounding() {
+    fn test_special_pool_block_is_pushed_against_the_page_end() {
         let page = 0xffff_8c8f_13a0_2000;
         assert_eq!(
             special_pool_placement(page, 0x68, 0x10, PAGE_SIZE),
@@ -2038,7 +2038,7 @@ mod tests {
     /// `PreviousSize` is 8 bits, so it cannot describe every legal special-pool block.
     /// When it is unusable the whole page is reported rather than a wrong sub-range.
     #[test]
-    fn special_pool_falls_back_to_the_page_when_the_size_is_untrustworthy() {
+    fn test_special_pool_falls_back_when_the_size_is_untrustworthy() {
         let page = 0xffff_8c8f_13a0_2000;
         assert_eq!(
             special_pool_placement(page, 0, 0x10, PAGE_SIZE),
@@ -2054,7 +2054,7 @@ mod tests {
     /// A partially readable page (the guard page truncates the read) must not report a
     /// size past what was actually read.
     #[test]
-    fn special_pool_fallback_respects_the_readable_length() {
+    fn test_special_pool_fallback_respects_the_readable_length() {
         let page = 0xffff_8c8f_13a0_2000;
         assert_eq!(
             special_pool_placement(page, 0, 0x10, 0x200),

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1555,7 +1555,19 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             let available = (bytes.len() - offset).min(PAGE_SIZE as usize);
             let page_bytes = &bytes[offset..offset + available];
             let Some(header) = decode_pool_header(bytes, offset, region.pool_header) else {
-                break;
+                // Special pool is page-granular: one undecodable page says nothing about
+                // the next, so stopping here would silently drop the rest of the region —
+                // and leaving `complete` set would cache that truncated result and re-serve
+                // it. Every other rejection path in this file reports and continues.
+                snapshot.diagnostics.push(format!(
+                    "special-pool page {page:#x}: pool header did not decode; page skipped"
+                ));
+                snapshot.complete = false;
+                let Some(next) = page.checked_add(PAGE_SIZE) else {
+                    break;
+                };
+                page = next;
+                continue;
             };
             // An untagged page is not an allocation. Freed special-pool pages are
             // unmapped rather than zeroed, so anything readable here should carry a tag.

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1302,29 +1302,47 @@ pub(crate) struct SnapshotWalker<'a, M> {
     pub traversal_limit: usize,
 }
 
+/// The byte Driver Verifier fills unused special-pool space with.
+const SPECIAL_POOL_FILL: u8 = 0xfd;
+
 /// Where a special-pool block sits inside its page, and how big it is.
 ///
-/// Free-standing because the 16-byte rounding is both the easiest part to get wrong and
-/// the only part worth pinning in a test: `PAGE_SIZE - size` puts the answer 8 bytes past
-/// the real block for a 0x68 allocation.
+/// Returns `(usable_address, size)`. The block is normally butted against the page end at
+/// `page + PAGE_SIZE - align_up(size, 16)`; the 16-byte rounding matters, since a plain
+/// `PAGE_SIZE - size` lands 8 bytes past the real block for a 0x68 allocation.
 ///
-/// Returns `(usable_address, size)`. The fallback — page-sized, starting after the header
-/// — is used whenever `requested` cannot be trusted, which is any time the 8-bit
-/// `PreviousSize` field cannot describe the block (zero, or too large for the page). An
-/// over-broad chunk still answers "was this freed, and which tag owned it"; a confidently
-/// wrong offset does not.
+/// The size comes from `_POOL_HEADER.PreviousSize`, which is **8 bits wide and so cannot
+/// describe every legal block**. A 0x140 allocation stores 0x40 there, and a bare range
+/// check cannot tell that from a genuine 0x40 — both fit the page comfortably. The
+/// placement is therefore corroborated against the fill: everything between the header and
+/// the block must be Verifier's `0xfd`. A truncated size puts the block too close to the
+/// page end, leaving real data where fill should be, and is rejected.
+///
+/// The same check declines rather than lies in the two other cases that break the
+/// assumption: a page read only in part (nothing corroborates the tail), and a
+/// start-aligned page (`nt!MmSpecialPoolCatchOverruns` clear), where the block sits
+/// against the *preceding* guard page instead.
+///
+/// The fallback reports the whole page after the header. An over-broad chunk still answers
+/// "was this freed, and which tag owned it"; a confidently wrong offset does not.
 fn special_pool_placement(
     page: u64,
     requested: u64,
     header_size: u64,
-    available: u64,
+    page_bytes: &[u8],
 ) -> (u64, u64) {
+    let available = page_bytes.len() as u64;
     let aligned = requested.next_multiple_of(16);
-    if requested != 0 && aligned + header_size <= PAGE_SIZE {
-        (page + PAGE_SIZE - aligned, requested)
-    } else {
-        (page + header_size, available.saturating_sub(header_size))
+    if requested != 0 && available == PAGE_SIZE && aligned + header_size <= PAGE_SIZE {
+        let start = (PAGE_SIZE - aligned) as usize;
+        if page_bytes[header_size as usize..start]
+            .iter()
+            .all(|byte| *byte == SPECIAL_POOL_FILL)
+        {
+            return (page + PAGE_SIZE - aligned, requested);
+        }
     }
+    (page + header_size, available.saturating_sub(header_size))
 }
 
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
@@ -1511,24 +1529,19 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             if offset >= bytes.len() {
                 break;
             }
-            let available = ((bytes.len() - offset) as u64).min(PAGE_SIZE);
+            let available = (bytes.len() - offset).min(PAGE_SIZE as usize);
+            let page_bytes = &bytes[offset..offset + available];
             let Some(header) = decode_pool_header(bytes, offset, region.pool_header) else {
                 break;
             };
             // An untagged page is not an allocation. Freed special-pool pages are
             // unmapped rather than zeroed, so anything readable here should carry a tag.
             if header.tag != 0 {
-                // `PreviousSize` carries the requested byte count, but it is only 8 bits
-                // wide, so it cannot describe an allocation of 0x100 bytes or more. When
-                // it does not yield a block that fits the page, report the whole page
-                // rather than a confidently wrong sub-range — an over-broad chunk still
-                // answers "was this freed, and what tag owned it", which is the question
-                // being asked, while a wrong offset quietly misleads.
                 let (usable, size) = special_pool_placement(
                     page,
                     u64::from(header.previous_size),
                     header_size,
-                    available,
+                    page_bytes,
                 );
                 snapshot.spans.push(self.base_span(
                     region,
@@ -2018,47 +2031,90 @@ mod tests {
         assert!(diagnostics[0].contains("neither the context nor an affinity slot"));
     }
 
+    const SPECIAL_PAGE: u64 = 0xffff_8c8f_13a0_2000;
+
+    /// A special-pool page holding a block of `requested` bytes: header, then Verifier
+    /// fill, then the block itself pushed against the page end.
+    fn special_page(requested: usize, header_size: usize) -> Vec<u8> {
+        let mut page = vec![0u8; PAGE_SIZE as usize];
+        let start = PAGE_SIZE as usize - requested.next_multiple_of(16);
+        page[header_size..start].fill(SPECIAL_POOL_FILL);
+        page[start..].fill(0x41);
+        page
+    }
+
     /// The real values read off Server 26100.32995: a 0x68 message in special pool sits at
     /// page+0xf90, not page+0xf98. Rounding the request up to 16 is what makes the
     /// difference, and getting it wrong reports an address 8 bytes into the block.
     #[test]
     fn test_special_pool_block_is_pushed_against_the_page_end() {
-        let page = 0xffff_8c8f_13a0_2000;
         assert_eq!(
-            special_pool_placement(page, 0x68, 0x10, PAGE_SIZE),
-            (page + 0xf90, 0x68)
+            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &special_page(0x68, 0x10)),
+            (SPECIAL_PAGE + 0xf90, 0x68)
         );
         // Already a multiple of 16: no rounding, block ends exactly at the page end.
         assert_eq!(
-            special_pool_placement(page, 0x40, 0x10, PAGE_SIZE),
-            (page + 0xfc0, 0x40)
+            special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &special_page(0x40, 0x10)),
+            (SPECIAL_PAGE + 0xfc0, 0x40)
         );
     }
 
-    /// `PreviousSize` is 8 bits, so it cannot describe every legal special-pool block.
-    /// When it is unusable the whole page is reported rather than a wrong sub-range.
+    /// The case a range check cannot catch: `PreviousSize` is 8 bits, so a 0x140 block
+    /// stores 0x40 there — a value that fits the page perfectly well and is indistinguishable
+    /// from a real 0x40 by size alone. Only the fill gives it away: placing a 0x40 block at
+    /// the page end would leave the real block's bytes sitting where fill should be.
+    #[test]
+    fn test_special_pool_detects_a_truncated_size_via_the_fill() {
+        // The page really holds 0x140 bytes of data; the header claims 0x40.
+        let page = special_page(0x140, 0x10);
+        assert_eq!(
+            special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &page),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10),
+            "a truncated PreviousSize must fall back, not report a block at the page end"
+        );
+        // Sanity: told the truth, the same page resolves precisely.
+        assert_eq!(
+            special_pool_placement(SPECIAL_PAGE, 0x140, 0x10, &page),
+            (SPECIAL_PAGE + 0xec0, 0x140)
+        );
+    }
+
+    /// A start-aligned page (`MmSpecialPoolCatchOverruns` clear) puts the block next to the
+    /// preceding guard page, so the end-of-page formula would be wrong. The fill check
+    /// declines instead of reporting a bogus address.
+    #[test]
+    fn test_special_pool_declines_a_start_aligned_page() {
+        let mut page = vec![0u8; PAGE_SIZE as usize];
+        page[0x10..0x78].fill(0x41); // block immediately after the header
+        page[0x78..].fill(SPECIAL_POOL_FILL); // fill trails it
+        assert_eq!(
+            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &page),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
+        );
+    }
+
     #[test]
     fn test_special_pool_falls_back_when_the_size_is_untrustworthy() {
-        let page = 0xffff_8c8f_13a0_2000;
+        let page = special_page(0x68, 0x10);
         assert_eq!(
-            special_pool_placement(page, 0, 0x10, PAGE_SIZE),
-            (page + 0x10, PAGE_SIZE - 0x10)
+            special_pool_placement(SPECIAL_PAGE, 0, 0x10, &page),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
         );
         // A request that cannot share the page with its own header is not believable.
         assert_eq!(
-            special_pool_placement(page, PAGE_SIZE, 0x10, PAGE_SIZE),
-            (page + 0x10, PAGE_SIZE - 0x10)
+            special_pool_placement(SPECIAL_PAGE, PAGE_SIZE, 0x10, &page),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10)
         );
     }
 
-    /// A partially readable page (the guard page truncates the read) must not report a
-    /// size past what was actually read.
+    /// A partially readable page corroborates nothing about where the block sits, so the
+    /// end-of-page placement must not be used and the size must not exceed what was read.
     #[test]
     fn test_special_pool_fallback_respects_the_readable_length() {
-        let page = 0xffff_8c8f_13a0_2000;
+        let partial = vec![SPECIAL_POOL_FILL; 0x200];
         assert_eq!(
-            special_pool_placement(page, 0, 0x10, 0x200),
-            (page + 0x10, 0x1f0)
+            special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &partial),
+            (SPECIAL_PAGE + 0x10, 0x1f0)
         );
     }
     use crate::pool::{

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -479,6 +479,113 @@ fn discover_pool_regions(
     Ok(discovery)
 }
 
+/// One place carrying VS free-chunk state.
+struct VsRoot {
+    base: u64,
+    tree_offset: usize,
+    delay_offset: Option<usize>,
+}
+
+/// Resolves where a VS context keeps its free-chunk state. Both shapes are supported,
+/// because a debugger host does not get to choose which build it is pointed at:
+///
+/// * **pre-26100** — `FreeChunkTree`/`DelayFreeContext` are inline in `_HEAP_VS_CONTEXT`,
+///   so there is exactly one root: the context itself.
+/// * **26100+** — they moved into `_HEAP_VS_AFFINITY_SLOT`s reached through a slot map.
+///   `SlotMapRef` and each `SlotRef` are offsets *from the context*, scaled by 64 bytes,
+///   and the map holds `AffinityMask + 1` entries. Entries routinely share a slot, so the
+///   result is deduplicated.
+///
+/// Returning an empty vector means neither shape resolved; the caller then walks no VS
+/// evidence rather than guessing at an address.
+fn vs_roots(
+    memory: &impl PoolMemory,
+    layout: &PoolLayout,
+    context: u64,
+    diagnostics: &mut Vec<String>,
+) -> Vec<VsRoot> {
+    // Legacy shape wins when present: a context that still carries the tree has no slots.
+    if let Ok(tree_offset) = layout.field("_HEAP_VS_CONTEXT", "FreeChunkTree") {
+        return vec![VsRoot {
+            base: context,
+            tree_offset,
+            delay_offset: layout.field("_HEAP_VS_CONTEXT", "DelayFreeContext").ok(),
+        }];
+    }
+
+    let (Ok(tree_offset), Ok(back_offset), Ok(slot_map_ref_offset), Ok(affinity_offset)) = (
+        layout.field("_HEAP_VS_AFFINITY_SLOT", "FreeChunkTree"),
+        layout.field("_HEAP_VS_AFFINITY_SLOT", "VsContext"),
+        layout.field("_HEAP_VS_CONTEXT", "SlotMapRef"),
+        layout.field("_HEAP_VS_CONTEXT", "AffinityMask"),
+    ) else {
+        diagnostics
+            .push("VS free-chunk state is in neither the context nor an affinity slot".into());
+        return Vec::new();
+    };
+
+    let (Ok(slot_map_ref), Ok(affinity_mask)) = (
+        scalar(memory, context + slot_map_ref_offset as u64, 2),
+        scalar(memory, context + affinity_offset as u64, 1),
+    ) else {
+        diagnostics.push(format!(
+            "cannot read the VS slot map of context {context:#x}"
+        ));
+        return Vec::new();
+    };
+
+    let entries = affinity_mask as usize + 1;
+    // A zero ref would alias the context, and the entry count is bounded by the affinity
+    // mask; both would otherwise walk arbitrary memory.
+    if slot_map_ref == 0 || entries > 256 {
+        diagnostics.push(format!(
+            "implausible VS slot map for context {context:#x}: ref {slot_map_ref:#x}, {entries} entries"
+        ));
+        return Vec::new();
+    }
+
+    let entry_size = layout
+        .type_layout("_HEAP_VS_SLOT_MAP")
+        .map_or(4, |map| map.size as u64);
+    let slot_ref_offset = layout.field("_HEAP_VS_SLOT_MAP", "SlotRef").unwrap_or(0);
+    let delay_offset = layout
+        .field("_HEAP_VS_AFFINITY_SLOT", "DelayFreeContext")
+        .ok();
+    let slot_map = context + (slot_map_ref << 6);
+
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    for index in 0..entries {
+        let entry = slot_map + index as u64 * entry_size;
+        let Ok(slot_ref) = scalar(memory, entry + slot_ref_offset as u64, 2) else {
+            continue;
+        };
+        if slot_ref == 0 {
+            continue;
+        }
+        let slot = context + (slot_ref << 6);
+        if !seen.insert(slot) {
+            continue;
+        }
+        // Require the slot to name the context we came from. A misdecoded SlotRef would
+        // otherwise point the tree walk at unrelated memory that happens to be readable.
+        match scalar(memory, slot + back_offset as u64, 8) {
+            Ok(owner) if owner == context => roots.push(VsRoot {
+                base: slot,
+                tree_offset,
+                delay_offset,
+            }),
+            Ok(owner) => diagnostics.push(format!(
+                "VS affinity slot {slot:#x} claims context {owner:#x}, not {context:#x}; skipped"
+            )),
+            Err(error) => {
+                diagnostics.push(format!("cannot read VS affinity slot {slot:#x}: {error}"))
+            }
+        }
+    }
+    roots
+}
+
 fn discover_vs_evidence(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
@@ -491,23 +598,28 @@ fn discover_vs_evidence(
         return Ok(Default::default());
     };
     let context = heap_address + vs_context_offset as u64;
-    let Ok(tree_offset) = layout.field("_HEAP_VS_CONTEXT", "FreeChunkTree") else {
+    let roots = vs_roots(memory, layout, context, diagnostics);
+    if roots.is_empty() {
         return Ok(Default::default());
-    };
+    }
     let tree_node_offset = layout
         .field("_HEAP_VS_CHUNK_FREE_HEADER", "TreeNode")
         .unwrap_or(0);
-    let reusable = tree_nodes(
-        memory,
-        layout,
-        context + tree_offset as u64,
-        limit,
-        "VS free tree",
-        diagnostics,
-    )?
-    .into_iter()
-    .map(|node| node.saturating_sub(tree_node_offset as u64))
-    .collect();
+    let mut reusable = HashSet::new();
+    for root in &roots {
+        reusable.extend(
+            tree_nodes(
+                memory,
+                layout,
+                root.base + root.tree_offset as u64,
+                limit,
+                "VS free tree",
+                diagnostics,
+            )?
+            .into_iter()
+            .map(|node| node.saturating_sub(tree_node_offset as u64)),
+        );
+    }
 
     let mut cached = HashSet::new();
     let pool_header_size = layout
@@ -516,19 +628,28 @@ fn discover_vs_evidence(
     let vs_header_size = layout
         .type_layout("_HEAP_VS_CHUNK_HEADER")
         .map_or(0, |value| value.size as u64);
-    if let (Ok(delay_offset), Ok(list_offset)) = (
-        layout.field("_HEAP_VS_CONTEXT", "DelayFreeContext"),
-        layout.field("_HEAP_VS_DELAY_FREE_CONTEXT", "ListHead"),
-    ) {
-        for entry in walk_slist_nodes(
-            memory,
-            layout,
-            context + delay_offset as u64 + list_offset as u64,
-            limit,
-            "VS delay-free",
-            diagnostics,
-        )? {
-            insert_cached_chunk_candidates(&mut cached, entry, pool_header_size, vs_header_size);
+    if let Ok(list_offset) = layout.field("_HEAP_VS_DELAY_FREE_CONTEXT", "ListHead") {
+        for root in &roots {
+            // Pre-26100 the delay-free list sits beside the tree in the context; from
+            // 26100 it is per-slot. Either way it is a known offset from `root.base`.
+            let Some(delay_offset) = root.delay_offset else {
+                continue;
+            };
+            for entry in walk_slist_nodes(
+                memory,
+                layout,
+                root.base + delay_offset as u64 + list_offset as u64,
+                limit,
+                "VS delay-free",
+                diagnostics,
+            )? {
+                insert_cached_chunk_candidates(
+                    &mut cached,
+                    entry,
+                    pool_header_size,
+                    vs_header_size,
+                );
+            }
         }
     }
 
@@ -826,7 +947,15 @@ fn discover_segment_context(
                 descriptor_index += unit_size.max(1);
                 continue;
             }
-            let backend = if decoded.flags & DESCRIPTOR_FLAG_LFH != 0 {
+            // Verifier special pool sets DESCRIPTOR_FLAG_LFH on its page-range descriptors,
+            // but the page holds a pool header plus fill rather than a subsegment. Parsing
+            // it as LFH rejects the range outright ("implausible LFH metadata") *during
+            // region creation*, so the allocation never reaches the walk at all — which is
+            // why classifying it correctly here, and not just at dispatch time, is what
+            // makes special-pool chunks visible. `walk_region` routes on `heap.special`.
+            let backend = if identity.special {
+                PoolBackend::Segment
+            } else if decoded.flags & DESCRIPTOR_FLAG_LFH != 0 {
                 PoolBackend::Lfh
             } else if decoded.flags & DESCRIPTOR_FLAG_VS != 0 {
                 PoolBackend::Vs
@@ -1173,6 +1302,31 @@ pub(crate) struct SnapshotWalker<'a, M> {
     pub traversal_limit: usize,
 }
 
+/// Where a special-pool block sits inside its page, and how big it is.
+///
+/// Free-standing because the 16-byte rounding is both the easiest part to get wrong and
+/// the only part worth pinning in a test: `PAGE_SIZE - size` puts the answer 8 bytes past
+/// the real block for a 0x68 allocation.
+///
+/// Returns `(usable_address, size)`. The fallback — page-sized, starting after the header
+/// — is used whenever `requested` cannot be trusted, which is any time the 8-bit
+/// `PreviousSize` field cannot describe the block (zero, or too large for the page). An
+/// over-broad chunk still answers "was this freed, and which tag owned it"; a confidently
+/// wrong offset does not.
+fn special_pool_placement(
+    page: u64,
+    requested: u64,
+    header_size: u64,
+    available: u64,
+) -> (u64, u64) {
+    let aligned = requested.next_multiple_of(16);
+    if requested != 0 && aligned + header_size <= PAGE_SIZE {
+        (page + PAGE_SIZE - aligned, requested)
+    } else {
+        (page + header_size, available.saturating_sub(header_size))
+    }
+}
+
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     pub(crate) fn walk(&self) -> Result<PoolSnapshot, SnapshotError> {
         let mut snapshot = PoolSnapshot {
@@ -1248,6 +1402,16 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                     continue;
                 }
             };
+            // Verifier special pool is page-granular, and its page-range descriptors still
+            // carry DESCRIPTOR_FLAG_LFH — so this has to come *before* the backend
+            // dispatch. Left to `walk_lfh`, the range's "subsegment header" is really a
+            // pool header plus fill, the block bitmap is nonsense, and every allocation in
+            // the heap silently disappears from the snapshot.
+            if region.heap.special {
+                self.walk_special_pool(region, valid_base, &bytes, snapshot);
+                cursor = valid_end;
+                continue;
+            }
             match region.backend {
                 PoolBackend::Lfh => self.walk_lfh(region, valid_base, &bytes, snapshot),
                 PoolBackend::Vs => self.walk_vs(region, valid_base, &bytes, snapshot),
@@ -1320,6 +1484,65 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 0,
                 PoolState::Unreadable,
             ));
+        }
+    }
+
+    /// Decodes a Driver Verifier special-pool region, one allocation per page.
+    ///
+    /// Special pool gives every allocation its own page: a `_POOL_HEADER` at the page
+    /// start, `0xfd` fill, then the caller's block pushed up against the page end so an
+    /// overrun lands on the following guard page. The guard page is unmapped, which is
+    /// why `valid_region` stops after the data page and why a *freed* allocation simply
+    /// vanishes — both are the mechanism working, not read failures.
+    ///
+    /// The block is placed at `page + PAGE_SIZE - align_up(size, 16)`; the 16-byte
+    /// alignment is easy to miss, and dropping it puts the reported address 8 bytes past
+    /// the real one (`0xf98` instead of `0xf90` for a 0x68 allocation).
+    fn walk_special_pool(
+        &self,
+        region: &PoolRegion,
+        base: u64,
+        bytes: &[u8],
+        snapshot: &mut PoolSnapshot,
+    ) {
+        let header_size = region.pool_header.size as u64;
+        let mut page = base.next_multiple_of(PAGE_SIZE);
+        while let Some(offset) = page.checked_sub(base).map(|delta| delta as usize) {
+            if offset >= bytes.len() {
+                break;
+            }
+            let available = ((bytes.len() - offset) as u64).min(PAGE_SIZE);
+            let Some(header) = decode_pool_header(bytes, offset, region.pool_header) else {
+                break;
+            };
+            // An untagged page is not an allocation. Freed special-pool pages are
+            // unmapped rather than zeroed, so anything readable here should carry a tag.
+            if header.tag != 0 {
+                // `PreviousSize` carries the requested byte count, but it is only 8 bits
+                // wide, so it cannot describe an allocation of 0x100 bytes or more. When
+                // it does not yield a block that fits the page, report the whole page
+                // rather than a confidently wrong sub-range — an over-broad chunk still
+                // answers "was this freed, and what tag owned it", which is the question
+                // being asked, while a wrong offset quietly misleads.
+                let (usable, size) = special_pool_placement(
+                    page,
+                    u64::from(header.previous_size),
+                    header_size,
+                    available,
+                );
+                snapshot.spans.push(self.base_span(
+                    region,
+                    page,
+                    usable,
+                    size,
+                    header.tag,
+                    PoolState::Allocated,
+                ));
+            }
+            let Some(next) = page.checked_add(PAGE_SIZE) else {
+                break;
+            };
+            page = next;
         }
     }
 
@@ -1533,6 +1756,50 @@ mod tests {
     use std::{cell::Cell, collections::HashMap};
 
     use super::*;
+
+    /// The real values read off Server 26100.32995: a 0x68 message in special pool sits at
+    /// page+0xf90, not page+0xf98. Rounding the request up to 16 is what makes the
+    /// difference, and getting it wrong reports an address 8 bytes into the block.
+    #[test]
+    fn special_pool_block_is_pushed_against_the_page_end_with_16_byte_rounding() {
+        let page = 0xffff_8c8f_13a0_2000;
+        assert_eq!(
+            special_pool_placement(page, 0x68, 0x10, PAGE_SIZE),
+            (page + 0xf90, 0x68)
+        );
+        // Already a multiple of 16: no rounding, block ends exactly at the page end.
+        assert_eq!(
+            special_pool_placement(page, 0x40, 0x10, PAGE_SIZE),
+            (page + 0xfc0, 0x40)
+        );
+    }
+
+    /// `PreviousSize` is 8 bits, so it cannot describe every legal special-pool block.
+    /// When it is unusable the whole page is reported rather than a wrong sub-range.
+    #[test]
+    fn special_pool_falls_back_to_the_page_when_the_size_is_untrustworthy() {
+        let page = 0xffff_8c8f_13a0_2000;
+        assert_eq!(
+            special_pool_placement(page, 0, 0x10, PAGE_SIZE),
+            (page + 0x10, PAGE_SIZE - 0x10)
+        );
+        // A request that cannot share the page with its own header is not believable.
+        assert_eq!(
+            special_pool_placement(page, PAGE_SIZE, 0x10, PAGE_SIZE),
+            (page + 0x10, PAGE_SIZE - 0x10)
+        );
+    }
+
+    /// A partially readable page (the guard page truncates the read) must not report a
+    /// size past what was actually read.
+    #[test]
+    fn special_pool_fallback_respects_the_readable_length() {
+        let page = 0xffff_8c8f_13a0_2000;
+        assert_eq!(
+            special_pool_placement(page, 0, 0x10, 0x200),
+            (page + 0x10, 0x1f0)
+        );
+    }
     use crate::pool::{
         decode::DESCRIPTOR_FLAG_COMMITTED,
         layout::{SessionKey, TypeLayout},

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -558,6 +558,11 @@ fn vs_roots(
     for index in 0..entries {
         let entry = slot_map + index as u64 * entry_size;
         let Ok(slot_ref) = scalar(memory, entry + slot_ref_offset as u64, 2) else {
+            // Skipping silently would drop that slot's free tree and delay-free list, so
+            // its chunks get misclassified with nothing to say why.
+            diagnostics.push(format!(
+                "cannot read VS slot map entry {index} at {entry:#x}; its affinity slot is omitted"
+            ));
             continue;
         };
         if slot_ref == 0 {

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1566,11 +1566,16 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             }
             let offset = slot_offset - slice_offset;
             let address = region.address + slot_offset as u64;
+            // A block never straddles a page: the allocator skips the slot that would and
+            // resumes at the next one, leaving the tail of the page as slack. Verified
+            // against `!pool` on Server 26100 — with a 0x1a0 unit, blocks fill a page to
+            // +0xef0 and the next block sits at +0x1090, which is exactly the following
+            // slot, so linear indexing stays correct across the gap.
+            //
+            // Ordinary layout, then, not damage. Reporting it cost ~11.6k diagnostics on
+            // an idle machine — drowning out the ones that meant something — and wrongly
+            // cleared `complete` on essentially every snapshot taken.
             if address / PAGE_SIZE != (address + unit as u64 - 1) / PAGE_SIZE {
-                snapshot.diagnostics.push(format!(
-                    "LFH slot {address:#x}+{unit:#x} would cross a page"
-                ));
-                snapshot.complete = false;
                 slot += 1;
                 continue;
             }
@@ -1756,6 +1761,80 @@ mod tests {
     use std::{cell::Cell, collections::HashMap};
 
     use super::*;
+
+    // ---- LFH slots that would straddle a page ---------------------------------------
+
+    fn lfh_region(address: u64, unit_size: u32) -> PoolRegion {
+        PoolRegion {
+            address,
+            size: 0x1000,
+            pool_kind: PoolKind::NonPagedNx,
+            numa_node: 0,
+            heap: HeapIdentity {
+                pool_state: 0,
+                heap: 0,
+                special: false,
+            },
+            subsegment: None,
+            backend: PoolBackend::Lfh,
+            unit_size,
+            // Two slots' worth, both marked allocated.
+            bitmap: vec![0xff],
+            heap_key: 0,
+            pool_header: PoolHeaderLayout {
+                size: 0x10,
+                previous_size: 0,
+                pool_index: 1,
+                block_size: 2,
+                pool_type: 3,
+                tag: 4,
+            },
+            vs_header_size: 0,
+            vs_sizes_offset: 0,
+            known_tag: None,
+            states: Vec::new(),
+            reusable_chunks: HashSet::new(),
+            cached_chunks: HashSet::new(),
+        }
+    }
+
+    /// The allocator refuses to let a block straddle a page: it skips that slot, leaves the
+    /// page tail as slack, and resumes at the next slot. Confirmed against `!pool` on
+    /// Server 26100. So the straddling slot must be skipped **silently** — it is ordinary
+    /// layout, and reporting it once cost ~11.6k diagnostics on an idle machine.
+    #[test]
+    fn a_page_straddling_lfh_slot_is_skipped_without_complaint() {
+        // Slot 0 at 0x1f80 spans 0x1f80..0x2080 and crosses; slot 1 at 0x2080 does not.
+        let region = lfh_region(0x1f80, 0x100);
+        let memory = FlatMemory::new(0x1f80, 0x200);
+        let layout = vs_layout(false);
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+        let mut snapshot = PoolSnapshot {
+            spans: Vec::new(),
+            diagnostics: Vec::new(),
+            complete: true,
+        };
+        walker.walk_lfh(&region, 0x1f80, &memory.bytes, &mut snapshot);
+
+        // The straddling slot is dropped, the following one is still reported: skipping
+        // must not desynchronise the linear slot indexing.
+        assert_eq!(snapshot.spans.len(), 1);
+        assert_eq!(snapshot.spans[0].header_address, 0x2080);
+        // The two properties that were wrong: silence, and an intact `complete`.
+        assert!(
+            snapshot.diagnostics.is_empty(),
+            "normal layout must not be reported: {:?}",
+            snapshot.diagnostics
+        );
+        assert!(
+            snapshot.complete,
+            "a straddling slot is expected layout and must not mark the snapshot incomplete"
+        );
+    }
 
     // ---- VS roots: legacy in-context shape vs 26100 affinity slots ------------------
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1757,6 +1757,188 @@ mod tests {
 
     use super::*;
 
+    // ---- VS roots: legacy in-context shape vs 26100 affinity slots ------------------
+
+    /// Memory backed by one contiguous buffer. Anything outside it fails to read, the way
+    /// an unmapped page does.
+    struct FlatMemory {
+        base: u64,
+        bytes: Vec<u8>,
+    }
+
+    impl FlatMemory {
+        fn new(base: u64, len: usize) -> Self {
+            Self {
+                base,
+                bytes: vec![0; len],
+            }
+        }
+
+        fn put(&mut self, address: u64, data: &[u8]) {
+            let offset = (address - self.base) as usize;
+            self.bytes[offset..offset + data.len()].copy_from_slice(data);
+        }
+
+        fn put_u16(&mut self, address: u64, value: u16) {
+            self.put(address, &value.to_le_bytes());
+        }
+
+        fn put_u64(&mut self, address: u64, value: u64) {
+            self.put(address, &value.to_le_bytes());
+        }
+    }
+
+    impl PoolMemory for FlatMemory {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            let offset = address
+                .checked_sub(self.base)
+                .and_then(|offset| usize::try_from(offset).ok())
+                .ok_or_else(|| SnapshotError::InvalidData {
+                    detail: format!("read below the fixture at {address:#x}"),
+                })?;
+            self.bytes
+                .get(offset..offset + size)
+                .map(<[u8]>::to_vec)
+                .ok_or_else(|| SnapshotError::InvalidData {
+                    detail: format!("read past the fixture at {address:#x}+{size:#x}"),
+                })
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+    }
+
+    const VS_CONTEXT: u64 = 0x1000;
+
+    /// A layout carrying only what `vs_roots` consults. `affinity` picks the shape: with
+    /// it, the 26100 slot types exist and `_HEAP_VS_CONTEXT` has no `FreeChunkTree`;
+    /// without it, the legacy in-context fields are present instead.
+    fn vs_layout(affinity: bool) -> PoolLayout {
+        let mut types = HashMap::new();
+        types.insert(
+            "_HEAP_VS_CONTEXT",
+            if affinity {
+                type_layout(0x60, &[("SlotMapRef", 0), ("AffinityMask", 2)])
+            } else {
+                type_layout(0x80, &[("FreeChunkTree", 0x10), ("DelayFreeContext", 0x30)])
+            },
+        );
+        if affinity {
+            types.insert(
+                "_HEAP_VS_AFFINITY_SLOT",
+                type_layout(
+                    0x80,
+                    &[
+                        ("VsContext", 0),
+                        ("FreeChunkTree", 0x10),
+                        ("DelayFreeContext", 0x40),
+                    ],
+                ),
+            );
+            types.insert("_HEAP_VS_SLOT_MAP", type_layout(4, &[("SlotRef", 0)]));
+        }
+        PoolLayout {
+            key: crate::pool::layout::SessionKey {
+                kernel_base: 0,
+                session: 1,
+            },
+            globals: HashMap::new(),
+            types,
+        }
+    }
+
+    /// Four affinity entries over three distinct slots: two whose back-pointer agrees (one
+    /// of them referenced twice, so dedup is exercised) and one that names another context.
+    fn affinity_fixture() -> FlatMemory {
+        let mut memory = FlatMemory::new(VS_CONTEXT, 0x1200);
+        memory.put_u16(VS_CONTEXT, 0x10); // SlotMapRef -> map at ctx + 0x10*64
+        memory.put(VS_CONTEXT + 2, &[3]); // AffinityMask -> 4 entries
+        let map = VS_CONTEXT + 0x400;
+        for (index, slot_ref) in [0x20u16, 0x30, 0x20, 0x40].into_iter().enumerate() {
+            memory.put_u16(map + index as u64 * 4, slot_ref);
+        }
+        memory.put_u64(VS_CONTEXT + 0x800, VS_CONTEXT); // 0x20 << 6, owner agrees
+        memory.put_u64(VS_CONTEXT + 0xc00, VS_CONTEXT); // 0x30 << 6, owner agrees
+        memory.put_u64(VS_CONTEXT + 0x1000, 0xdead_beef); // 0x40 << 6, owner disagrees
+        memory
+    }
+
+    /// Pre-26100: the tree is inline in the context, so there is exactly one root and no
+    /// slot map is consulted at all.
+    #[test]
+    fn vs_roots_reads_the_legacy_in_context_shape() {
+        let memory = FlatMemory::new(VS_CONTEXT, 0x100);
+        let mut diagnostics = Vec::new();
+        let roots = vs_roots(&memory, &vs_layout(false), VS_CONTEXT, &mut diagnostics);
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].base, VS_CONTEXT);
+        assert_eq!(roots[0].tree_offset, 0x10);
+        assert_eq!(roots[0].delay_offset, Some(0x30));
+        assert!(diagnostics.is_empty());
+    }
+
+    /// 26100: `slot = VsContext + (SlotRef << 6)`, and entries routinely share a slot.
+    #[test]
+    fn vs_roots_walks_the_affinity_slots_and_dedups_them() {
+        let memory = affinity_fixture();
+        let mut diagnostics = Vec::new();
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        let bases: Vec<u64> = roots.iter().map(|root| root.base).collect();
+        // Four entries, one repeat, one rejected -> two roots.
+        assert_eq!(bases, vec![VS_CONTEXT + 0x800, VS_CONTEXT + 0xc00]);
+        assert!(roots.iter().all(|root| root.tree_offset == 0x10));
+        assert!(roots.iter().all(|root| root.delay_offset == Some(0x40)));
+    }
+
+    /// A slot whose back-pointer names a different context is not this context's slot.
+    /// Trusting it would aim the tree walk at unrelated but readable memory.
+    #[test]
+    fn vs_roots_rejects_a_slot_whose_back_pointer_disagrees() {
+        let memory = affinity_fixture();
+        let mut diagnostics = Vec::new();
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        assert!(roots.iter().all(|root| root.base != VS_CONTEXT + 0x1000));
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("claims context"));
+    }
+
+    /// A zero `SlotMapRef` would alias the context itself; refuse rather than walk it.
+    #[test]
+    fn vs_roots_refuses_an_implausible_slot_map() {
+        let mut memory = affinity_fixture();
+        memory.put_u16(VS_CONTEXT, 0);
+        let mut diagnostics = Vec::new();
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        assert!(roots.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("implausible VS slot map"));
+    }
+
+    /// Neither shape resolving is a reportable condition, not a silently empty walk — that
+    /// ambiguity is exactly what made the 26100 breakage so hard to see.
+    #[test]
+    fn vs_roots_reports_when_neither_shape_resolves() {
+        let memory = FlatMemory::new(VS_CONTEXT, 0x100);
+        let layout = PoolLayout {
+            key: crate::pool::layout::SessionKey {
+                kernel_base: 0,
+                session: 1,
+            },
+            globals: HashMap::new(),
+            types: HashMap::new(),
+        };
+        let mut diagnostics = Vec::new();
+        let roots = vs_roots(&memory, &layout, VS_CONTEXT, &mut diagnostics);
+        assert!(roots.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("neither the context nor an affinity slot"));
+    }
+
     /// The real values read off Server 26100.32995: a 0x68 message in special pool sits at
     /// page+0xf90, not page+0xf98. Rounding the request up to 16 is what makes the
     /// difference, and getting it wrong reports an address 8 bytes into the block.

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -1,34 +1,19 @@
 use std::ffi::{CStr, c_void};
 use std::mem::ManuallyDrop;
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG, E_UNEXPECTED, S_OK};
-use windows::Win32::System::Diagnostics::Debug::Extensions::{
-    DEBUG_STATUS_BREAK, DEBUG_STATUS_NO_DEBUGGEE,
-};
 use windows::core::{HRESULT, IUnknown, Interface, PCSTR};
 
 use crate::dbgeng::DebugEngine;
 use crate::pool::decode::parse_tag;
-use crate::pool::index::SnapshotCache;
-use crate::pool::layout::{LayoutCache, SessionKey};
+use crate::pool::query;
 use crate::pool::render::{RenderOptions, render_pool_map};
-use crate::pool::snapshot::SnapshotWalker;
 
-const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
 const DEBUG_NOTIFY_SESSION_ACTIVE: u32 = 0x0000_0000;
 const DEBUG_NOTIFY_SESSION_INACTIVE: u32 = 0x0000_0001;
 const DEBUG_NOTIFY_SESSION_ACCESSIBLE: u32 = 0x0000_0002;
 const DEBUG_NOTIFY_SESSION_INACCESSIBLE: u32 = 0x0000_0003;
-
-static SESSION_GENERATION: AtomicU64 = AtomicU64::new(1);
-
-fn snapshots() -> &'static SnapshotCache {
-    static CACHE: OnceLock<SnapshotCache> = OnceLock::new();
-    CACHE.get_or_init(SnapshotCache::default)
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PoolFilter {
@@ -54,12 +39,6 @@ fn parse_address(text: &str) -> Option<u64> {
     (!digits.is_empty())
         .then(|| u64::from_str_radix(digits, 16).ok())
         .flatten()
-}
-
-fn validate_pool_target(processor: u32) -> Result<(), String> {
-    (processor == IMAGE_FILE_MACHINE_AMD64)
-        .then_some(())
-        .ok_or_else(|| format!("pool walking supports x64 targets only (machine {processor:#x})"))
 }
 
 fn parse_args(args: &str) -> Result<PoolCommand, String> {
@@ -143,41 +122,7 @@ fn args_string(args: PCSTR) -> Result<String, String> {
 
 fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
     let command = parse_args(args)?;
-    if !engine
-        .is_kernel_target()
-        .map_err(|error| error.to_string())?
-    {
-        return Err("poolmap requires a kernel target".into());
-    }
-    let status = engine
-        .execution_status()
-        .map_err(|error| error.to_string())?;
-    if status == DEBUG_STATUS_NO_DEBUGGEE {
-        return Err("no accessible target is attached".into());
-    }
-    if status != DEBUG_STATUS_BREAK {
-        return Err("target is running; break in before taking a pool snapshot".into());
-    }
-    let processor = engine.processor_type().map_err(|error| error.to_string())?;
-    validate_pool_target(processor)?;
-    let kernel_base = engine.kernel_base().map_err(|error| error.to_string())?;
-    let generation = SESSION_GENERATION.load(Ordering::Acquire);
-    let key = SessionKey {
-        kernel_base,
-        session: generation,
-    };
-    let layout = LayoutCache::global()
-        .get_or_resolve(engine, key)
-        .map_err(|error| error.to_string())?;
-    let index = snapshots().get_or_refresh(generation, command.refresh, || {
-        SnapshotWalker {
-            memory: engine,
-            layout: &layout,
-            traversal_limit: 1_000_000,
-        }
-        .walk()
-        .map_err(|error| error.to_string())
-    })?;
+    let index = query::prepare_index(engine, command.refresh).map_err(|error| error.to_string())?;
 
     if let Some(address) = command.address {
         let detail = index
@@ -293,16 +238,14 @@ pub unsafe extern "system" fn DebugExtensionUninitialize() {
 pub unsafe extern "system" fn DebugExtensionNotify(notify: u32, _argument: u64) {
     let _ = catch_unwind(AssertUnwindSafe(|| match notify {
         DEBUG_NOTIFY_SESSION_ACTIVE | DEBUG_NOTIFY_SESSION_INACTIVE => invalidate_session(),
-        DEBUG_NOTIFY_SESSION_INACCESSIBLE => snapshots().invalidate(),
+        DEBUG_NOTIFY_SESSION_INACCESSIBLE => query::snapshots().invalidate(),
         DEBUG_NOTIFY_SESSION_ACCESSIBLE => {}
         _ => {}
     }));
 }
 
 fn invalidate_session() {
-    SESSION_GENERATION.fetch_add(1, Ordering::AcqRel);
-    snapshots().invalidate();
-    LayoutCache::global().invalidate();
+    query::invalidate_session();
 }
 
 #[unsafe(no_mangle)]
@@ -351,11 +294,6 @@ mod tests {
         );
         assert!(parse_args("-tag ABCDE").is_err());
         assert!(parse_args("-tag Test -paged -nonpaged").is_err());
-        assert_eq!(validate_pool_target(IMAGE_FILE_MACHINE_AMD64), Ok(()));
-        assert_eq!(
-            validate_pool_target(0xaa64),
-            Err("pool walking supports x64 targets only (machine 0xaa64)".into())
-        );
 
         let mut span = crate::pool::PoolSpan::allocation(
             0x1010,
@@ -377,9 +315,9 @@ mod tests {
         assert!(!span.contains_address(0x0fff));
         assert!(!span.contains_address(0x1030));
 
-        let before = SESSION_GENERATION.load(Ordering::Acquire);
+        let before = query::generation();
         unsafe { DebugExtensionNotify(DEBUG_NOTIFY_SESSION_INACTIVE, 0) };
-        assert!(SESSION_GENERATION.load(Ordering::Acquire) > before);
+        assert!(query::generation() > before);
         assert_eq!(
             unsafe { poolmap(std::ptr::null_mut(), PCSTR::null()) },
             E_FAIL


### PR DESCRIPTION
Two parts: a public API over the existing pool walker, and the fixes needed to make that walker function at all on current builds.

## Typed query API

The walker was reachable only through `!win_kexp.poolmap`, with every record type `pub(crate)` — a host that already owns a `DebugEngine` had no way in except scraping rendered DML.

`pool::query` adds `find_tag`, `chunk_at`, `tag_census`, `snapshot_report`, returning `PoolSpan`s. `chunk_at` reports the chunk **with its neighbours** (refusing to cross a heap boundary), because judging a use-after-free means asking what now sits where the victim was.

The extension command routes through the same `prepare_index`, so the two entry points cannot drift on validation or caching — which removed 60 lines from `pool_extension.rs`.

## Windows 26100

Three independent breakages. Each accepts **both** shapes — a debugger host does not choose which build it is pointed at, and the legacy synthetic tests passing unchanged is the back-compat evidence.

| | symptom |
|---|---|
| VS state moved to `_HEAP_VS_AFFINITY_SLOT` | layout resolution refused before walking anything |
| page-segment signature lost its constant | every segment rejected → empty pool, reported as success |
| Verifier special pool parsed as LFH | verified drivers invisible; dropped at region creation |

Addressing details, all derived from the kernel's own code and verified live:

- Slots: `slot = VsContext + (SlotRef << 6)`, slot map at `VsContext + (SlotMapRef << 6)` with `AffinityMask + 1` entries. From `nt!RtlpHpVsContextGetSlotInfo`. Each decoded slot is validated by its back-pointer so a bad `SlotRef` cannot aim the walk at unrelated memory.
- Signature: `segment ^ context ^ heap_key`, no constant. Independently confirmed by `nt!ExGetHeapFromVA`, which recovers the heap with exactly that arithmetic.
- Special pool: page-granular, block at `page + PAGE_SIZE - align_up(size, 16)` — `0xf90` for `0x68`, not `0xf98`. `PreviousSize` is 8 bits and cannot describe every legal block, so the whole page is reported when it is untrustworthy; an over-broad chunk still answers "was this freed and which tag owned it", a wrong offset does not.

## Why `snapshot_report`

The signature bug reported *success* while seeing nothing. A walker that authenticates by signature must not let "rejected everything" look like "the pool is empty" — the diagnostics were being collected and discarded. They are now retrievable.

## Verification

Live 26100 KDNET target: 307k chunks across 1222 tags, and a driver under `verifier /flags 0x1` resolving to the byte (`pool_find_tag Tgsm` → `ffff8c8f13a02f90 / 0x68 / SpecialNonPagedNx`, matching `!pool` exactly). 39 tests pass, `cargo fmt` clean, no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pool inspection queries for tag searches, address lookups, neighbouring allocations, snapshot reports and allocation censuses.
  * Added paged and non-paged allocation filtering, structured results, diagnostics and broader pool information access for tooling.
  * Exposed pool inspection types and target identity information for integrations.

* **Bug Fixes**
  * Improved compatibility with legacy and newer Windows pool layouts.
  * Improved special-pool and LFH allocation handling.
  * Expanded signature validation across supported Windows build variants.
  * Improved snapshot refresh, completeness reporting and target-specific cache isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->