### PR TITLE
ci: let the Claude workflows actually post their reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,10 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # write is required so /code-review --comment can publish inline PR feedback
+      # write, not read: the job goes green either way, but the action silently posts
+      # nothing without it (anthropics/claude-code-action#1562).
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # The job-level `actions: read` scope is not enough on its own: the action only
+          # reaches CI results when the scope is passed to it as an input too.
+          additional_permissions: |
+            actions: read
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the job goes green either way, but the action silently posts
+      # nothing without it (anthropics/claude-code-action#1562).
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
Both workflows shipped with read-only `issues` — and `claude.yml` with read-only `pull-requests` as well — which is the installer default described in [anthropics/claude-code-action#1562](https://github.com/anthropics/claude-code-action/issues/1562).

The failure mode is the worst kind: **the job runs, goes green, and posts nothing.** No error, no warning, nothing in the log to suggest a review was ever meant to appear. On #80 `claude-review` has been "passing" for every push without producing a single review.

PR-level comments go through the **issues** API even on a pull request, so `pull-requests: write` alone does not cover the summary comment. `claude-code-review.yml` also gains `actions: read`, matching what `claude.yml` already had, so it can read CI results.

```diff
   contents: read
-  pull-requests: read      # claude.yml
-  issues: read
+  pull-requests: write
+  issues: write
   id-token: write
+  actions: read            # claude-code-review.yml
```

Kept on its own branch — nothing to do with the pool work in #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)