### PR TITLE
feat(pool): carry diagnostic counts as counts, not as prose

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -14,6 +14,7 @@ pub mod query;
 
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
+pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics};
 
 /// Exact allocator identity.  Values are deliberately not collapsed into just
 /// paged/nonpaged because crossing one of these boundaries creates false holes.

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
-use super::{PoolSpan, PoolState, snapshot::PoolSnapshot};
+use super::{PoolDiagnostics, PoolSpan, PoolState, snapshot::PoolSnapshot};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Direction {
@@ -23,7 +23,7 @@ pub(crate) struct Hole {
 pub(crate) struct PoolIndex {
     pub spans: Vec<PoolSpan>,
     pub postings: HashMap<u32, Vec<usize>>,
-    pub diagnostics: Vec<String>,
+    pub diagnostics: PoolDiagnostics,
     /// Whether the walk covered everything it set out to. Carried through from
     /// [`PoolSnapshot`] because a walk can end incomplete *without* emitting a
     /// diagnostic — `walk_vs` clears it when a readable region stops mid-chunk — and a
@@ -264,7 +264,7 @@ mod tests {
                 span(0x1080, tag, PoolState::Allocated, 2),
             ],
             complete: true,
-            diagnostics: vec![],
+            diagnostics: PoolDiagnostics::default(),
         };
         let index = PoolIndex::build(snapshot.clone());
         assert_eq!(index.postings[&tag], vec![1, 4]);
@@ -286,7 +286,7 @@ mod tests {
                 span(0x1080, other, PoolState::Allocated, 1),
             ],
             complete: true,
-            diagnostics: vec![],
+            diagnostics: PoolDiagnostics::default(),
         });
         assert_eq!(contextual.context_for_tag(tag), vec![0, 1, 2, 3, 4]);
         assert_eq!(contextual.successor(2), None);

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -22,7 +22,7 @@ use super::decode::parse_tag;
 use super::index::{PoolIndex, SnapshotCache};
 use super::layout::{LayoutCache, SessionKey};
 use super::snapshot::SnapshotWalker;
-use super::{PoolSpan, PoolState};
+use super::{PoolDiagnostics, PoolSpan, PoolState};
 use crate::dbgeng::{DbgEngError, DebugEngine};
 
 const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
@@ -207,7 +207,12 @@ pub struct PoolSnapshotReport {
     /// anything — `walk_vs` clears it when a readable region stops mid-chunk. A caller
     /// that wants to reject partial results has to consult this, not the diagnostics.
     pub complete: bool,
-    pub diagnostics: Vec<String>,
+    /// What the walk complained about, grouped by shape.
+    ///
+    /// Ask it for [`PoolDiagnostics::emitted`] when reporting how much the walk complained:
+    /// the messages it carries verbatim are a capped sample, so counting them measures the
+    /// cap rather than the target.
+    pub diagnostics: PoolDiagnostics,
 }
 
 /// Summarises the cached snapshot: how much was walked, and what the walk could not do.
@@ -441,7 +446,7 @@ mod tests {
     fn index_of(spans: Vec<PoolSpan>) -> PoolIndex {
         PoolIndex::build(crate::pool::PoolSnapshot {
             spans,
-            diagnostics: Vec::new(),
+            diagnostics: PoolDiagnostics::default(),
             complete: true,
         })
     }
@@ -604,13 +609,17 @@ mod tests {
     fn test_empty_walk_still_reports_why() {
         let index = PoolIndex::build(crate::pool::PoolSnapshot {
             spans: Vec::new(),
-            diagnostics: vec!["cannot read pool node 0 heap 2".into()],
+            diagnostics: PoolDiagnostics::from_iter(["cannot read pool node 0 heap 2".to_string()]),
             complete: false,
         });
         let report = report_of(&index);
         assert_eq!(report.total_chunks, 0);
         assert_eq!(report.allocated_chunks, 0);
-        assert_eq!(report.diagnostics, vec!["cannot read pool node 0 heap 2"]);
+        assert_eq!(
+            report.diagnostics.examples(),
+            ["cannot read pool node 0 heap 2"]
+        );
+        assert_eq!(report.diagnostics.emitted(), 1);
     }
 
     #[test]

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -189,11 +189,11 @@ pub(crate) fn render_pool_map(index: &PoolIndex, options: RenderOptions) -> Vec<
     }
 
     let mut chunks = Vec::new();
-    for diagnostic in &index.diagnostics {
+    for diagnostic in index.diagnostics.lines() {
         let diagnostic = if options.dml {
-            escape_dml(diagnostic)
+            escape_dml(&diagnostic)
         } else {
-            diagnostic.clone()
+            diagnostic
         };
         push_chunked(
             &mut chunks,
@@ -336,6 +336,7 @@ pub(crate) fn render_advice(index: &PoolIndex, tag: u32, dml: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pool::PoolDiagnostics;
     use crate::pool::snapshot::PoolSnapshot;
 
     fn span(
@@ -409,7 +410,9 @@ mod tests {
         let index = PoolIndex::build(PoolSnapshot {
             spans,
             complete: true,
-            diagnostics: vec!["per-session paged heaps are not included".into()],
+            diagnostics: PoolDiagnostics::from_iter([
+                "per-session paged heaps are not included".to_string()
+            ]),
         });
         let plain = render_pool_map(
             &index,
@@ -497,7 +500,7 @@ mod tests {
         let many_index = PoolIndex::build(PoolSnapshot {
             spans: many,
             complete: true,
-            diagnostics: vec![],
+            diagnostics: PoolDiagnostics::default(),
         });
         let dml_chunks = render_pool_map(
             &many_index,

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1435,7 +1435,7 @@ fn lookup_big_page_target(
 }
 
 /// How many verbatim examples of one kind of diagnostic to keep.
-const DIAGNOSTIC_EXAMPLES: usize = 8;
+pub const DIAGNOSTIC_EXAMPLES: usize = 8;
 
 /// The shape of a diagnostic: the message with every number standing in for itself.
 ///
@@ -1455,46 +1455,131 @@ fn diagnostic_shape(message: &str) -> String {
         .join(" ")
 }
 
-/// Collapse floods of near-identical diagnostics into examples plus a count.
+/// One kind of complaint, and how many times the walk made it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticShape {
+    /// The message with every number standing in for itself, so that the same complaint
+    /// about different addresses is one shape and a different complaint is not.
+    pub shape: String,
+    /// How many messages of this shape the walk emitted, including any kept verbatim in
+    /// [`PoolDiagnostics::examples`].
+    pub total: usize,
+}
+
+/// What a walk complained about: a bounded verbatim sample, and the per-shape totals that
+/// say what the sample left out.
 ///
 /// A live target keeps allocating between the reads that make up one walk, so a single
 /// stale list pointer yields one "unreadable ... node" line per node — 14k of them measured
-/// on a busy kernel. That buries the handful of *distinct* problems a reader needs, and
-/// every consumer truncates the list anyway, so which ones survive is decided by position
-/// rather than by significance.
+/// on a busy kernel. Keeping them all buries the handful of *distinct* problems a reader
+/// needs, and every consumer truncates the list anyway, so which ones survive gets decided
+/// by position rather than by significance. Hence the cap of [`DIAGNOSTIC_EXAMPLES`] kept
+/// messages per shape.
 ///
-/// Nothing is dropped silently: each group keeps its first [`DIAGNOSTIC_EXAMPLES`] verbatim
-/// and the rest become a count, so the volume — the number that says the walk was fighting a
-/// moving target — is still on the page. Summaries go at the end, in the order the groups
-/// first appeared, rather than interleaved where a group's last member happened to land.
-fn collapse_repeats(diagnostics: Vec<String>) -> Vec<String> {
-    let mut counts: HashMap<String, usize> = HashMap::new();
-    let mut order: Vec<String> = Vec::new();
-    let mut kept: Vec<String> = Vec::new();
-    for message in diagnostics {
+/// The totals are why this is a type rather than a `Vec<String>`. Flattened to text they
+/// survive only as prose inside a summary line, and a consumer that counts the lines it
+/// received is measuring this cap — then printing the answer as a property of the target.
+/// A walk that emitted 7,700 complaints reporting "71 diagnostics" is the specific failure
+/// the module exists to avoid, so the numbers travel as numbers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PoolDiagnostics {
+    examples: Vec<String>,
+    shapes: Vec<DiagnosticShape>,
+    /// Where each seen shape sits in `shapes`. Derived from it, not state of its own.
+    positions: HashMap<String, usize>,
+}
+
+impl PoolDiagnostics {
+    /// Records one complaint, keeping it verbatim only while its shape has room.
+    pub(crate) fn push(&mut self, message: String) {
         let shape = diagnostic_shape(&message);
-        let count = counts.entry(shape.clone()).or_insert_with(|| {
-            order.push(shape);
-            0
-        });
-        *count += 1;
-        if *count <= DIAGNOSTIC_EXAMPLES {
-            kept.push(message);
+        let position = match self.positions.get(&shape) {
+            Some(&position) => position,
+            None => {
+                self.shapes.push(DiagnosticShape {
+                    shape: shape.clone(),
+                    total: 0,
+                });
+                let position = self.shapes.len() - 1;
+                self.positions.insert(shape, position);
+                position
+            }
+        };
+        let seen = &mut self.shapes[position];
+        seen.total += 1;
+        if seen.total <= DIAGNOSTIC_EXAMPLES {
+            self.examples.push(message);
         }
     }
-    for shape in order {
-        let total = counts[&shape];
-        if let Some(collapsed) = total.checked_sub(DIAGNOSTIC_EXAMPLES).filter(|n| *n > 0) {
-            kept.push(format!("... and {collapsed} more like `{shape}`"));
+
+    /// Whether the walk complained at all.
+    pub fn is_empty(&self) -> bool {
+        self.shapes.is_empty()
+    }
+
+    /// How many messages the walk emitted, the ones collapsed away included.
+    ///
+    /// This is the number that describes the *walk*; `examples().len()` and `lines().len()`
+    /// describe this struct, and on a busy target the two differ by two orders of magnitude.
+    pub fn emitted(&self) -> usize {
+        self.shapes.iter().map(|seen| seen.total).sum()
+    }
+
+    /// The messages kept verbatim, in the order the walk emitted them.
+    ///
+    /// Emission order rather than by shape because heaps are walked in order, so the tail is
+    /// the most recently discovered ones — which is what a caller printing "the last few" is
+    /// reaching for.
+    pub fn examples(&self) -> &[String] {
+        &self.examples
+    }
+
+    /// The shapes, in the order they were first seen.
+    pub fn shapes(&self) -> &[DiagnosticShape] {
+        &self.shapes
+    }
+
+    /// The whole thing as text: every kept example, then one summary line per shape that had
+    /// more than the cap.
+    ///
+    /// Summaries go at the end, in the order the shapes first appeared, rather than
+    /// interleaved where a shape's last kept member happened to land. For display only —
+    /// [`Self::emitted`] is the count, and the length of this is not.
+    pub fn lines(&self) -> Vec<String> {
+        let mut lines = self.examples.clone();
+        for seen in &self.shapes {
+            if let Some(collapsed) = seen
+                .total
+                .checked_sub(DIAGNOSTIC_EXAMPLES)
+                .filter(|more| *more > 0)
+            {
+                lines.push(format!("... and {collapsed} more like `{}`", seen.shape));
+            }
+        }
+        lines
+    }
+}
+
+impl Extend<String> for PoolDiagnostics {
+    fn extend<T: IntoIterator<Item = String>>(&mut self, messages: T) {
+        for message in messages {
+            self.push(message);
         }
     }
-    kept
+}
+
+impl FromIterator<String> for PoolDiagnostics {
+    fn from_iter<T: IntoIterator<Item = String>>(messages: T) -> Self {
+        let mut diagnostics = Self::default();
+        diagnostics.extend(messages);
+        diagnostics
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PoolSnapshot {
     pub spans: Vec<PoolSpan>,
-    pub diagnostics: Vec<String>,
+    pub diagnostics: PoolDiagnostics,
     pub complete: bool,
 }
 
@@ -1635,7 +1720,9 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     pub(crate) fn walk(&self, budget: Option<Duration>) -> Result<PoolSnapshot, SnapshotError> {
         let (discovery_deadline, walk_deadline) = budget_deadlines(Instant::now(), budget);
         let mut snapshot = PoolSnapshot {
-            diagnostics: vec!["per-session paged heaps are not included".into()],
+            diagnostics: PoolDiagnostics::from_iter([
+                "per-session paged heaps are not included".to_string()
+            ]),
             complete: true,
             ..PoolSnapshot::default()
         };
@@ -1655,7 +1742,9 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         if !discovery.diagnostics.is_empty() {
             snapshot.complete = false;
         }
-        snapshot.diagnostics.append(&mut discovery.diagnostics);
+        snapshot
+            .diagnostics
+            .extend(std::mem::take(&mut discovery.diagnostics));
 
         // The full deadline, so regions found before discovery ran out of its share still get
         // walked with the time discovery did not use.
@@ -1703,7 +1792,6 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         snapshot
             .spans
             .sort_by_key(|span| (span.heap, span.usable_address));
-        snapshot.diagnostics = collapse_repeats(snapshot.diagnostics);
         Ok(snapshot)
     }
 
@@ -2249,7 +2337,7 @@ mod tests {
         };
         let mut snapshot = PoolSnapshot {
             spans: Vec::new(),
-            diagnostics: Vec::new(),
+            diagnostics: PoolDiagnostics::default(),
             complete: true,
         };
         walker.walk_lfh(&region, 0x1f80, &memory.bytes, &mut snapshot);
@@ -3225,12 +3313,14 @@ mod tests {
         assert!(
             snapshot
                 .diagnostics
+                .examples()
                 .iter()
                 .any(|message| { message.contains("per-session paged heaps are not included") })
         );
         assert!(
             snapshot
                 .diagnostics
+                .examples()
                 .iter()
                 .any(|message| message.contains("only committed through"))
         );
@@ -3330,6 +3420,7 @@ mod tests {
         assert!(
             snapshot
                 .diagnostics
+                .examples()
                 .iter()
                 .any(|message| message.contains("ran out of its")
                     && message.contains("discovered regions")),
@@ -3358,6 +3449,7 @@ mod tests {
                 assert!(
                     !snapshot
                         .diagnostics
+                        .examples()
                         .iter()
                         .any(|message| message.contains(absorbed)),
                     "budget {allowance}: a per-unit handler absorbed the halt as \
@@ -3689,6 +3781,7 @@ mod tests {
         assert!(
             snapshot
                 .diagnostics
+                .examples()
                 .iter()
                 .any(|message| message.contains("cannot read region")),
             "the failure has to be said out loud: {:?}",
@@ -3730,6 +3823,7 @@ mod tests {
         let snapshot = walk_impatiently(120);
         let summary = snapshot
             .diagnostics
+            .examples()
             .iter()
             .find(|message| message.contains("discovered regions"))
             .expect("the walk stopped short and must say so");
@@ -3896,6 +3990,15 @@ mod tests {
 
     // ---- diagnostic floods -------------------------------------------------------------
 
+    /// A thousand of one complaint and one of another, the shape of a real flood.
+    fn flooded() -> PoolDiagnostics {
+        let mut diagnostics: Vec<String> = (0..1000)
+            .map(|node| format!("unreadable VS free tree node {node:#x}: sparse memory"))
+            .collect();
+        diagnostics.push("rejecting implausible LFH unit size 3 at 0x1000".into());
+        PoolDiagnostics::from_iter(diagnostics)
+    }
+
     /// A live target keeps allocating between the reads of one walk, so a single stale list
     /// pointer yields one complaint per node — 14k of them measured on a busy kernel, which
     /// buries the few distinct problems and leaves every consumer truncating by position.
@@ -3903,30 +4006,75 @@ mod tests {
     /// finding, so it must survive.
     #[test]
     fn test_a_flood_of_one_complaint_becomes_examples_plus_a_count() {
-        let mut diagnostics: Vec<String> = (0..1000)
-            .map(|node| format!("unreadable VS free tree node {node:#x}: sparse memory"))
-            .collect();
-        diagnostics.push("rejecting implausible LFH unit size 3 at 0x1000".into());
-
-        let collapsed = collapse_repeats(diagnostics);
+        let diagnostics = flooded();
 
         assert_eq!(
-            collapsed.len(),
-            DIAGNOSTIC_EXAMPLES + 2,
-            "expected {DIAGNOSTIC_EXAMPLES} examples, the distinct message, and one summary"
+            diagnostics.examples().len(),
+            DIAGNOSTIC_EXAMPLES + 1,
+            "expected {DIAGNOSTIC_EXAMPLES} examples of the flood, plus the distinct message"
         );
-        assert!(collapsed[0].contains("unreadable VS free tree node 0x0"));
+        assert!(diagnostics.examples()[0].contains("unreadable VS free tree node 0x0"));
         assert!(
-            collapsed
+            diagnostics
+                .examples()
                 .iter()
                 .any(|message| message.contains("rejecting implausible LFH unit size")),
             "a distinct complaint must not be collapsed away by a flood of another"
         );
+
+        let totals: Vec<usize> = diagnostics.shapes().iter().map(|seen| seen.total).collect();
+        assert_eq!(
+            totals,
+            vec![1000, 1],
+            "shapes carry the whole count each, in the order first seen: {:?}",
+            diagnostics.shapes()
+        );
         assert!(
-            collapsed.last().is_some_and(
-                |message| message.contains(&format!("and {} more", 1000 - DIAGNOSTIC_EXAMPLES))
+            diagnostics.lines().last().is_some_and(
+                |line| line.contains(&format!("and {} more", 1000 - DIAGNOSTIC_EXAMPLES))
             ),
-            "the count is the finding and has to survive: {collapsed:?}"
+            "the rendering owes the reader the count too: {:?}",
+            diagnostics.lines()
+        );
+    }
+
+    /// The count of the *walk* is not the count of what survived the cap, and the gap is two
+    /// orders of magnitude on a real target. Reporting the latter as the former — measured
+    /// once as "71 diagnostics" for a walk that made ~7,700 complaints — describes the
+    /// collapsing as though it were a property of the pool, which is precisely the lie this
+    /// module is built to avoid.
+    #[test]
+    fn test_the_emitted_count_is_the_walk_not_the_sample() {
+        let diagnostics = flooded();
+
+        assert_eq!(diagnostics.emitted(), 1001, "every message is counted");
+        assert!(
+            diagnostics.emitted() > diagnostics.lines().len() * 50,
+            "a caller that counted lines ({}) instead of messages ({}) would be off by two \
+             orders of magnitude and never know",
+            diagnostics.lines().len(),
+            diagnostics.emitted()
+        );
+    }
+
+    /// Merging is by message, not by wholesale concatenation: discovery's complaints join the
+    /// walk's own shapes rather than starting fresh ones, or a flood split across the two
+    /// phases would keep twice the examples and report itself as two findings.
+    #[test]
+    fn test_extending_merges_into_the_shapes_already_seen() {
+        let mut diagnostics = flooded();
+        diagnostics.extend(
+            (1000..1010)
+                .map(|node| format!("unreadable VS free tree node {node:#x}: sparse memory")),
+        );
+
+        assert_eq!(diagnostics.shapes().len(), 2, "no shape was duplicated");
+        assert_eq!(diagnostics.shapes()[0].total, 1010);
+        assert_eq!(diagnostics.emitted(), 1011);
+        assert_eq!(
+            diagnostics.examples().len(),
+            DIAGNOSTIC_EXAMPLES + 1,
+            "the cap holds across the merge"
         );
     }
 


### PR DESCRIPTION
Upstream half of glslang/windbg-mcp#77.

## The problem

`collapse_repeats` folded a walk's diagnostics into a `Vec<String>` — up to eight
verbatim examples per shape, then one `... and 5621 more like \`<shape>\`` line per
collapsed group. The per-shape totals existed only inside that prose.

So every count a consumer could reach was `diagnostics.len()`, which counts *lines that
survived the cap*. Measured on a live 26100 kernel, `windbg-mcp` rendered:

```text
71 diagnostic(s) in 24 categories:
```

for a walk that emitted roughly **7,700** complaints. The line reads as a measurement of
the target and is an artifact of this crate's processing — the one thing the collapsing
exists to avoid. Two smaller faults follow from the same cause: the summary lines get
re-grouped downstream as if they were findings, and their counts get masked by the
consumer's own address-blanking (`and 5621 more` → `and <addr> more`).

None of it is fixable downstream. Recovering the totals would mean parsing numbers back
out of strings this crate formats.

## The change

The grouping now travels as a type instead of as text:

```rust
pub struct DiagnosticShape { pub shape: String, pub total: usize }

pub struct PoolDiagnostics { /* examples, shapes, positions */ }
impl PoolDiagnostics {
    pub fn emitted(&self) -> usize;          // what the walk said
    pub fn examples(&self) -> &[String];     // the capped sample, in emission order
    pub fn shapes(&self) -> &[DiagnosticShape];
    pub fn lines(&self) -> Vec<String>;      // the old rendering, for display
    pub fn is_empty(&self) -> bool;
}
```

`PoolSnapshot`, `PoolIndex` and the public `PoolSnapshotReport` carry it in place of
`Vec<String>`.

Two things fall out:

- **Grouping happens on `push`**, so there is no collapse pass at the end and the flood is
  never held whole. The 14k-complaint walk that motivated the cap no longer accumulates
  14k strings in order to discard most of them.
- **`lines()` reproduces the old collapse output exactly** — examples in emission order,
  then one summary per over-cap shape in first-seen order — so `!poolmap` renders
  unchanged.

Emission order is preserved for `examples()` deliberately: heaps are walked in order, so
a caller printing \"the last few\" is reaching for recency, which shape-ordering would
destroy.

## Verification

`cargo test --lib` — 67 pass. Three tests cover the new behaviour, and the central one
was checked by mutation: reverting `emitted()` to `self.lines().len()` (i.e. the bug)
fails `test_the_emitted_count_is_the_walk_not_the_sample` and
`test_extending_merges_into_the_shapes_already_seen`.

`cargo clippy --all-targets` is clean apart from one pre-existing warning in
`src/process.rs`, untouched here.

## Note for the dependent PR

This is a breaking change to `PoolSnapshotReport.diagnostics`. `windbg-mcp` needs the
matching change; that PR is prepared and will repin `Cargo.lock` once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Diagnostics are now grouped by shape and include occurrence totals.
  * Diagnostic output preserves a limited number of example messages for clearer reporting.
  * Snapshot and report views now display structured diagnostic information consistently.
  * Diagnostic text is safely escaped when rendered in DML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->