### PR TITLE
fix(pool): bound the pool walk so it cannot outlive its caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ allocation breakpoints or reconstruct allocation history. The cache is invalidat
 when execution resumes or the debugger session changes, and incomplete or
 Ctrl+C-interrupted walks are never cached.
 
+A walk is thousands of debugger reads plus every committed pool page, so over a live
+KDNET link it can run for minutes. `!win_kexp.poolmap` lets it run to completion —
+you are at the prompt and can Ctrl+Break. The programmatic API in `pool::query`
+cannot assume that, because nothing else sets that flag, so its walks carry a
+wall-clock budget (`PoolWalk`, defaulting to `DEFAULT_WALK_BUDGET`). A walk that runs
+out of it is not an error: it returns the chunks it reached with `complete` cleared
+and a diagnostic saying how much of the pool it got through. As everywhere else here,
+“the walk did not see it” is reported as exactly that and never as “it is not there”.
+
 When WinDbg accepts DML, map cells have colors and clickable address-detail links.
 The same rows use meaningful ASCII glyphs and include a legend when DML is stripped
 or plain-text output is captured.

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -11,6 +11,7 @@
 //! extension prints would be lossy and brittle.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use thiserror::Error;
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
@@ -89,6 +90,79 @@ pub enum PoolQueryError {
     Engine(#[from] DbgEngError),
 }
 
+/// How long a walk may run before it stops and reports what it reached.
+///
+/// A walk is thousands of debugger reads plus every committed pool page, and over a live
+/// KDNET link each of those crosses the wire; on a busy kernel that is minutes. Nothing used
+/// to stop it. The walk polls for Ctrl+C, but **only a human at a WinDbg prompt ever sets
+/// that flag** — a programmatic caller has no way to say "that is long enough". Its own
+/// timeout frees the caller and leaves the engine walking, and since one engine serves one
+/// target one call at a time, every later call to that target queues behind the walk; the
+/// session is wedged until it is killed, which on a live kernel leaves the guest halted.
+///
+/// 120s is sized to fit inside a typical host's per-call budget with room for the answer to
+/// travel back. A host that knows its own deadline should pass that instead of taking this.
+pub const DEFAULT_WALK_BUDGET: Duration = Duration::from_secs(120);
+
+/// How a query is allowed to reach the pool: reuse or rebuild, and for how long.
+///
+/// `bool` converts into this — `true` meaning refresh — so the ordinary call reads as it
+/// always did and picks up [`DEFAULT_WALK_BUDGET`] without asking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PoolWalk {
+    /// Rebuild rather than reuse the snapshot cached for this target.
+    pub refresh: bool,
+    /// Wall-clock ceiling on a rebuild, or `None` to run to completion.
+    ///
+    /// `None` is correct only where something else can stop the walk — an operator at an
+    /// interactive prompt, who can Ctrl+C. Everywhere else it is the wedge described on
+    /// [`DEFAULT_WALK_BUDGET`].
+    pub budget: Option<Duration>,
+}
+
+impl PoolWalk {
+    /// Reuse the cached snapshot if there is one; otherwise walk under the default budget.
+    pub fn cached() -> Self {
+        Self {
+            refresh: false,
+            budget: Some(DEFAULT_WALK_BUDGET),
+        }
+    }
+
+    /// Discard the cached snapshot and walk again, under the default budget.
+    pub fn refreshed() -> Self {
+        Self {
+            refresh: true,
+            ..Self::cached()
+        }
+    }
+
+    /// Replace the budget with the caller's own deadline.
+    pub fn within(self, budget: Duration) -> Self {
+        Self {
+            budget: Some(budget),
+            ..self
+        }
+    }
+
+    /// Let the walk run to completion. Only for a caller that can interrupt it.
+    pub fn unbounded(self) -> Self {
+        Self {
+            budget: None,
+            ..self
+        }
+    }
+}
+
+impl From<bool> for PoolWalk {
+    fn from(refresh: bool) -> Self {
+        Self {
+            refresh,
+            ..Self::cached()
+        }
+    }
+}
+
 /// Restrict results to one side of the paged/nonpaged split.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PoolPageFilter {
@@ -139,9 +213,9 @@ pub struct PoolSnapshotReport {
 /// Summarises the cached snapshot: how much was walked, and what the walk could not do.
 pub fn snapshot_report(
     engine: &DebugEngine,
-    refresh: bool,
+    walk: impl Into<PoolWalk>,
 ) -> Result<PoolSnapshotReport, PoolQueryError> {
-    let index = prepare_index(engine, refresh)?;
+    let index = prepare_index(engine, walk.into())?;
     Ok(report_of(&index))
 }
 
@@ -160,11 +234,12 @@ fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
 
 /// Validate the target, resolve the layout, and take (or reuse) a pool snapshot.
 ///
-/// `refresh` forces a fresh walk; otherwise a snapshot cached for this session is
+/// `walk.refresh` forces a fresh walk; otherwise a snapshot cached for this session is
 /// reused, because walking every pool page is far too expensive to repeat per query.
+/// `walk.budget` bounds a walk that does happen — see [`DEFAULT_WALK_BUDGET`].
 pub(crate) fn prepare_index(
     engine: &DebugEngine,
-    refresh: bool,
+    walk: PoolWalk,
 ) -> Result<PoolIndex, PoolQueryError> {
     if !engine.is_kernel_target()? {
         return Err(PoolQueryError::NotKernelTarget);
@@ -204,13 +279,13 @@ pub(crate) fn prepare_index(
     // Keyed on the whole `SessionKey`: a programmatic host receives no session
     // notifications, so the generation alone would let a snapshot outlive its target.
     snapshots()
-        .get_or_refresh(key, refresh, || {
+        .get_or_refresh(key, walk.refresh, || {
             SnapshotWalker {
                 memory: engine,
                 layout: &layout,
                 traversal_limit: 1_000_000,
             }
-            .walk()
+            .walk(walk.budget)
             .map_err(|error| error.to_string())
         })
         .map_err(PoolQueryError::Walk)
@@ -225,10 +300,10 @@ pub fn find_tag(
     engine: &DebugEngine,
     tag: &str,
     filter: Option<PoolPageFilter>,
-    refresh: bool,
+    walk: impl Into<PoolWalk>,
 ) -> Result<Vec<PoolSpan>, PoolQueryError> {
     let raw_tag = parse_tag(tag).ok_or(PoolQueryError::InvalidTag)?;
-    let index = prepare_index(engine, refresh)?;
+    let index = prepare_index(engine, walk.into())?;
     Ok(collect_tag(&index, raw_tag, filter))
 }
 
@@ -256,9 +331,9 @@ fn collect_tag(index: &PoolIndex, raw_tag: u32, filter: Option<PoolPageFilter>) 
 pub fn chunk_at(
     engine: &DebugEngine,
     address: u64,
-    refresh: bool,
+    walk: impl Into<PoolWalk>,
 ) -> Result<Option<PoolNeighbourhood>, PoolQueryError> {
-    let index = prepare_index(engine, refresh)?;
+    let index = prepare_index(engine, walk.into())?;
     Ok(neighbourhood_at(&index, address))
 }
 
@@ -308,9 +383,9 @@ fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood
 /// taken from our own walk, so it stays consistent with [`find_tag`] and [`chunk_at`].
 pub fn tag_census(
     engine: &DebugEngine,
-    refresh: bool,
+    walk: impl Into<PoolWalk>,
 ) -> Result<Vec<PoolTagSummary>, PoolQueryError> {
-    let index = prepare_index(engine, refresh)?;
+    let index = prepare_index(engine, walk.into())?;
     Ok(summarize_tags(&index))
 }
 
@@ -395,6 +470,33 @@ mod tests {
         assert_eq!(
             PoolQueryError::UnsupportedArchitecture { machine: 0xaa64 }.to_string(),
             "pool walking supports x64 targets only (machine 0xaa64)"
+        );
+    }
+
+    /// The conversion is what keeps a plain `refresh` argument safe: every caller that never
+    /// heard of a budget gets one anyway, which is the whole reason the wedge is closed
+    /// without each of them having to opt in.
+    #[test]
+    fn test_a_bare_refresh_flag_still_carries_a_budget() {
+        assert_eq!(
+            PoolWalk::from(false),
+            PoolWalk {
+                refresh: false,
+                budget: Some(DEFAULT_WALK_BUDGET)
+            }
+        );
+        assert_eq!(PoolWalk::from(true), PoolWalk::refreshed());
+        assert_eq!(
+            PoolWalk::cached().within(Duration::from_secs(5)).budget,
+            Some(Duration::from_secs(5))
+        );
+        // Only for a caller that can interrupt the walk itself — the extension command.
+        assert_eq!(
+            PoolWalk::refreshed().unbounded(),
+            PoolWalk {
+                refresh: true,
+                budget: None
+            }
         );
     }
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1582,6 +1582,16 @@ const DISCOVERY_BUDGET_SHARE: (u32, u32) = (2, 3);
 /// deadline is observed at a useful granularity, large enough that a megabyte-scale extent is
 /// still a handful of transfers rather than hundreds. Extents at or below this are read whole,
 /// so the ordinary small region pays nothing for this.
+///
+/// **This sets the residual overshoot, and that is the guarantee.** Checks sit *before* reads,
+/// never after, so a walk can finish one transfer — at most this many bytes — past its
+/// ceiling. Checking after a successful read would not improve on that: mid-walk the next
+/// iteration's check fires anyway, so the only case it would change is the one where the walk
+/// has just finished everything, and there it would clear `complete` and announce that "what
+/// is missing is unknown, not absent" about a walk with nothing missing. Manufacturing a false
+/// incompleteness is the same class of lie as reporting an unread region as empty, reached
+/// from the other side. The budget is a ceiling on effort, not a promise about return latency:
+/// it exists so the engine cannot run for *minutes* after its caller has given up.
 const EXTENT_READ_CHUNK: usize = 256 * 1024;
 
 /// Splits a walk budget into the deadline discovery works to and the one the whole walk

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -614,21 +614,25 @@ struct VsRoot {
 ///   and the map holds `AffinityMask + 1` entries. Entries routinely share a slot, so the
 ///   result is deduplicated.
 ///
-/// Returning an empty vector means neither shape resolved; the caller then walks no VS
-/// evidence rather than guessing at an address.
+/// An empty vector means neither shape resolved; the caller then walks no VS evidence
+/// rather than guessing at an address. An `Err` means the walk itself is over — the slot
+/// map is up to 256 entries plus an owner read per distinct slot, all over the wire, so it
+/// polls the deadline like every other read-issuing loop (see [`check_budget`]). It cannot
+/// lean on a later poll: invalid slot refs yield no roots, so nothing downstream reads at
+/// all and the next check is a whole segment context away.
 fn vs_roots(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
     context: u64,
     diagnostics: &mut Vec<String>,
-) -> Vec<VsRoot> {
+) -> Result<Vec<VsRoot>, SnapshotError> {
     // Legacy shape wins when present: a context that still carries the tree has no slots.
     if let Ok(tree_offset) = layout.field("_HEAP_VS_CONTEXT", "FreeChunkTree") {
-        return vec![VsRoot {
+        return Ok(vec![VsRoot {
             base: context,
             tree_offset,
             delay_offset: layout.field("_HEAP_VS_CONTEXT", "DelayFreeContext").ok(),
-        }];
+        }]);
     }
 
     let (Ok(tree_offset), Ok(back_offset), Ok(slot_map_ref_offset), Ok(affinity_offset)) = (
@@ -639,7 +643,7 @@ fn vs_roots(
     ) else {
         diagnostics
             .push("VS free-chunk state is in neither the context nor an affinity slot".into());
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     let (Ok(slot_map_ref), Ok(affinity_mask)) = (
@@ -649,7 +653,7 @@ fn vs_roots(
         diagnostics.push(format!(
             "cannot read the VS slot map of context {context:#x}"
         ));
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     let entries = affinity_mask as usize + 1;
@@ -659,7 +663,7 @@ fn vs_roots(
         diagnostics.push(format!(
             "implausible VS slot map for context {context:#x}: ref {slot_map_ref:#x}, {entries} entries"
         ));
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let entry_size = layout
@@ -674,6 +678,7 @@ fn vs_roots(
     let mut roots = Vec::new();
     let mut seen = HashSet::new();
     for index in 0..entries {
+        check_budget(memory)?;
         let entry = slot_map + index as u64 * entry_size;
         let Ok(slot_ref) = scalar(memory, entry + slot_ref_offset as u64, 2) else {
             // Skipping silently would drop that slot's free tree and delay-free list, so
@@ -706,7 +711,7 @@ fn vs_roots(
             }
         }
     }
-    roots
+    Ok(roots)
 }
 
 fn discover_vs_evidence(
@@ -721,7 +726,7 @@ fn discover_vs_evidence(
         return Ok(Default::default());
     };
     let context = heap_address + vs_context_offset as u64;
-    let roots = vs_roots(memory, layout, context, diagnostics);
+    let roots = vs_roots(memory, layout, context, diagnostics)?;
     if roots.is_empty() {
         return Ok(Default::default());
     }
@@ -1571,6 +1576,14 @@ fn special_pool_placement(
 /// asked a pool query for.
 const DISCOVERY_BUDGET_SHARE: (u32, u32) = (2, 3);
 
+/// How much of one committed extent to ask for per debugger read.
+///
+/// Sized so a chunk is a fraction of a second even on a slow KD link — small enough that the
+/// deadline is observed at a useful granularity, large enough that a megabyte-scale extent is
+/// still a handful of transfers rather than hundreds. Extents at or below this are read whole,
+/// so the ordinary small region pays nothing for this.
+const EXTENT_READ_CHUNK: usize = 256 * 1024;
+
 /// Splits a walk budget into the deadline discovery works to and the one the whole walk
 /// works to. `None` in gives `None` out for both: no budget, no deadlines.
 ///
@@ -1731,11 +1744,12 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 self.unreadable(region, valid_base, requested_end - valid_base, snapshot);
                 break;
             }
-            let bytes = match self
-                .memory
-                .read_exact(valid_base, (valid_end - valid_base) as usize)
-            {
+            let bytes = match self.read_extent(valid_base, (valid_end - valid_base) as usize) {
                 Ok(bytes) => bytes,
+                // Out of time is not "this memory would not read". Left to the arm below it
+                // would be filed as an unreadable span — the walk asserting a fact about the
+                // target out of its own failure to look.
+                Err(error) if error.halts_walk() => return Err(error),
                 Err(error) => {
                     snapshot
                         .diagnostics
@@ -1764,6 +1778,43 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             cursor = valid_end;
         }
         Ok(())
+    }
+
+    /// Reads one committed extent, polling the deadline as the bytes come in.
+    ///
+    /// A single `read_exact` of a whole extent is one synchronous transfer that cannot
+    /// observe the deadline while it runs, so a large committed page range could carry the
+    /// walk past its ceiling however carefully the loops around it polled.
+    ///
+    /// **The chunking is of the transfer, not of the decoding.** Handing each chunk to the
+    /// backend decoders instead would be much simpler and quietly wrong: `walk_lfh` skips any
+    /// slot straddling the end of its slice and `walk_vs` stops at a chunk that runs past it
+    /// and clears `complete`, so every chunk boundary would lose an allocation or invent an
+    /// incomplete walk. The decoders still see one contiguous extent, exactly as before.
+    fn read_extent(&self, base: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+        if size <= EXTENT_READ_CHUNK {
+            return self.memory.read_exact(base, size);
+        }
+        let mut bytes = Vec::with_capacity(size);
+        while bytes.len() < size {
+            check_budget(self.memory)?;
+            let take = EXTENT_READ_CHUNK.min(size - bytes.len());
+            // A failed chunk fails the extent, which is what a failed whole-extent read did.
+            // Returning the prefix would hand the decoders a short buffer, and they read a
+            // short buffer as "the region ends here".
+            let chunk = self.memory.read_exact(base + bytes.len() as u64, take)?;
+            if chunk.len() != take {
+                return Err(SnapshotError::InvalidData {
+                    detail: format!(
+                        "short extent read at {:#x}: asked {take:#x}, got {:#x}",
+                        base + bytes.len() as u64,
+                        chunk.len()
+                    ),
+                });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
     }
 
     fn walk_large(&self, region: &PoolRegion, snapshot: &mut PoolSnapshot) {
@@ -2312,13 +2363,30 @@ mod tests {
         memory
     }
 
+    /// The slot map is up to 256 entries plus an owner read per distinct slot, all over the
+    /// wire. It cannot lean on a later poll either: invalid slot refs produce no roots, so
+    /// nothing downstream reads at all and the next check is a whole segment context away.
+    #[test]
+    fn test_vs_roots_polls_the_budget_between_slot_map_entries() {
+        // Two reads resolve the slot map itself; the loop below them gets nothing.
+        let memory = Impatient::over(affinity_fixture(), 2);
+
+        let outcome = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut Vec::new());
+
+        assert!(
+            matches!(outcome, Err(SnapshotError::BudgetExpired)),
+            "the slot-map loop read on past the deadline, resolving {} roots",
+            outcome.map_or(0, |roots| roots.len())
+        );
+    }
+
     /// Pre-26100: the tree is inline in the context, so there is exactly one root and no
     /// slot map is consulted at all.
     #[test]
     fn test_vs_roots_reads_the_legacy_in_context_shape() {
         let memory = FlatMemory::new(VS_CONTEXT, 0x100);
         let mut diagnostics = Vec::new();
-        let roots = vs_roots(&memory, &vs_layout(false), VS_CONTEXT, &mut diagnostics);
+        let roots = vs_roots(&memory, &vs_layout(false), VS_CONTEXT, &mut diagnostics).unwrap();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].base, VS_CONTEXT);
         assert_eq!(roots[0].tree_offset, 0x10);
@@ -2331,7 +2399,7 @@ mod tests {
     fn test_vs_roots_walks_the_affinity_slots_and_dedups_them() {
         let memory = affinity_fixture();
         let mut diagnostics = Vec::new();
-        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics).unwrap();
         let bases: Vec<u64> = roots.iter().map(|root| root.base).collect();
         // Four entries, one repeat, one rejected -> two roots.
         assert_eq!(bases, vec![VS_CONTEXT + 0x800, VS_CONTEXT + 0xc00]);
@@ -2345,7 +2413,7 @@ mod tests {
     fn test_vs_roots_rejects_a_slot_whose_back_pointer_disagrees() {
         let memory = affinity_fixture();
         let mut diagnostics = Vec::new();
-        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics).unwrap();
         assert!(roots.iter().all(|root| root.base != VS_CONTEXT + 0x1000));
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].contains("claims context"));
@@ -2357,7 +2425,7 @@ mod tests {
         let mut memory = affinity_fixture();
         memory.put_u16(VS_CONTEXT, 0);
         let mut diagnostics = Vec::new();
-        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics);
+        let roots = vs_roots(&memory, &vs_layout(true), VS_CONTEXT, &mut diagnostics).unwrap();
         assert!(roots.is_empty());
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].contains("implausible VS slot map"));
@@ -2378,7 +2446,7 @@ mod tests {
             types: HashMap::new(),
         };
         let mut diagnostics = Vec::new();
-        let roots = vs_roots(&memory, &layout, VS_CONTEXT, &mut diagnostics);
+        let roots = vs_roots(&memory, &layout, VS_CONTEXT, &mut diagnostics).unwrap();
         assert!(roots.is_empty());
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].contains("neither the context nor an affinity slot"));
@@ -3175,18 +3243,20 @@ mod tests {
     /// budget exists to bound — over a live KD link every one crosses the wire — and their
     /// count is exactly what differs between a dump that walks in a second and a live kernel
     /// that takes minutes.
-    struct Impatient {
-        inner: SyntheticMemory,
+    struct Impatient<M> {
+        inner: M,
         reads: Cell<usize>,
         allowance: usize,
     }
 
-    impl Impatient {
+    impl Impatient<SyntheticMemory> {
         fn new(allowance: usize) -> Self {
             Self::over(synthetic_memory(), allowance)
         }
+    }
 
-        fn over(inner: SyntheticMemory, allowance: usize) -> Self {
+    impl<M> Impatient<M> {
+        fn over(inner: M, allowance: usize) -> Self {
             Self {
                 inner,
                 reads: Cell::new(0),
@@ -3195,7 +3265,7 @@ mod tests {
         }
     }
 
-    impl PoolMemory for Impatient {
+    impl<M: PoolMemory> PoolMemory for Impatient<M> {
         fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
             self.reads.set(self.reads.get() + 1);
             self.inner.read_exact(address, size)
@@ -3469,6 +3539,89 @@ mod tests {
             "{} reads for a budget of {ALLOWANCE}: the node loop ran on past the deadline",
             memory.reads.get()
         );
+    }
+
+    /// One extent far larger than a single read should be, reported as entirely committed.
+    struct OneHugeExtent {
+        reads: Cell<usize>,
+        allowance: usize,
+    }
+
+    impl PoolMemory for OneHugeExtent {
+        fn read_exact(&self, _address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            self.reads.set(self.reads.get() + 1);
+            Ok(vec![0; size])
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+
+        fn out_of_budget(&self) -> bool {
+            self.reads.get() >= self.allowance
+        }
+    }
+
+    /// The loops around a read can poll perfectly and still overrun, because the read itself
+    /// is one synchronous transfer: a large committed page range is megabytes in flight with
+    /// no opportunity to notice the deadline. Chunking the transfer is what makes the ceiling
+    /// hold whatever the pool's geometry turns out to be.
+    #[test]
+    fn test_a_large_extent_is_read_in_chunks_that_observe_the_deadline() {
+        const ALLOWANCE: usize = 2;
+        let memory = OneHugeExtent {
+            reads: Cell::new(0),
+            allowance: ALLOWANCE,
+        };
+        let layout = vs_layout(false);
+        let mut region = lfh_region(0x1000, 0x100);
+        region.size = EXTENT_READ_CHUNK * 8;
+        region.bitmap = vec![0xff; 64];
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+
+        let outcome = walker.walk_region(&region, &mut PoolSnapshot::default());
+
+        assert!(
+            matches!(outcome, Err(SnapshotError::BudgetExpired)),
+            "an extent that outlives the deadline has to stop mid-transfer: {outcome:?}"
+        );
+        assert_eq!(
+            memory.reads.get(),
+            ALLOWANCE,
+            "the extent was not chunked, so the deadline could not be observed while it \
+             transferred"
+        );
+    }
+
+    /// The common case must not pay for the uncommon one: an extent that fits in a chunk is
+    /// still exactly one read.
+    #[test]
+    fn test_a_small_extent_is_still_a_single_read() {
+        let memory = OneHugeExtent {
+            reads: Cell::new(0),
+            allowance: usize::MAX,
+        };
+        let layout = vs_layout(false);
+        let region = lfh_region(0x1000, 0x100);
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+
+        walker
+            .walk_region(&region, &mut PoolSnapshot::default())
+            .unwrap();
+
+        assert_eq!(memory.reads.get(), 1);
     }
 
     /// Discovery finds the regions and the walk reads what is in them, so a budget spent

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -209,10 +209,22 @@ impl PoolMemory for crate::dbgeng::DebugEngine {
 
 /// The one place a walk asks whether it is still allowed to run.
 ///
-/// Called from every loop that can iterate an unbounded number of times, so the cost of one
-/// runaway step is a step and not a walk. Both answers halt (see
-/// [`SnapshotError::halts_walk`]); they differ in what the caller does with the halt, which
-/// [`SnapshotWalker::walk`] decides.
+/// **The rule: every loop that issues a debugger read calls this, first thing.** Not only the
+/// unbounded ones — a bounded loop is not automatically safe. The descriptor loop in
+/// [`discover_segment_context`] is capped at 4096 iterations and reads twice per LFH
+/// descriptor, so polling one level out in the segment loop still left ~8k reads between the
+/// deadline passing and anything noticing. On a live KD link that is thousands of round
+/// trips, minutes of them: the very failure this budget exists to prevent, reintroduced
+/// inside the fix for it.
+///
+/// Reads themselves deliberately keep working past the deadline rather than failing. Having
+/// [`Budgeted`] reject them would bound the walk with no rule to remember — but nearly every
+/// read here is swallowed into a "cannot read ..." diagnostic, so out-of-time would surface
+/// as *unreadable memory*. That is the one lie this module is built to avoid: what the walk
+/// did not reach must never be reported as what is not there.
+///
+/// Both answers halt (see [`SnapshotError::halts_walk`]); they differ in what the caller does
+/// with the halt, which [`SnapshotWalker::walk`] decides.
 fn check_budget(memory: &impl PoolMemory) -> Result<(), SnapshotError> {
     if memory.interrupted()? {
         return Err(SnapshotError::Interrupted);
@@ -483,6 +495,9 @@ fn discover_pool_regions(
     }
     let mut heaps = Vec::new();
     for numa_node in 0..number {
+        // Four pointer reads per node, up to 256 nodes: bounded, but a thousand round trips
+        // is still seconds on a live link, and the rule is uniform — a loop that reads polls.
+        check_budget(memory)?;
         let Some(node_address) = state_address
             .checked_add(node_offset as u64)
             .and_then(|address| address.checked_add(numa_node as u64 * node.size as u64))
@@ -778,6 +793,7 @@ fn discover_vs_evidence(
             (buckets_offset, lookaside, list_offset)
         {
             for bucket in 0..bucket_count {
+                check_budget(memory)?;
                 let Some(bucket_address) = dynamic
                     .checked_add(buckets_offset as u64)
                     .and_then(|value| value.checked_add(bucket as u64 * u64::from(lookaside.size)))
@@ -1031,6 +1047,10 @@ fn discover_segment_context(
         };
         let mut descriptor_index = first_descriptor;
         while descriptor_index < descriptor_count {
+            // Up to 4096 descriptors per segment, and an LFH one costs a subsegment header
+            // plus a bitmap read apiece. Polling only in the enclosing segment loop left ~8k
+            // reads between the deadline passing and anything noticing.
+            check_budget(memory)?;
             let offset = descriptor_index * descriptor.size as usize;
             let Some(decoded) = decode_descriptor_at(
                 &metadata,
@@ -1236,6 +1256,10 @@ fn discover_large_allocations(
         &mut discovery.diagnostics,
     )?;
     for node in nodes {
+        // One metadata read per node, and `nodes` is bounded only by `traversal_limit`. The
+        // nested poll in `lookup_big_page_target` covers only nodes that get that far; one
+        // whose metadata will not read continues from here, reading and never asking.
+        check_budget(memory)?;
         let allocation_address = node.saturating_sub(tree_node as u64);
         let allocation = match guarded_read(memory, allocation_address, large.size as usize) {
             Ok(bytes) => bytes,
@@ -3159,8 +3183,12 @@ mod tests {
 
     impl Impatient {
         fn new(allowance: usize) -> Self {
+            Self::over(synthetic_memory(), allowance)
+        }
+
+        fn over(inner: SyntheticMemory, allowance: usize) -> Self {
             Self {
-                inner: synthetic_memory(),
+                inner,
                 reads: Cell::new(0),
                 allowance,
             }
@@ -3249,6 +3277,198 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// How many reads a walk may still issue after its budget is spent.
+    ///
+    /// Not zero: the check sits at the top of each read-issuing loop, so the iteration
+    /// already under way finishes and a few of those loops nest. Measured at 3 against this
+    /// fixture, and pinned there rather than rounded up — the number this guards against is
+    /// the thousands a single unpolled loop costs, so slack here buys nothing and hides the
+    /// next missing check.
+    const OVERSHOOT_ALLOWED: usize = 3;
+
+    #[test]
+    fn test_the_walk_stops_reading_promptly_once_its_budget_is_gone() {
+        let overshoots: Vec<(usize, usize)> = [10, 25, 40, 80, 120, 200, 400]
+            .into_iter()
+            .map(|allowance| {
+                let memory = Impatient::new(allowance);
+                let layout = synthetic_layout();
+                SnapshotWalker {
+                    memory: &memory,
+                    layout: &layout,
+                    traversal_limit: 1024,
+                }
+                .walk(None)
+                .expect("running out of budget is an outcome, not an error");
+                (allowance, memory.reads.get().saturating_sub(allowance))
+            })
+            .collect();
+
+        let worst = overshoots.iter().map(|(_, over)| *over).max().unwrap_or(0);
+        assert!(
+            worst <= OVERSHOOT_ALLOWED,
+            "{worst} reads issued after the deadline (limit {OVERSHOOT_ALLOWED}) — some \
+             read-issuing loop is not polling the budget. (budget, overshoot): {overshoots:?}"
+        );
+    }
+
+    /// One page segment whose every descriptor is a committed LFH range.
+    ///
+    /// The shared fixture has five descriptors in a sixteen-slot array and only one of them
+    /// is LFH, so its descriptor loop issues almost no reads — a walk over it stays inside
+    /// the overshoot limit *even with the loop's budget check deleted*, which is exactly how
+    /// that missing check went unnoticed. A real kernel segment is the opposite: descriptors
+    /// packed with committed subsegments, one header read each.
+    ///
+    /// The subsegment bodies are deliberately left unwritten. Reading one still costs the
+    /// round trip this is counting, and what the walk makes of the bytes afterwards is not
+    /// what is under test.
+    fn segment_of_lfh_descriptors(heap_key: u64) -> SyntheticMemory {
+        let mut bytes = Writes::default();
+        let context = HEAP + 0x100;
+
+        fill(&mut bytes, HEAP, 0x800);
+        put_u64(&mut bytes, context, SEGMENT); // SegmentListHead
+        put(&mut bytes, context + 0x20, &[12, 1]); // UnitShift, FirstDescriptorIndex
+        put_u64(&mut bytes, context + 0x28, !0xffffu64); // SegmentMask: 16 descriptors
+
+        fill(&mut bytes, SEGMENT, 0x300);
+        put_u64(&mut bytes, SEGMENT, context); // ListEntry back to the head: one segment
+        put_u64(
+            &mut bytes,
+            SEGMENT + 0x20,
+            SEGMENT ^ context ^ heap_key ^ super::super::decode::PAGE_SEGMENT_SIGNATURE,
+        );
+        for index in 1..16u64 {
+            let descriptor = SEGMENT + 0x100 + index * 0x20;
+            put_u32(
+                &mut bytes,
+                descriptor,
+                super::super::decode::DESCRIPTOR_TREE_SIGNATURE,
+            );
+            put(
+                &mut bytes,
+                descriptor + 0x18,
+                &[DESCRIPTOR_FLAG_LFH | DESCRIPTOR_FLAG_COMMITTED | 0x0c],
+            );
+            put(&mut bytes, descriptor + 0x1f, &[1]);
+        }
+        SyntheticMemory::new(bytes, Vec::new())
+    }
+
+    /// The descriptor loop is bounded — 4096 iterations — and that is precisely why it was
+    /// missed: "bounded" is not "cheap" when each iteration reads. Polling one level out, in
+    /// the segment loop, let a single segment issue thousands of round trips after the
+    /// deadline, which on a live KD link is minutes: the wedge, rebuilt inside its own fix.
+    #[test]
+    fn test_a_segment_full_of_descriptors_polls_the_budget_between_them() {
+        // Enough to get through the context fields, the free-page tree, the segment header
+        // and the descriptor array, so the halt lands *inside* the descriptor loop — which
+        // is the loop under test.
+        const ALLOWANCE: usize = 10;
+        let heap_key = 0x55aa_1234_9876_0000;
+        let memory = Impatient::over(segment_of_lfh_descriptors(heap_key), ALLOWANCE);
+        let layout = synthetic_layout();
+        let mut discovery = Discovery::default();
+
+        let outcome = discover_segment_context(
+            &memory,
+            &layout,
+            HEAP + 0x100,
+            0,
+            PoolKind::NonPagedNx,
+            HeapIdentity {
+                pool_state: STATE,
+                heap: HEAP,
+                special: false,
+            },
+            heap_key,
+            0xa5c3_1357,
+            1024,
+            &SharedChunks::default(),
+            &SharedChunks::default(),
+            &mut discovery,
+        );
+
+        assert!(
+            matches!(outcome, Err(SnapshotError::BudgetExpired)),
+            "the descriptor loop has to report the halt: {outcome:?}"
+        );
+        assert!(
+            memory.reads.get() <= ALLOWANCE + OVERSHOOT_ALLOWED,
+            "{} reads for a budget of {ALLOWANCE}: the descriptor loop ran on past the \
+             deadline instead of polling it",
+            memory.reads.get()
+        );
+    }
+
+    /// A large-allocation tree of `count` nodes whose metadata will not read.
+    ///
+    /// Each node carries only its `_RTL_BALANCED_NODE` links, so the tree walk finds them all
+    /// and the metadata read that follows fails — which is the path under test. A node whose
+    /// metadata *does* read reaches `lookup_big_page_target`, and that polls the budget
+    /// itself, so it could never demonstrate the missing check.
+    fn large_allocation_tree(count: u64) -> SyntheticMemory {
+        let mut bytes = Writes::default();
+        let tree = HEAP + 0x400;
+        let node = |index: u64| LARGE_META + index * 0x40;
+
+        fill(&mut bytes, tree, 0x10);
+        put_u64(&mut bytes, tree, node(0)); // Root
+        for index in 0..count {
+            // Left chains to the next node, Right terminates. Only 0x10 bytes per node, so
+            // the 0x28-byte metadata read spans into a gap and fails.
+            fill(&mut bytes, node(index), 0x10);
+            let next = if index + 1 < count {
+                node(index + 1)
+            } else {
+                0
+            };
+            put_u64(&mut bytes, node(index), next);
+        }
+        SyntheticMemory::new(bytes, Vec::new())
+    }
+
+    /// The large-allocation loop reads once per node and `nodes` is capped only by
+    /// `traversal_limit` — a million. Without a poll here the deadline is not consulted again
+    /// until the enclosing heap.
+    #[test]
+    fn test_the_large_allocation_loop_polls_the_budget_between_nodes() {
+        // The tree walk itself costs a read per node plus the root and encoded flag, so the
+        // budget has to clear that for the halt to land in the node loop below it.
+        const NODES: u64 = 12;
+        const ALLOWANCE: usize = 16;
+        let memory = Impatient::over(large_allocation_tree(NODES), ALLOWANCE);
+        let layout = synthetic_layout();
+        let mut discovery = Discovery::default();
+
+        let outcome = discover_large_allocations(
+            &memory,
+            &layout,
+            HEAP,
+            0,
+            PoolKind::NonPagedNx,
+            HeapIdentity {
+                pool_state: STATE,
+                heap: HEAP,
+                special: false,
+            },
+            0,
+            1024,
+            &mut discovery,
+        );
+
+        assert!(
+            matches!(outcome, Err(SnapshotError::BudgetExpired)),
+            "the node loop has to report the halt: {outcome:?}"
+        );
+        assert!(
+            memory.reads.get() <= ALLOWANCE + OVERSHOOT_ALLOWED,
+            "{} reads for a budget of {ALLOWANCE}: the node loop ran on past the deadline",
+            memory.reads.get()
+        );
     }
 
     /// Discovery finds the regions and the walk reads what is in them, so a budget spent

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -890,6 +890,14 @@ fn discover_heap_regions(
             &cached_chunks,
             discovery,
         ) {
+            // As in `discover_pool_regions`: a halt is about the walk, not about this
+            // context. Absorbed here it would read as "context 1 is unreadable", and on the
+            // *last* context index it would be absorbed entirely — `discover_heap_regions`
+            // would carry on into `discover_large_allocations` and return `Ok`, so even a
+            // Ctrl+C would only stop the walk if some later site happened to raise it again.
+            if error.halts_walk() {
+                return Err(error);
+            }
             discovery.diagnostics.push(format!(
                 "cannot discover segment context {context_index} at {context_address:#x}: {error}"
             ));
@@ -1541,14 +1549,26 @@ const DISCOVERY_BUDGET_SHARE: (u32, u32) = (2, 3);
 
 /// Splits a walk budget into the deadline discovery works to and the one the whole walk
 /// works to. `None` in gives `None` out for both: no budget, no deadlines.
+///
+/// A budget too large for `Instant` to represent — `PoolWalk::within` takes any `Duration`,
+/// so a caller can hand over `Duration::MAX` — also yields `None` for both. Adding it would
+/// panic, and "longer than this machine can measure" is a request to run unbounded, so
+/// answering it that way is the caller's own meaning rather than a substitution for it.
+///
+/// Both halves stand or fall together, keyed on the whole-walk deadline. Deciding them
+/// independently would pass `Duration::MAX` as a *bounded* discovery share (two thirds of it
+/// still fits) against an unbounded walk — a state with no meaning behind it.
 fn budget_deadlines(
     start: Instant,
     budget: Option<Duration>,
 ) -> (Option<Instant>, Option<Instant>) {
     let (numerator, denominator) = DISCOVERY_BUDGET_SHARE;
+    let Some(whole) = budget.and_then(|full| start.checked_add(full)) else {
+        return (None, None);
+    };
     (
-        budget.map(|full| start + full / denominator * numerator),
-        budget.map(|full| start + full),
+        budget.and_then(|full| start.checked_add(full / denominator * numerator)),
+        Some(whole),
     )
 }
 
@@ -1601,20 +1621,23 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         let discovered = discovery.regions.len();
         let mut walked = 0usize;
         for region in discovery.regions {
-            match check_budget(&walk_clock) {
-                Ok(()) => {}
+            let outcome = if region.backend == PoolBackend::Large {
+                // No reads of its own: the span comes from metadata discovery already did.
+                walker.walk_large(&region, &mut snapshot);
+                Ok(())
+            } else {
+                walker.walk_region(&region, &mut snapshot)
+            };
+            match outcome {
+                // Counted only when the region was walked *through*. A region abandoned
+                // part-way is exactly what the caveat below is for.
+                Ok(()) => walked += 1,
                 Err(SnapshotError::BudgetExpired) => {
                     expired = true;
                     break;
                 }
                 Err(error) => return Err(error),
             }
-            if region.backend == PoolBackend::Large {
-                walker.walk_large(&region, &mut snapshot);
-            } else {
-                walker.walk_region(&region, &mut snapshot);
-            }
-            walked += 1;
         }
 
         if expired {
@@ -1637,10 +1660,22 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         Ok(snapshot)
     }
 
-    fn walk_region(&self, region: &PoolRegion, snapshot: &mut PoolSnapshot) {
+    /// Reads one region and decodes its chunks, stopping if the walk's time runs out.
+    ///
+    /// Checked per *extent*, not just per region: a region the allocator left with holes
+    /// costs one `valid_region` and one `read_exact` per committed run, so a fragmented
+    /// region is many round trips and checking only on the way in would let one region
+    /// overrun the deadline by an unbounded amount. The backend decoders below need no such
+    /// check — they run over bytes already in hand, off the wire entirely.
+    fn walk_region(
+        &self,
+        region: &PoolRegion,
+        snapshot: &mut PoolSnapshot,
+    ) -> Result<(), SnapshotError> {
         let requested_end = region.address.saturating_add(region.size as u64);
         let mut cursor = region.address;
         while cursor < requested_end {
+            check_budget(self.memory)?;
             let remaining = requested_end.saturating_sub(cursor).min(usize::MAX as u64) as usize;
             let (reported_base, reported_size) = match self.memory.valid_region(cursor, remaining) {
                 Ok(valid) => valid,
@@ -1700,10 +1735,11 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 PoolBackend::Lfh => self.walk_lfh(region, valid_base, &bytes, snapshot),
                 PoolBackend::Vs => self.walk_vs(region, valid_base, &bytes, snapshot),
                 PoolBackend::Segment => self.walk_page_ranges(region, valid_base, &bytes, snapshot),
-                PoolBackend::Large => return,
+                PoolBackend::Large => return Ok(()),
             }
             cursor = valid_end;
         }
+        Ok(())
     }
 
     fn walk_large(&self, region: &PoolRegion, snapshot: &mut PoolSnapshot) {
@@ -3185,22 +3221,34 @@ mod tests {
         );
     }
 
-    /// Running out of time is about the walk, not about whichever heap happened to be under
-    /// the cursor. Recorded as a per-heap failure it would read as "heap 3 is unreadable"
-    /// and — the real damage — the heap loop would swallow it and carry on to heaps 4..n,
-    /// each stopping the same way, so the deadline would bound one heap instead of the walk.
+    /// Running out of time is about the walk, not about whichever unit happened to be under
+    /// the cursor. Recorded as a per-unit failure it reads as "heap 3 is unreadable", and —
+    /// the real damage — the enclosing loop swallows it and carries on to the next unit,
+    /// each stopping the same way, so the deadline bounds one unit instead of the walk. On
+    /// the *last* iteration it is absorbed outright and the walk simply continues.
+    ///
+    /// Swept over budgets because where the halt lands decides which handler sees it: an
+    /// early one stops inside a heap's VS evidence, a later one inside a segment context.
+    /// Both swallow errors into diagnostics, so both have to re-raise.
     #[test]
-    fn test_running_out_of_budget_is_not_reported_as_a_broken_heap() {
-        let snapshot = walk_impatiently(40);
-
-        assert!(
-            !snapshot
-                .diagnostics
-                .iter()
-                .any(|message| message.contains("cannot fully discover heap")),
-            "the halt was absorbed by the per-heap handler: {:?}",
-            snapshot.diagnostics
-        );
+    fn test_running_out_of_budget_is_never_reported_as_a_broken_unit() {
+        for allowance in [10, 25, 40, 80, 120, 200, 400] {
+            let snapshot = walk_impatiently(allowance);
+            for absorbed in [
+                "cannot fully discover heap",
+                "cannot discover segment context",
+            ] {
+                assert!(
+                    !snapshot
+                        .diagnostics
+                        .iter()
+                        .any(|message| message.contains(absorbed)),
+                    "budget {allowance}: a per-unit handler absorbed the halt as \
+                     `{absorbed}`: {:?}",
+                    snapshot.diagnostics
+                );
+            }
+        }
     }
 
     /// Discovery finds the regions and the walk reads what is in them, so a budget spent
@@ -3251,6 +3299,10 @@ mod tests {
             "discovery must get real time, not a token slice"
         );
         assert_eq!(budget_deadlines(start, None), (None, None));
+        // `PoolWalk::within` accepts any `Duration`, so a budget longer than `Instant` can
+        // represent is reachable from safe public API. Adding it would panic; a budget
+        // beyond measuring is a request to run unbounded, and is answered as one.
+        assert_eq!(budget_deadlines(start, Some(Duration::MAX)), (None, None));
     }
 
     /// A budget and a Ctrl+C both halt the walk, and they must not be confused. Running out
@@ -3290,6 +3342,69 @@ mod tests {
             .walk(Some(Duration::from_secs(600))),
             Err(SnapshotError::Interrupted)
         ));
+    }
+
+    /// Memory that hands back one small extent at a time and runs out of budget after a
+    /// fixed number of them.
+    ///
+    /// This is the shape that makes a per-*region* check insufficient. A region the
+    /// allocator left with holes is read one committed run at a time — a `valid_region` and
+    /// a `read_exact` each, both over the wire on a live target — so checking only on the
+    /// way in lets a single region overrun the deadline by as many round trips as it has
+    /// extents.
+    struct Fragmented {
+        extent: usize,
+        allowance: usize,
+        extents_read: Cell<usize>,
+    }
+
+    impl PoolMemory for Fragmented {
+        fn read_exact(&self, _address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            Ok(vec![0; size])
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            self.extents_read.set(self.extents_read.get() + 1);
+            Ok((address, size.min(self.extent)))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+
+        fn out_of_budget(&self) -> bool {
+            self.extents_read.get() >= self.allowance
+        }
+    }
+
+    #[test]
+    fn test_a_fragmented_region_checks_the_budget_between_extents() {
+        // 0x1000 of region in 0x400 extents is four round trips; the budget allows three.
+        let memory = Fragmented {
+            extent: 0x400,
+            allowance: 3,
+            extents_read: Cell::new(0),
+        };
+        let layout = vs_layout(false);
+        let mut region = lfh_region(0x1000, 0x100);
+        region.bitmap = vec![0xff; 16];
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+
+        let outcome = walker.walk_region(&region, &mut PoolSnapshot::default());
+
+        assert!(
+            matches!(outcome, Err(SnapshotError::BudgetExpired)),
+            "the region walk has to report the halt, not absorb it: {outcome:?}"
+        );
+        assert_eq!(
+            memory.extents_read.get(),
+            3,
+            "the region went on reading past its deadline"
+        );
     }
 
     /// A budget nobody comes close to spending must not change the answer.

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1810,8 +1810,17 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             check_budget(self.memory)?;
             let take = EXTENT_READ_CHUNK.min(size - bytes.len());
             // A failed chunk fails the extent, which is what a failed whole-extent read did.
-            // Returning the prefix would hand the decoders a short buffer, and they read a
-            // short buffer as "the region ends here".
+            //
+            // A *short* chunk has to fail it too, and that is specific to reading in pieces.
+            // Two things go wrong without this. The next chunk's address comes from how much
+            // has been collected, so a short one shifts every later chunk and assembles a
+            // buffer of contiguous bytes taken from discontiguous addresses — which the
+            // decoders cannot detect, and which makes them report allocations that were never
+            // at those addresses. Worse, the loop then cannot finish: the last chunk asks for
+            // the remainder, comes back short, and `bytes.len()` never reaches `size`.
+            // Deleting this check hangs the walk rather than failing it — verified. Refusing
+            // the extent reports it unreadable, which is true, and is what a short
+            // whole-extent read did before.
             let chunk = self.memory.read_exact(base + bytes.len() as u64, take)?;
             if chunk.len() != take {
                 return Err(SnapshotError::InvalidData {
@@ -3608,6 +3617,82 @@ mod tests {
             ALLOWANCE,
             "the extent was not chunked, so the deadline could not be observed while it \
              transferred"
+        );
+    }
+
+    /// A source that answers every read one byte short.
+    struct ShortChunks {
+        reads: Cell<usize>,
+    }
+
+    impl PoolMemory for ShortChunks {
+        fn read_exact(&self, _address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            self.reads.set(self.reads.get() + 1);
+            Ok(vec![0; size.saturating_sub(1)])
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            Ok((address, size))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+    }
+
+    /// Reading in pieces makes a short chunk dangerous in a way a short whole-extent read
+    /// never was: the next chunk's address comes from how much has been collected, so
+    /// accepting a short one shifts every later chunk and assembles contiguous bytes out of
+    /// discontiguous addresses. The decoders cannot tell — they would report allocations that
+    /// were never at those addresses. So the extent fails, and stays honestly unreadable.
+    #[test]
+    fn test_a_short_chunk_fails_the_extent_instead_of_misassembling_it() {
+        let memory = ShortChunks {
+            reads: Cell::new(0),
+        };
+        let layout = vs_layout(false);
+        let mut region = lfh_region(0x1000, 0x100);
+        region.size = EXTENT_READ_CHUNK * 3;
+        region.bitmap = vec![0xff; 64];
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+
+        assert!(
+            matches!(
+                walker.read_extent(region.address, region.size),
+                Err(SnapshotError::InvalidData { .. })
+            ),
+            "a short chunk has to fail the extent"
+        );
+        assert_eq!(
+            memory.reads.get(),
+            1,
+            "it must not read on after the short chunk"
+        );
+
+        // And through the region walk: reported as unreadable, with nothing decoded out of a
+        // buffer that was never assembled.
+        let mut snapshot = PoolSnapshot::default();
+        walker.walk_region(&region, &mut snapshot).unwrap();
+
+        assert!(
+            snapshot
+                .spans
+                .iter()
+                .all(|span| span.state == PoolState::Unreadable),
+            "a misassembled extent must not yield decoded allocations: {:?}",
+            snapshot.spans
+        );
+        assert!(
+            snapshot
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("cannot read region")),
+            "the failure has to be said out loud: {:?}",
+            snapshot.diagnostics
         );
     }
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1,4 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
@@ -15,6 +17,11 @@ use super::{
 };
 
 type SnapshotSource = Box<dyn std::error::Error + Send + Sync>;
+
+/// A set of chunk addresses shared by every region one heap's evidence covers.
+///
+/// Shared rather than owned per region: see [`PoolRegion::reusable_chunks`].
+type SharedChunks = Arc<HashSet<u64>>;
 
 #[derive(Debug, Error)]
 pub(crate) enum SnapshotError {
@@ -48,6 +55,8 @@ pub(crate) enum SnapshotError {
     },
     #[error("pool snapshot interrupted by Ctrl+C")]
     Interrupted,
+    #[error("pool snapshot ran out of its walk budget")]
+    BudgetExpired,
     #[error("interrupt-status query failed: {source}")]
     InterruptQuery {
         #[source]
@@ -55,6 +64,22 @@ pub(crate) enum SnapshotError {
     },
     #[error("invalid snapshot data: {detail}")]
     InvalidData { detail: String },
+}
+
+impl SnapshotError {
+    /// Whether this ends the whole walk rather than one step of it.
+    ///
+    /// Every other variant is local — a node that would not read, a region that is not
+    /// committed — so the walk records it and carries on. These two are not: carrying on
+    /// would ignore the operator's Ctrl+C, or run past the deadline that exists precisely
+    /// so nobody is left waiting on a walk they have already given up on.
+    ///
+    /// **Every site that swallows an error into a diagnostic has to re-raise these**, or
+    /// the stop signal is absorbed by the first enclosing loop and the walk keeps going —
+    /// which is the failure this predicate exists to make hard to reintroduce.
+    fn halts_walk(&self) -> bool {
+        matches!(self, Self::Interrupted | Self::BudgetExpired)
+    }
 }
 
 impl From<LayoutError> for SnapshotError {
@@ -86,15 +111,72 @@ pub(crate) struct PoolRegion {
     /// Allocator-derived states for segment/page-range cells.
     pub states: Vec<PoolState>,
     /// VS chunk-header addresses present in the free tree.
-    pub reusable_chunks: HashSet<u64>,
-    /// VS chunk-header addresses present in delay-free/lookaside lists.
-    pub cached_chunks: HashSet<u64>,
+    ///
+    /// Shared, not owned: one region is created per page-range descriptor, so on a real
+    /// kernel there are thousands of them, and they all carry the *same* evidence — the one
+    /// set their heap's free tree produced. Cloning the set per region copied it thousands
+    /// of times over, entirely off the wire and so invisible when the walk was blamed on
+    /// debugger reads.
+    pub reusable_chunks: SharedChunks,
+    /// VS chunk-header addresses present in delay-free/lookaside lists. Shared for the
+    /// reason [`Self::reusable_chunks`] is.
+    pub cached_chunks: SharedChunks,
 }
 
 pub(crate) trait PoolMemory {
     fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError>;
     fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError>;
     fn interrupted(&self) -> Result<bool, SnapshotError>;
+
+    /// Whether this walk's wall-clock deadline has passed.
+    ///
+    /// Defaulted to "never" so a plain memory source carries no clock; [`Budgeted`] is what
+    /// puts one in front of it, and [`SnapshotWalker::walk`] is what wraps it.
+    fn out_of_budget(&self) -> bool {
+        false
+    }
+}
+
+/// A memory source with a deadline attached.
+///
+/// The walk already polled for Ctrl+C, but **only a human at a WinDbg prompt ever sets
+/// that**. A programmatic caller — an MCP server driving the query API — has no way to say
+/// "that is long enough", so its own timeout frees the caller and leaves the engine
+/// walking; since one engine serves one target one call at a time, every later call to that
+/// target queues behind the walk. The session is then wedged until it is killed, which on a
+/// live kernel leaves the guest halted. This is the clock that makes that impossible.
+struct Budgeted<'a, M> {
+    inner: &'a M,
+    /// `None` runs to completion — correct only where something else can stop the walk.
+    deadline: Option<Instant>,
+}
+
+impl<'a, M> Budgeted<'a, M> {
+    fn new(inner: &'a M, deadline: Option<Instant>) -> Self {
+        Self { inner, deadline }
+    }
+}
+
+impl<M: PoolMemory> PoolMemory for Budgeted<'_, M> {
+    fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+        self.inner.read_exact(address, size)
+    }
+
+    fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+        self.inner.valid_region(address, size)
+    }
+
+    fn interrupted(&self) -> Result<bool, SnapshotError> {
+        self.inner.interrupted()
+    }
+
+    /// This wrapper *adds* a deadline; it does not replace whatever the source already had,
+    /// so wrapping can only ever make a walk stop sooner.
+    fn out_of_budget(&self) -> bool {
+        self.deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+            || self.inner.out_of_budget()
+    }
 }
 
 impl PoolMemory for crate::dbgeng::DebugEngine {
@@ -125,12 +207,20 @@ impl PoolMemory for crate::dbgeng::DebugEngine {
     }
 }
 
-fn check_interrupted(memory: &impl PoolMemory) -> Result<(), SnapshotError> {
+/// The one place a walk asks whether it is still allowed to run.
+///
+/// Called from every loop that can iterate an unbounded number of times, so the cost of one
+/// runaway step is a step and not a walk. Both answers halt (see
+/// [`SnapshotError::halts_walk`]); they differ in what the caller does with the halt, which
+/// [`SnapshotWalker::walk`] decides.
+fn check_budget(memory: &impl PoolMemory) -> Result<(), SnapshotError> {
     if memory.interrupted()? {
-        Err(SnapshotError::Interrupted)
-    } else {
-        Ok(())
+        return Err(SnapshotError::Interrupted);
     }
+    if memory.out_of_budget() {
+        return Err(SnapshotError::BudgetExpired);
+    }
+    Ok(())
 }
 
 fn guarded_read(
@@ -200,7 +290,7 @@ fn walk_tree_nodes(
         if node == 0 {
             continue;
         }
-        check_interrupted(memory)?;
+        check_budget(memory)?;
         if !seen.insert(node) {
             diagnostics.push(format!("{label} cycle detected at {node:#x}"));
             continue;
@@ -304,7 +394,7 @@ fn walk_slist_nodes(
         .unwrap_or(0);
     let expected = depth.min(limit);
     while entry != 0 && nodes.len() < expected {
-        check_interrupted(memory)?;
+        check_budget(memory)?;
         if !seen.insert(entry) {
             diagnostics.push(format!("{label} list cycle detected at {entry:#x}"));
             break;
@@ -358,11 +448,18 @@ const SPECIAL_POOL_KINDS: [PoolKind; 4] = [
     PoolKind::SpecialPrototypePaged,
 ];
 
+/// Enumerates every pool region, appending to `discovery`.
+///
+/// Takes `discovery` by reference rather than returning it so that a walk which halts
+/// part-way still hands back the regions it *did* find. Returning `Result<Discovery, _>`
+/// threw them away on the one path where they matter most — the caller can then walk what
+/// discovery reached instead of reporting an empty pool.
 fn discover_pool_regions(
     memory: &impl PoolMemory,
     layout: &PoolLayout,
     traversal_limit: usize,
-) -> Result<Discovery, SnapshotError> {
+    discovery: &mut Discovery,
+) -> Result<(), SnapshotError> {
     let state_address = *layout
         .globals
         .get("ExPoolState")
@@ -384,7 +481,6 @@ fn discover_pool_regions(
             detail: format!("implausible ExPoolState.NumberOfPools {number}"),
         });
     }
-    let mut discovery = Discovery::default();
     let mut heaps = Vec::new();
     for numa_node in 0..number {
         let Some(node_address) = state_address
@@ -468,15 +564,22 @@ fn discover_pool_regions(
             heap_key,
             lfh_key,
             traversal_limit,
-            &mut discovery,
+            discovery,
         ) {
+            // A halt is about the walk, not about this heap. Recorded as a per-heap failure
+            // it would read as "heap 3 is unreadable" and — worse — the loop would carry on
+            // to heaps 4..n, each stopping the same way, so the deadline would bound one
+            // heap instead of the walk.
+            if error.halts_walk() {
+                return Err(error);
+            }
             discovery.diagnostics.push(format!(
                 "cannot fully discover heap {heap_address:#x}: {error}"
             ));
         }
     }
     let _ = state.size;
-    Ok(discovery)
+    Ok(())
 }
 
 /// One place carrying VS free-chunk state.
@@ -598,7 +701,7 @@ fn discover_vs_evidence(
     dynamic_lookaside: Option<u64>,
     limit: usize,
     diagnostics: &mut Vec<String>,
-) -> Result<(HashSet<u64>, HashSet<u64>), SnapshotError> {
+) -> Result<(SharedChunks, SharedChunks), SnapshotError> {
     let Ok(vs_context_offset) = layout.field("_SEGMENT_HEAP", "VsContext") else {
         return Ok(Default::default());
     };
@@ -721,7 +824,7 @@ fn discover_vs_evidence(
             }
         }
     }
-    Ok((reusable, cached))
+    Ok((Arc::new(reusable), Arc::new(cached)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -770,7 +873,7 @@ fn discover_heap_regions(
     }
 
     for context_index in 0..2usize {
-        check_interrupted(memory)?;
+        check_budget(memory)?;
         let context_address =
             heap_address + contexts_offset as u64 + context_index as u64 * context.size as u64;
         if let Err(error) = discover_segment_context(
@@ -818,8 +921,8 @@ fn discover_segment_context(
     heap_key: u64,
     lfh_key: u64,
     traversal_limit: usize,
-    reusable_chunks: &HashSet<u64>,
-    cached_chunks: &HashSet<u64>,
+    reusable_chunks: &SharedChunks,
+    cached_chunks: &SharedChunks,
     discovery: &mut Discovery,
 ) -> Result<(), SnapshotError> {
     let segment = layout.type_layout("_HEAP_PAGE_SEGMENT")?;
@@ -876,7 +979,7 @@ fn discover_segment_context(
     let mut entry = scalar(memory, list_head, 8)? & !0xf;
     let mut seen = HashSet::new();
     while entry != 0 && entry != list_head && seen.len() < traversal_limit {
-        check_interrupted(memory)?;
+        check_budget(memory)?;
         if !seen.insert(entry) {
             discovery
                 .diagnostics
@@ -1078,8 +1181,8 @@ fn discover_segment_context(
                 vs_sizes_offset: layout.field("_HEAP_VS_CHUNK_HEADER", "Sizes")?,
                 known_tag: None,
                 states: vec![state],
-                reusable_chunks: reusable_chunks.clone(),
-                cached_chunks: cached_chunks.clone(),
+                reusable_chunks: Arc::clone(reusable_chunks),
+                cached_chunks: Arc::clone(cached_chunks),
             });
             descriptor_index += unit_size;
         }
@@ -1177,8 +1280,8 @@ fn discover_large_allocations(
             vs_sizes_offset: 0,
             known_tag: Some(tag),
             states: vec![PoolState::Allocated],
-            reusable_chunks: HashSet::new(),
-            cached_chunks: HashSet::new(),
+            reusable_chunks: Arc::default(),
+            cached_chunks: Arc::default(),
         });
     }
     Ok(())
@@ -1234,7 +1337,7 @@ fn lookup_big_page_target(
     })?;
     let mut remaining = count;
     'probe: while let Some(first_index) = probes.next() {
-        check_interrupted(memory)?;
+        check_budget(memory)?;
         let batch_len = BIG_PAGE_PROBE_BATCH.min(remaining).min(count - first_index);
         let byte_len =
             entry_size
@@ -1292,6 +1395,63 @@ fn lookup_big_page_target(
         "no validated big-page entry for large allocation {address:#x}"
     ));
     Ok(None)
+}
+
+/// How many verbatim examples of one kind of diagnostic to keep.
+const DIAGNOSTIC_EXAMPLES: usize = 8;
+
+/// The shape of a diagnostic: the message with every number standing in for itself.
+///
+/// "unreadable VS free tree node 0xffffc00f6ec02f90" and the same complaint about a
+/// different node share a shape; a genuinely different complaint does not.
+fn diagnostic_shape(message: &str) -> String {
+    message
+        .split_whitespace()
+        .map(|token| {
+            if token.contains(|character: char| character.is_ascii_digit()) {
+                "#"
+            } else {
+                token
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Collapse floods of near-identical diagnostics into examples plus a count.
+///
+/// A live target keeps allocating between the reads that make up one walk, so a single
+/// stale list pointer yields one "unreadable ... node" line per node — 14k of them measured
+/// on a busy kernel. That buries the handful of *distinct* problems a reader needs, and
+/// every consumer truncates the list anyway, so which ones survive is decided by position
+/// rather than by significance.
+///
+/// Nothing is dropped silently: each group keeps its first [`DIAGNOSTIC_EXAMPLES`] verbatim
+/// and the rest become a count, so the volume — the number that says the walk was fighting a
+/// moving target — is still on the page. Summaries go at the end, in the order the groups
+/// first appeared, rather than interleaved where a group's last member happened to land.
+fn collapse_repeats(diagnostics: Vec<String>) -> Vec<String> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    let mut kept: Vec<String> = Vec::new();
+    for message in diagnostics {
+        let shape = diagnostic_shape(&message);
+        let count = counts.entry(shape.clone()).or_insert_with(|| {
+            order.push(shape);
+            0
+        });
+        *count += 1;
+        if *count <= DIAGNOSTIC_EXAMPLES {
+            kept.push(message);
+        }
+    }
+    for shape in order {
+        let total = counts[&shape];
+        if let Some(collapsed) = total.checked_sub(DIAGNOSTIC_EXAMPLES).filter(|n| *n > 0) {
+            kept.push(format!("... and {collapsed} more like `{shape}`"));
+        }
+    }
+    kept
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1368,29 +1528,112 @@ fn special_pool_placement(
     }
 }
 
+/// The share of the budget discovery may spend before the region walk claims the rest.
+///
+/// The two halves are useless apart: discovery finds the regions, the walk reads what is in
+/// them, and a snapshot with neither half finished is an empty pool. Discovery is also the
+/// pointer-chasing half — one read per free-tree node, per list entry, per subsegment — so
+/// on a live link it is the half that runs long, and left unchecked it would spend the whole
+/// budget and leave nothing to walk. Holding it to two thirds means a walk that runs out of
+/// time still reports the chunks in the regions it did reach, which is the answer a caller
+/// asked a pool query for.
+const DISCOVERY_BUDGET_SHARE: (u32, u32) = (2, 3);
+
+/// Splits a walk budget into the deadline discovery works to and the one the whole walk
+/// works to. `None` in gives `None` out for both: no budget, no deadlines.
+fn budget_deadlines(
+    start: Instant,
+    budget: Option<Duration>,
+) -> (Option<Instant>, Option<Instant>) {
+    let (numerator, denominator) = DISCOVERY_BUDGET_SHARE;
+    (
+        budget.map(|full| start + full / denominator * numerator),
+        budget.map(|full| start + full),
+    )
+}
+
 impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
-    pub(crate) fn walk(&self) -> Result<PoolSnapshot, SnapshotError> {
+    /// Walks the pool, giving up after `budget` rather than running as long as it takes.
+    ///
+    /// `None` runs to completion. That is right only where something *else* can stop the
+    /// walk — an operator's Ctrl+C at a WinDbg prompt — and wrong for a programmatic caller,
+    /// where nothing sets that flag; see [`Budgeted`].
+    ///
+    /// Running out of time is **not** an error. It comes back as a snapshot that says what
+    /// it reached, with `complete` cleared and a diagnostic naming the budget, because a
+    /// partial walk still answers "here is a chunk carrying that tag" — and the alternative,
+    /// an error, discards minutes of work to say nothing at all. A Ctrl+C is the opposite
+    /// and still errors: an operator who interrupts is asking for the walk to stop, not for
+    /// whatever it happened to have.
+    pub(crate) fn walk(&self, budget: Option<Duration>) -> Result<PoolSnapshot, SnapshotError> {
+        let (discovery_deadline, walk_deadline) = budget_deadlines(Instant::now(), budget);
         let mut snapshot = PoolSnapshot {
             diagnostics: vec!["per-session paged heaps are not included".into()],
             complete: true,
             ..PoolSnapshot::default()
         };
-        let discovery = discover_pool_regions(self.memory, self.layout, self.traversal_limit)?;
+
+        let discovery_clock = Budgeted::new(self.memory, discovery_deadline);
+        let mut discovery = Discovery::default();
+        let mut expired = match discover_pool_regions(
+            &discovery_clock,
+            self.layout,
+            self.traversal_limit,
+            &mut discovery,
+        ) {
+            Ok(()) => false,
+            Err(SnapshotError::BudgetExpired) => true,
+            Err(error) => return Err(error),
+        };
         if !discovery.diagnostics.is_empty() {
             snapshot.complete = false;
         }
-        snapshot.diagnostics.extend(discovery.diagnostics);
+        snapshot.diagnostics.append(&mut discovery.diagnostics);
+
+        // The full deadline, so regions found before discovery ran out of its share still get
+        // walked with the time discovery did not use.
+        let walk_clock = Budgeted::new(self.memory, walk_deadline);
+        let walker = SnapshotWalker {
+            memory: &walk_clock,
+            layout: self.layout,
+            traversal_limit: self.traversal_limit,
+        };
+        let discovered = discovery.regions.len();
+        let mut walked = 0usize;
         for region in discovery.regions {
-            check_interrupted(self.memory)?;
-            if region.backend == PoolBackend::Large {
-                self.walk_large(&region, &mut snapshot);
-            } else {
-                self.walk_region(&region, &mut snapshot);
+            match check_budget(&walk_clock) {
+                Ok(()) => {}
+                Err(SnapshotError::BudgetExpired) => {
+                    expired = true;
+                    break;
+                }
+                Err(error) => return Err(error),
             }
+            if region.backend == PoolBackend::Large {
+                walker.walk_large(&region, &mut snapshot);
+            } else {
+                walker.walk_region(&region, &mut snapshot);
+            }
+            walked += 1;
+        }
+
+        if expired {
+            snapshot.complete = false;
+            let allowed = match budget {
+                Some(budget) => format!("{budget:?} budget"),
+                None => "walk budget".to_string(),
+            };
+            snapshot.diagnostics.push(format!(
+                "the walk ran out of its {allowed}: {walked} of {discovered} discovered regions \
+                 were walked, and region discovery itself may not have finished. What is \
+                 reported was really there; what is missing is unknown, not absent. Allow a \
+                 longer budget for full coverage."
+            ));
         }
         snapshot
             .spans
             .sort_by_key(|span| (span.heap, span.usable_address));
+        snapshot.diagnostics = collapse_repeats(snapshot.diagnostics);
         Ok(snapshot)
     }
 
@@ -1854,8 +2097,8 @@ mod tests {
             vs_sizes_offset: 0,
             known_tag: None,
             states: Vec::new(),
-            reusable_chunks: HashSet::new(),
-            cached_chunks: HashSet::new(),
+            reusable_chunks: Arc::default(),
+            cached_chunks: Arc::default(),
         }
     }
 
@@ -2781,7 +3024,7 @@ mod tests {
             layout: &layout,
             traversal_limit: 1024,
         };
-        let snapshot = walker.walk().unwrap();
+        let snapshot = walker.walk(None).unwrap();
         for backend in [
             PoolBackend::Lfh,
             PoolBackend::Vs,
@@ -2860,6 +3103,261 @@ mod tests {
         assert_eq!(
             walker.lookup_big_page(&table, 24, address),
             Some((u32::from_le_bytes(*b"NEXT"), 0x7000))
+        );
+    }
+
+    // ---- the walk budget --------------------------------------------------------------
+
+    /// The synthetic fixture, with a budget that runs out after a fixed number of reads.
+    ///
+    /// The real budget is wall-clock, which is untestable without making the test a race
+    /// against the machine it runs on. Reads are the honest stand-in: they are what the
+    /// budget exists to bound — over a live KD link every one crosses the wire — and their
+    /// count is exactly what differs between a dump that walks in a second and a live kernel
+    /// that takes minutes.
+    struct Impatient {
+        inner: SyntheticMemory,
+        reads: Cell<usize>,
+        allowance: usize,
+    }
+
+    impl Impatient {
+        fn new(allowance: usize) -> Self {
+            Self {
+                inner: synthetic_memory(),
+                reads: Cell::new(0),
+                allowance,
+            }
+        }
+    }
+
+    impl PoolMemory for Impatient {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            self.reads.set(self.reads.get() + 1);
+            self.inner.read_exact(address, size)
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            self.inner.valid_region(address, size)
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+
+        fn out_of_budget(&self) -> bool {
+            self.reads.get() >= self.allowance
+        }
+    }
+
+    fn walk_impatiently(allowance: usize) -> PoolSnapshot {
+        let memory = Impatient::new(allowance);
+        let layout = synthetic_layout();
+        SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1024,
+        }
+        .walk(None)
+        .expect("running out of budget is an outcome, not an error")
+    }
+
+    /// The wedge this budget exists to prevent: with nothing to stop it, the walk ran on
+    /// past the caller's timeout and every later call to that target queued behind it. So
+    /// the deadline has to produce an *answer* — a snapshot that says what it reached and
+    /// admits what it did not. An `Err` would discard the work and say nothing.
+    #[test]
+    fn test_a_walk_that_runs_out_of_budget_reports_what_it_reached() {
+        let snapshot = walk_impatiently(40);
+
+        assert!(
+            !snapshot.complete,
+            "a truncated walk that claims completeness is the lie this whole API guards against"
+        );
+        assert!(
+            snapshot
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("ran out of its")
+                    && message.contains("discovered regions")),
+            "the snapshot has to say why it is short: {:?}",
+            snapshot.diagnostics
+        );
+    }
+
+    /// Running out of time is about the walk, not about whichever heap happened to be under
+    /// the cursor. Recorded as a per-heap failure it would read as "heap 3 is unreadable"
+    /// and — the real damage — the heap loop would swallow it and carry on to heaps 4..n,
+    /// each stopping the same way, so the deadline would bound one heap instead of the walk.
+    #[test]
+    fn test_running_out_of_budget_is_not_reported_as_a_broken_heap() {
+        let snapshot = walk_impatiently(40);
+
+        assert!(
+            !snapshot
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("cannot fully discover heap")),
+            "the halt was absorbed by the per-heap handler: {:?}",
+            snapshot.diagnostics
+        );
+    }
+
+    /// Discovery finds the regions and the walk reads what is in them, so a budget spent
+    /// entirely on the first half yields an empty pool. Two things keep that from happening:
+    /// discovery is held to a share of the budget, and — pinned here — the regions it found
+    /// before stopping survive the halt instead of being dropped with the error.
+    #[test]
+    fn test_regions_found_before_the_halt_are_not_thrown_away() {
+        // Enough reads to get past VS evidence and into the segment walk, not enough to
+        // finish it.
+        let snapshot = walk_impatiently(120);
+        let summary = snapshot
+            .diagnostics
+            .iter()
+            .find(|message| message.contains("discovered regions"))
+            .expect("the walk stopped short and must say so");
+        let tokens: Vec<&str> = summary.split_whitespace().collect();
+        let discovered: usize = tokens
+            .iter()
+            .position(|token| *token == "discovered")
+            .and_then(|index| index.checked_sub(1))
+            .and_then(|index| tokens[index].parse().ok())
+            .unwrap_or_else(|| panic!("no region count in `{summary}`"));
+
+        assert!(
+            discovered > 0,
+            "discovery's partial results were discarded with the halt: `{summary}`"
+        );
+    }
+
+    /// Neither half of the walk is useful without the other, so discovery gets a share of
+    /// the budget rather than all of it — and the whole walk still stops at the deadline it
+    /// was given.
+    #[test]
+    fn test_discovery_gets_a_share_of_the_budget_and_the_walk_the_rest() {
+        let start = Instant::now();
+        let budget = Duration::from_secs(120);
+        let (discovery, whole) = budget_deadlines(start, Some(budget));
+        let (discovery, whole) = (discovery.unwrap(), whole.unwrap());
+
+        assert_eq!(whole, start + budget);
+        assert!(
+            discovery < whole,
+            "discovery must yield before the deadline"
+        );
+        assert!(
+            discovery > start,
+            "discovery must get real time, not a token slice"
+        );
+        assert_eq!(budget_deadlines(start, None), (None, None));
+    }
+
+    /// A budget and a Ctrl+C both halt the walk, and they must not be confused. Running out
+    /// of time means "here is what I got"; an operator interrupting means "stop" — handing
+    /// them a snapshot they cancelled, which then renders as a full table, is not that.
+    #[test]
+    fn test_an_interrupt_still_stops_the_walk_outright() {
+        struct Interrupting(SyntheticMemory);
+
+        impl PoolMemory for Interrupting {
+            fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+                self.0.read_exact(address, size)
+            }
+
+            fn valid_region(
+                &self,
+                address: u64,
+                size: usize,
+            ) -> Result<(u64, usize), SnapshotError> {
+                self.0.valid_region(address, size)
+            }
+
+            fn interrupted(&self) -> Result<bool, SnapshotError> {
+                Ok(true)
+            }
+        }
+
+        let memory = Interrupting(synthetic_memory());
+        let layout = synthetic_layout();
+
+        assert!(matches!(
+            SnapshotWalker {
+                memory: &memory,
+                layout: &layout,
+                traversal_limit: 1024,
+            }
+            .walk(Some(Duration::from_secs(600))),
+            Err(SnapshotError::Interrupted)
+        ));
+    }
+
+    /// A budget nobody comes close to spending must not change the answer.
+    #[test]
+    fn test_a_generous_budget_walks_exactly_as_an_unbounded_one_does() {
+        let memory = synthetic_memory();
+        let layout = synthetic_layout();
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1024,
+        };
+
+        let unbounded = walker.walk(None).unwrap();
+        let budgeted = walker.walk(Some(Duration::from_secs(600))).unwrap();
+
+        assert_eq!(budgeted.spans, unbounded.spans);
+        assert_eq!(budgeted.complete, unbounded.complete);
+        assert_eq!(budgeted.diagnostics, unbounded.diagnostics);
+    }
+
+    // ---- diagnostic floods -------------------------------------------------------------
+
+    /// A live target keeps allocating between the reads of one walk, so a single stale list
+    /// pointer yields one complaint per node — 14k of them measured on a busy kernel, which
+    /// buries the few distinct problems and leaves every consumer truncating by position.
+    /// Collapsing keeps examples and, crucially, the *count*: the volume is itself the
+    /// finding, so it must survive.
+    #[test]
+    fn test_a_flood_of_one_complaint_becomes_examples_plus_a_count() {
+        let mut diagnostics: Vec<String> = (0..1000)
+            .map(|node| format!("unreadable VS free tree node {node:#x}: sparse memory"))
+            .collect();
+        diagnostics.push("rejecting implausible LFH unit size 3 at 0x1000".into());
+
+        let collapsed = collapse_repeats(diagnostics);
+
+        assert_eq!(
+            collapsed.len(),
+            DIAGNOSTIC_EXAMPLES + 2,
+            "expected {DIAGNOSTIC_EXAMPLES} examples, the distinct message, and one summary"
+        );
+        assert!(collapsed[0].contains("unreadable VS free tree node 0x0"));
+        assert!(
+            collapsed
+                .iter()
+                .any(|message| message.contains("rejecting implausible LFH unit size")),
+            "a distinct complaint must not be collapsed away by a flood of another"
+        );
+        assert!(
+            collapsed.last().is_some_and(
+                |message| message.contains(&format!("and {} more", 1000 - DIAGNOSTIC_EXAMPLES))
+            ),
+            "the count is the finding and has to survive: {collapsed:?}"
+        );
+    }
+
+    /// Grouping is by shape, so the same complaint about different addresses is one group
+    /// while genuinely different complaints stay apart.
+    #[test]
+    fn test_diagnostic_shape_ignores_numbers_but_not_wording() {
+        assert_eq!(
+            diagnostic_shape("unreadable VS free tree node 0xdeadbeef: sparse"),
+            diagnostic_shape("unreadable VS free tree node 0x41414141: sparse")
+        );
+        assert_ne!(
+            diagnostic_shape("unreadable VS free tree node 0xdeadbeef"),
+            diagnostic_shape("unreadable VS delay-free node 0xdeadbeef")
         );
     }
 

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -122,7 +122,12 @@ fn args_string(args: PCSTR) -> Result<String, String> {
 
 fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
     let command = parse_args(args)?;
-    let index = query::prepare_index(engine, command.refresh).map_err(|error| error.to_string())?;
+    // Unbounded, unlike the programmatic API. This path has an operator in front of it who
+    // can Ctrl+Break — which the walk already honours — so a deadline here would only
+    // truncate a walk somebody was willing to wait out. The budget exists for callers that
+    // have no such control; see `query::DEFAULT_WALK_BUDGET`.
+    let walk = query::PoolWalk::from(command.refresh).unbounded();
+    let index = query::prepare_index(engine, walk).map_err(|error| error.to_string())?;
 
     if let Some(address) = command.address {
         let detail = index


### PR DESCRIPTION
## The wedge

A pool walk had nothing that could stop it.

It polls `GetInterrupt` between nodes — but **only a human at a WinDbg prompt ever sets that flag**. On the programmatic path (`pool::query`, which windbg-mcp drives) the poll never fired. Over a live KDNET link a walk runs for minutes, so the caller's timeout expired first and the engine kept walking; since one engine serves one target one call at a time, every later call to that target queued behind it. The session was wedged until it was killed, and killing an engine attached to a live kernel leaves the guest halted.

Found driving a Server 26100 target over KDNET: `pool_find_tag` / `pool_census` repeatedly timed out and took the session with them, so pool objects had to be located by hand through `!handle` → `FILE_OBJECT` instead.

Note this is **not** the diagnosis I started from — `check_interrupted` was already in every node loop. It was the *interrupt source* that did not exist.

## The fix

**A wall-clock budget the walk enforces itself.** `SnapshotWalker::walk` takes a deadline, reached through the new `PoolWalk` / `DEFAULT_WALK_BUDGET` (120s). Running out of it is **not an error**: it returns the chunks it reached with `complete` cleared and a diagnostic saying how much of the pool it got through. A partial walk still answers "here is a chunk carrying that tag"; an `Err` discards minutes of work to say nothing at all. A Ctrl+C is the opposite request — stop, not "give me what you have" — and still errors.

**Discovery is held to two thirds of the budget.** The two halves are useless apart, and discovery is the pointer-chasing one, so unchecked it spent the whole budget and left nothing to walk — an empty pool. `discover_pool_regions` now appends into a caller-owned `Discovery`, so the regions it *did* find survive the halt instead of being dropped with the error.

**Halts are re-raised at the sites that swallow errors.** `SnapshotError::halts_walk()` distinguishes "this one node failed" from "stop". The per-heap handler used to absorb the halt and carry on to heaps 4..n, each stopping the same way, so the deadline bounded one heap rather than the walk.

Two costs found while measuring, both live-target-only:

- **`PoolRegion`'s free-chunk sets were deep-cloned per region** — thousands of regions each copying a set of thousands of nodes. Entirely off the wire, and so invisible while the walk was being blamed on debugger reads. `Arc` now.
- **Diagnostics are collapsed by shape**, keeping examples plus an exact count. A target that moves under the walk yields one complaint per stale node — 14k measured — which buried the few distinct problems and left every consumer truncating by position rather than by significance. The count survives, because the volume is itself the finding.

`!win_kexp.poolmap` stays unbounded: it has an operator in front of it who can Ctrl+Break, and the budget exists for callers with no such control.

## Compatibility

`bool: Into<PoolWalk>` keeps every existing call site compiling and gives it the default budget without opting in. Verified against windbg-mcp through a temporary `[patch]`: it builds unchanged and its 135 tests pass, so it needs only `cargo update -p win-kexp`.

## Verification

- 57 tests pass, `cargo fmt` clean, no new clippy warnings (the `collapsible_if` in `src/process.rs:33` is pre-existing).
- All 50 `pool::` tests pass under Miri.
- The three substantive new tests were mutation-checked — dropping the halt re-raise, discarding partial discovery, and making expiry an error each fail the test that pins them.

## Deliberately not in scope

- Pushing the paged/nonpaged filter down into the walk. It would roughly halve the wire traffic for a `find_tag` query, but `SnapshotCache` would have to key on scope and a nonpaged-only snapshot must never answer a `chunk_at`. That is its own change with its own review.
- A host passing its real remaining deadline instead of taking the 120s default. That belongs in the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable time limits for pool walks, including cached, refreshed, bounded and unbounded options.
  * Pool queries now return partial results with clear completion status when the time limit is reached.
  * Added support for newer affinity-slot layouts and improved special-pool identification.

* **Bug Fixes**
  * Prevented timed-out walks from incorrectly reporting missing allocations or returning errors.
  * Improved diagnostics by collapsing repeated entries.
  * Large memory reads are now processed more reliably during pool walks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->