### PR TITLE
fix(pool): read RangeFlags as the kernel does, and say why an LFH header was refused

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ out of it is not an error: it returns the chunks it reached with `complete` clea
 and a diagnostic saying how much of the pool it got through. As everywhere else here,
 “the walk did not see it” is reported as exactly that and never as “it is not there”.
 
+Against a live kernel a walk is **normally incomplete**, and that is the target being
+honest rather than the walker being broken: paged pool is partly out on disk, and a
+page the memory manager has paged out cannot be read through the debugger either. Such
+ranges come back as `sparse virtual range` diagnostics and the chunks inside them are
+absent from the snapshot, so `complete` is cleared. Expect a live walk to carry
+thousands of diagnostics too, and read them by shape (`PoolDiagnostics::shapes`, which
+counts each distinct complaint) rather than by how many lines were kept — one stale
+list pointer or one paged-out region yields one message per node.
+
 When WinDbg accepts DML, map cells have colors and clickable address-detail links.
 The same rows use meaningful ASCII glyphs and include a legend when DML is stripped
 or plain-text output is captured.

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -1,18 +1,65 @@
-use super::PoolState;
+use std::fmt;
+
+use super::{PoolBackend, PoolState};
 
 pub(crate) const PAGE_SIZE: u64 = 0x1000;
 pub(crate) const VS_SIGNATURE: u16 = 0x2bed;
 pub(crate) const PAGE_SEGMENT_SIGNATURE: u64 = 0xa2e6_4ead_a2e6_4ead;
 pub(crate) const DESCRIPTOR_TREE_SIGNATURE: u32 = 0xccdd_ccdd;
-pub(crate) const DESCRIPTOR_FLAG_LFH: u8 = 0x01;
-pub(crate) const DESCRIPTOR_FLAG_COMMITTED: u8 = 0x02;
-pub(crate) const DESCRIPTOR_FLAG_VS: u8 = 0x20;
+
+/// `_HEAP_PAGE_RANGE_DESCRIPTOR.RangeFlags`: the page range is in use.
+///
+/// Set on **every** unit descriptor of the range, not just its first, so on its own it says
+/// nothing about what formats the range's contents — see [`descriptor_backend`].
+pub(crate) const DESCRIPTOR_FLAG_ALLOCATED: u8 = 0x01;
+/// This descriptor is the first of its page range, so its `UnitSize`, `Key` and
+/// `TreeSignature` are the range's own. Interior units carry `UnitOffset` back to it instead.
+pub(crate) const DESCRIPTOR_FLAG_FIRST: u8 = 0x02;
+/// The subsegment is a VS one. Only meaningful together with [`DESCRIPTOR_FLAG_SUBSEGMENT`].
+pub(crate) const DESCRIPTOR_FLAG_VS: u8 = 0x04;
+/// The range holds a subsegment — an `_HEAP_LFH_SUBSEGMENT`, or an `_HEAP_VS_SUBSEGMENT`
+/// when [`DESCRIPTOR_FLAG_VS`] is set too — rather than one plain page-range allocation.
+pub(crate) const DESCRIPTOR_FLAG_SUBSEGMENT: u8 = 0x08;
+
+/// Which allocator formats the contents of a page range, from its descriptor's `RangeFlags`.
+///
+/// These four bits are the kernel's own reading, taken from `nt` on Server 26100:
+/// `nt!RtlpHpFreeHeap` walks back to the range's first descriptor and dispatches on the flags
+/// byte, requiring `0x0b` for the LFH path, exactly `0x0f` for `RtlpHpVsContextFree`, and only
+/// `flags & 3 == 3` for a plain page range. The two producers agree: `RtlpHpSegLfhAllocate`
+/// asks `RtlpHpSegPageRangeAllocate` for `0x08` and `RtlpHpSegVsAllocate` for `0x0c`, and the
+/// allocator masks the caller's request with `0x0c` before adding `0x01` to every unit of the
+/// range.
+///
+/// Reading `0x01` as "LFH" instead — as this did until it was measured — makes *every*
+/// allocated range look like an LFH subsegment: VS subsegments (`0x0f`), page-range and large
+/// allocations (`0x03`) and Verifier special pool (`0x03`) all have it set. Their contents
+/// then fail to decode as a subsegment header and the whole range is dropped, which is the
+/// silent coverage loss behind glslang/win-kexp#90.
+pub(crate) fn descriptor_backend(flags: u8) -> PoolBackend {
+    if flags & DESCRIPTOR_FLAG_SUBSEGMENT == 0 {
+        PoolBackend::Segment
+    } else if flags & DESCRIPTOR_FLAG_VS != 0 {
+        PoolBackend::Vs
+    } else {
+        PoolBackend::Lfh
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Descriptor {
     pub unit_size: u32,
     pub flags: u8,
-    pub committed: bool,
+    /// Whether this descriptor is the first of its page range, and so whether the fields
+    /// decoded from it describe a range at all.
+    pub first: bool,
+}
+
+impl Descriptor {
+    /// Whether the range this descriptor belongs to is in use.
+    pub(crate) fn allocated(&self) -> bool {
+        self.flags & DESCRIPTOR_FLAG_ALLOCATED != 0
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,7 +116,7 @@ pub(crate) fn decode_descriptor(word: u32) -> Option<Descriptor> {
     (unit_size != 0).then_some(Descriptor {
         unit_size,
         flags,
-        committed: flags & DESCRIPTOR_FLAG_COMMITTED != 0,
+        first: flags & DESCRIPTOR_FLAG_FIRST != 0,
     })
 }
 
@@ -144,6 +191,103 @@ pub(crate) fn decode_lfh_offsets(encoded: u32, subsegment: u64, lfh_key: u32) ->
     // the upper half of LfhKey and produces a bogus FirstBlockOffset.
     let decoded = encoded ^ lfh_key ^ (subsegment >> 12) as u32;
     (decoded as u16, (decoded >> 16) as u16)
+}
+
+/// The smallest LFH block the kernel buckets. Anything under it is a misread, not a bucket.
+const LFH_MIN_BLOCK_SIZE: u32 = 8;
+
+/// How an `_HEAP_LFH_SUBSEGMENT` header divides its page range into blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LfhSubsegment {
+    pub block_size: u32,
+    /// Where the first block starts, past the header and block bitmap.
+    pub first: usize,
+    pub blocks: usize,
+}
+
+/// Why an LFH subsegment header was not believed, and the decoded values that say so.
+///
+/// The failing predicate is spelled out in words while the values stay numbers, because
+/// `PoolDiagnostics` collapses messages by shape — numbers fold into `#`, words do not. A walk
+/// therefore reports how many subsegments failed *each* check, and keeps a verbatim sample of
+/// each with its numbers intact. That is what separates the two explanations for a rejection
+/// that a bare count cannot: a header rewritten by the running target between our reads fails
+/// the way a half-built subsegment does and in varying ways, while a field we are decoding
+/// wrongly fails the same way every time, with values that never look like a bucket size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LfhRejection {
+    /// The predicate that failed, as prose with no digits in it.
+    pub reason: &'static str,
+    pub block_size: u32,
+    pub blocks: usize,
+    pub first: usize,
+    pub region_size: usize,
+    /// `BlockOffsets.EncodedData` as read, so a rejected header can be re-decoded by hand
+    /// against another candidate mix without another walk of the target.
+    pub encoded: u32,
+}
+
+impl fmt::Display for LfhRejection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} (block size {:#x}, {} blocks at offset {:#x} of a {:#x} byte range, encoded {:#010x})",
+            self.reason, self.block_size, self.blocks, self.first, self.region_size, self.encoded
+        )
+    }
+}
+
+/// Decodes an LFH subsegment header, or says which plausibility check it failed.
+///
+/// `region_size` is the byte length the page-range descriptor gave for this range.
+/// `nt!RtlpHpLfhSubsegmentInitialize` picks `BlockCount` by dividing exactly that range by the
+/// bucket's block size after reserving `FirstBlockOffset` for the header and block bitmap, so
+/// `first + blocks * block_size <= region_size` holds by construction. A header that does not
+/// fit is one we misread or one that was mid-rewrite while we read it.
+pub(crate) fn decode_lfh_subsegment(
+    encoded: u32,
+    subsegment: u64,
+    lfh_key: u32,
+    blocks: usize,
+    region_size: usize,
+) -> Result<LfhSubsegment, LfhRejection> {
+    let (decoded_block_size, decoded_first) = decode_lfh_offsets(encoded, subsegment, lfh_key);
+    let block_size = u32::from(decoded_block_size);
+    let first = usize::from(decoded_first);
+    let reject = |reason| {
+        Err(LfhRejection {
+            reason,
+            block_size,
+            blocks,
+            first,
+            region_size,
+            encoded,
+        })
+    };
+
+    // Both fields zero is a range committed but not yet made into a subsegment: the encoding
+    // mixes in the subsegment's own address, so an initialised header practically cannot
+    // encode to zero. Worth its own reason — it is the shape of a race, not of a misdecode.
+    if encoded == 0 && blocks == 0 {
+        return reject("header is not initialised");
+    }
+    if blocks == 0 {
+        return reject("block count is zero");
+    }
+    if block_size < LFH_MIN_BLOCK_SIZE {
+        return reject("block size is below the eight byte minimum");
+    }
+    if first >= region_size {
+        return reject("first block offset is past the end of the range");
+    }
+    if blocks.saturating_mul(block_size as usize) > region_size - first {
+        return reject("the blocks overrun the range");
+    }
+    Ok(LfhSubsegment {
+        block_size,
+        first,
+        blocks,
+    })
 }
 
 /// Each LFH slot uses two bits. Bit 0 is the busy state, while bit 1 records
@@ -301,25 +445,31 @@ mod tests {
     fn test_pool_decoder_bounds_and_shifted_offsets() {
         assert_eq!(read_u32(&[0, 1, 2, 3, 4], 1), Some(0x0403_0201));
         assert_eq!(read_u64(&[0; 7], 0), None);
-        let committed = decode_descriptor(0x0200_0020).unwrap();
-        assert_eq!(committed.unit_size, 0x20);
-        assert!(committed.committed);
-        assert!(!decode_descriptor(0x0100_0020).unwrap().committed);
+        let first = decode_descriptor(0x0200_0020).unwrap();
+        assert_eq!(first.unit_size, 0x20);
+        assert!(first.first);
+        assert!(!first.allocated());
+        let interior = decode_descriptor(0x0100_0020).unwrap();
+        assert!(
+            !interior.first,
+            "0x01 marks a unit in use, not a range start"
+        );
+        assert!(interior.allocated());
         assert_eq!(decode_descriptor(0), None);
         let mut descriptor = [0u8; 12];
         descriptor[7] = 0x20;
-        descriptor[3] = DESCRIPTOR_FLAG_COMMITTED;
+        descriptor[3] = DESCRIPTOR_FLAG_FIRST;
         assert_eq!(
             decode_descriptor_at(&descriptor, 2, 10, 5, 1),
             Some(Descriptor {
                 unit_size: 0x20,
-                flags: DESCRIPTOR_FLAG_COMMITTED,
-                committed: true
+                flags: DESCRIPTOR_FLAG_FIRST,
+                first: true
             })
         );
         let mut wide_descriptor = [0u8; 16];
         wide_descriptor[5..8].copy_from_slice(&[0x56, 0x34, 0x12]);
-        wide_descriptor[2] = DESCRIPTOR_FLAG_COMMITTED;
+        wide_descriptor[2] = DESCRIPTOR_FLAG_FIRST;
         assert_eq!(
             decode_descriptor_at(&wide_descriptor, 0, 8, 5, 2)
                 .unwrap()
@@ -381,6 +531,98 @@ mod tests {
                 .unwrap()
                 .pool_index,
             3
+        );
+    }
+
+    /// The flag combinations the kernel itself dispatches on, as read out of `nt` on Server
+    /// 26100: `0x0b` reaches the LFH free path, exactly `0x0f` reaches `RtlpHpVsContextFree`,
+    /// and `flags & 3 == 3` on its own is a plain page-range allocation. Reading the low bit
+    /// as "LFH" made the last two cases parse as LFH subsegments and vanish.
+    #[test]
+    fn test_range_flags_name_the_allocator_that_owns_the_range() {
+        const ALLOCATED: u8 = DESCRIPTOR_FLAG_ALLOCATED | DESCRIPTOR_FLAG_FIRST;
+        assert_eq!(
+            descriptor_backend(ALLOCATED | DESCRIPTOR_FLAG_SUBSEGMENT),
+            PoolBackend::Lfh
+        );
+        assert_eq!(
+            descriptor_backend(ALLOCATED | DESCRIPTOR_FLAG_SUBSEGMENT | DESCRIPTOR_FLAG_VS),
+            PoolBackend::Vs
+        );
+        assert_eq!(descriptor_backend(ALLOCATED), PoolBackend::Segment);
+        // Verifier special pool: an ordinary allocated page range, told apart by its heap.
+        assert_eq!(descriptor_backend(0x03), PoolBackend::Segment);
+        // An interior unit of an allocated range, and a free range: neither is a subsegment.
+        assert_eq!(
+            descriptor_backend(DESCRIPTOR_FLAG_ALLOCATED),
+            PoolBackend::Segment
+        );
+        assert_eq!(
+            descriptor_backend(DESCRIPTOR_FLAG_FIRST),
+            PoolBackend::Segment
+        );
+    }
+
+    /// Every rejection has to name the check it failed and carry the values that failed it.
+    /// A walk against a live 26100 kernel rejected 5.5k subsegments as one undifferentiated
+    /// "implausible", which cannot distinguish a header rewritten under us from a field we
+    /// decode wrongly — the whole point of glslang/win-kexp#90.
+    #[test]
+    fn test_lfh_rejections_name_their_predicate_and_carry_their_values() {
+        let subsegment = 0xffff_8c8f_0d60_2000;
+        let lfh_key = 0xa5c3_1357u32;
+        let encode = |block_size: u16, first: u16| {
+            (u32::from(block_size) | (u32::from(first) << 16)) ^ lfh_key ^ (subsegment >> 12) as u32
+        };
+        let decode = |encoded, blocks, region_size| {
+            decode_lfh_subsegment(encoded, subsegment, lfh_key, blocks, region_size)
+        };
+
+        assert_eq!(
+            decode(encode(0x70, 0x40), 0x24, 0x1000),
+            Ok(LfhSubsegment {
+                block_size: 0x70,
+                first: 0x40,
+                blocks: 0x24
+            })
+        );
+        // The kernel divides the range exactly, so a header that fills it is not suspicious.
+        assert!(decode(encode(0x40, 0x40), 0x3f, 0x1000).is_ok());
+
+        let reasons = |cases: &[(u32, usize, usize)]| {
+            cases
+                .iter()
+                .map(|&(encoded, blocks, region_size)| {
+                    decode(encoded, blocks, region_size).unwrap_err().reason
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            reasons(&[
+                (0, 0, 0x1000),
+                (encode(0x70, 0x40), 0, 0x1000),
+                (encode(4, 0x40), 0x24, 0x1000),
+                (encode(0x70, 0x2000), 0x24, 0x1000),
+                (encode(0x70, 0x40), 0x100, 0x1000),
+            ]),
+            [
+                "header is not initialised",
+                "block count is zero",
+                "block size is below the eight byte minimum",
+                "first block offset is past the end of the range",
+                "the blocks overrun the range",
+            ]
+        );
+
+        let rejection = decode(encode(0x70, 0x40), 0x100, 0x1000).unwrap_err();
+        let message = rejection.to_string();
+        assert!(
+            message.contains("0x70") && message.contains("256") && message.contains("0x40"),
+            "a rejection has to show what it decoded: {message}"
+        );
+        assert!(
+            message.contains(&format!("{:#010x}", rejection.encoded)),
+            "and the raw word, so it can be re-decoded without another walk: {message}"
         );
     }
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -5,11 +5,11 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use super::decode::{
-    DESCRIPTOR_FLAG_LFH, DESCRIPTOR_FLAG_VS, PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header,
-    big_page_probe, decode_descriptor_at, decode_large_allocation, decode_lfh_offsets,
-    decode_pool_header, decode_rb_root, decode_slist_header_next, decode_vs_sizes,
-    lfh_bitmap_state, read_u16, read_u32, read_u64, valid_descriptor_tree_signature,
-    valid_page_segment_signature, valid_vs_signature,
+    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_probe, decode_descriptor_at,
+    decode_large_allocation, decode_lfh_subsegment, decode_pool_header, decode_rb_root,
+    decode_slist_header_next, decode_vs_sizes, descriptor_backend, lfh_bitmap_state, read_u16,
+    read_u32, read_u64, valid_descriptor_tree_signature, valid_page_segment_signature,
+    valid_vs_signature,
 };
 use super::{
     HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState,
@@ -1067,7 +1067,9 @@ fn discover_segment_context(
                 descriptor_index += 1;
                 continue;
             };
-            if decoded.committed
+            // `TreeSignature` shares its bytes with the range's tree node, so it only means
+            // anything on the descriptor that *is* the range's node — its first.
+            if decoded.first
                 && !read_u32(&metadata, offset + tree_signature_offset)
                     .is_some_and(valid_descriptor_tree_signature)
             {
@@ -1088,20 +1090,17 @@ fn discover_segment_context(
                 descriptor_index += unit_size.max(1);
                 continue;
             }
-            // Verifier special pool sets DESCRIPTOR_FLAG_LFH on its page-range descriptors,
-            // but the page holds a pool header plus fill rather than a subsegment. Parsing
-            // it as LFH rejects the range outright ("implausible LFH metadata") *during
-            // region creation*, so the allocation never reaches the walk at all — which is
-            // why classifying it correctly here, and not just at dispatch time, is what
-            // makes special-pool chunks visible. `walk_region` routes on `heap.special`.
+            // Getting this wrong is expensive in the quietest way available: a range parsed as
+            // the wrong kind of subsegment fails to decode and is dropped *during region
+            // creation*, so its allocations never reach the walk at all and nothing downstream
+            // can tell they existed. Verifier special pool is the one range whose flags cannot
+            // answer the question — a special-pool page range is a plain allocated range
+            // (`0x03`), but it holds a pool header plus fill laid out page-granularly, so it is
+            // routed by the heap it came from. `walk_region` routes the same way.
             let backend = if identity.special {
                 PoolBackend::Segment
-            } else if decoded.flags & DESCRIPTOR_FLAG_LFH != 0 {
-                PoolBackend::Lfh
-            } else if decoded.flags & DESCRIPTOR_FLAG_VS != 0 {
-                PoolBackend::Vs
             } else {
-                PoolBackend::Segment
+                descriptor_backend(decoded.flags)
             };
             let mut region_address = address;
             let mut region_size = size;
@@ -1124,28 +1123,30 @@ fn discover_segment_context(
                     }
                 };
                 let encoded = read_u32(&header, offsets).unwrap_or(0);
-                let (decoded_block_size, decoded_first) =
-                    decode_lfh_offsets(encoded, address, lfh_key as u32);
-                block_size = u32::from(decoded_block_size);
-                let first = usize::from(decoded_first);
                 let blocks = read_u16(&header, count_offset)
                     .map(usize::from)
                     .unwrap_or(0);
-                if block_size < 8
-                    || blocks == 0
-                    || first >= region_size
-                    || blocks.saturating_mul(block_size as usize) > region_size - first
-                {
-                    discovery.diagnostics.push(format!(
-                        "rejecting implausible LFH metadata at {address:#x}"
-                    ));
-                    descriptor_index += unit_size;
-                    continue;
-                }
+                let lfh = match decode_lfh_subsegment(
+                    encoded,
+                    address,
+                    lfh_key as u32,
+                    blocks,
+                    region_size,
+                ) {
+                    Ok(lfh) => lfh,
+                    Err(rejection) => {
+                        discovery.diagnostics.push(format!(
+                            "rejecting LFH subsegment {address:#x}: {rejection}"
+                        ));
+                        descriptor_index += unit_size;
+                        continue;
+                    }
+                };
+                block_size = lfh.block_size;
                 bitmap = match guarded_read(
                     memory,
                     address + bitmap_offset as u64,
-                    blocks.div_ceil(4),
+                    lfh.blocks.div_ceil(4),
                 ) {
                     Ok(bytes) => bytes,
                     Err(error) => {
@@ -1156,8 +1157,8 @@ fn discover_segment_context(
                         continue;
                     }
                 };
-                region_address += first as u64;
-                region_size = blocks * block_size as usize;
+                region_address += lfh.first as u64;
+                region_size = lfh.blocks * block_size as usize;
             } else if backend == PoolBackend::Vs {
                 let vs = layout.type_layout("_HEAP_VS_SUBSEGMENT")?;
                 let header = match guarded_read(memory, address, vs.size as usize) {
@@ -1193,7 +1194,9 @@ fn discover_segment_context(
                 block_size = 0;
             }
             let descriptor_node = metadata_address + offset as u64 + tree_node_offset as u64;
-            let state = if free_nodes.contains(&descriptor_node) || !decoded.committed {
+            // Two independent ways to be free, and either is enough: the range sits in the
+            // segment's free-page tree, or its own flags say it is not in use.
+            let state = if free_nodes.contains(&descriptor_node) || !decoded.allocated() {
                 PoolState::ReusableFree
             } else {
                 PoolState::Allocated
@@ -1857,11 +1860,11 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                     continue;
                 }
             };
-            // Verifier special pool is page-granular, and its page-range descriptors still
-            // carry DESCRIPTOR_FLAG_LFH — so this has to come *before* the backend
-            // dispatch. Left to `walk_lfh`, the range's "subsegment header" is really a
-            // pool header plus fill, the block bitmap is nonsense, and every allocation in
-            // the heap silently disappears from the snapshot.
+            // Verifier special pool is page-granular and its ranges are indistinguishable
+            // from any other plain page range by their flags, so this has to come *before*
+            // the backend dispatch. Walked as page ranges instead, the pool header plus
+            // 0xfd fill decodes as garbage and every allocation in the heap silently
+            // disappears from the snapshot.
             if region.heap.special {
                 self.walk_special_pool(region, valid_base, &bytes, snapshot);
                 cursor = valid_end;
@@ -2662,9 +2665,20 @@ mod tests {
         );
     }
     use crate::pool::{
-        decode::DESCRIPTOR_FLAG_COMMITTED,
+        decode::{
+            DESCRIPTOR_FLAG_ALLOCATED, DESCRIPTOR_FLAG_FIRST, DESCRIPTOR_FLAG_SUBSEGMENT,
+            DESCRIPTOR_FLAG_VS,
+        },
         layout::{SessionKey, TypeLayout},
     };
+
+    /// `RangeFlags` for an in-use page range: allocated, and the range's first descriptor.
+    /// The kernel's own free path insists on both before it looks at anything else.
+    const RANGE_IN_USE: u8 = DESCRIPTOR_FLAG_ALLOCATED | DESCRIPTOR_FLAG_FIRST;
+    /// An LFH subsegment range, as `nt!RtlpHpFreeHeap` requires it: `0x0b`.
+    const RANGE_LFH: u8 = RANGE_IN_USE | DESCRIPTOR_FLAG_SUBSEGMENT;
+    /// A VS subsegment range: `0x0f`.
+    const RANGE_VS: u8 = RANGE_LFH | DESCRIPTOR_FLAG_VS;
 
     const K: u64 = 0xffff_8000_0000_0000;
     const STATE: u64 = K + 0x10_0000;
@@ -3111,18 +3125,14 @@ mod tests {
         );
         fill(&mut bytes, SEGMENT + 0x100, 16 * 0x20);
         for (index, units, flags) in [
-            (
-                1u64,
-                2u8,
-                DESCRIPTOR_FLAG_LFH | DESCRIPTOR_FLAG_COMMITTED | 0x0c,
-            ),
-            (3, 2, DESCRIPTOR_FLAG_VS | DESCRIPTOR_FLAG_COMMITTED | 0x0c),
-            (5, 1, DESCRIPTOR_FLAG_COMMITTED | 0x0c),
+            (1u64, 2u8, RANGE_LFH),
+            (3, 2, RANGE_VS),
+            (5, 1, RANGE_IN_USE),
             (6, 1, 0x00),
-            (7, 1, DESCRIPTOR_FLAG_COMMITTED | 0x0c),
+            (7, 1, RANGE_IN_USE),
         ] {
             let descriptor = SEGMENT + 0x100 + index * 0x20;
-            if flags & DESCRIPTOR_FLAG_COMMITTED != 0 {
+            if flags & DESCRIPTOR_FLAG_FIRST != 0 {
                 put_u32(
                     &mut bytes,
                     descriptor,
@@ -3495,6 +3505,102 @@ mod tests {
         );
     }
 
+    /// A segment holding one plain allocated page range and one free range, and nothing else.
+    ///
+    /// Neither is a subsegment, and that is the point: with `RangeFlags` bit `0x01` read as
+    /// "LFH", both look like LFH subsegment ranges, their page contents decode as a subsegment
+    /// header, and they are discarded before the walk ever sees them. The free range is
+    /// deliberately *not* in the free-page tree, so its state has to come from its own flags.
+    fn segment_of_plain_page_ranges(heap_key: u64) -> SyntheticMemory {
+        let mut bytes = Writes::default();
+        let context = HEAP + 0x100;
+
+        fill(&mut bytes, HEAP, 0x800);
+        put_u64(&mut bytes, context, SEGMENT); // SegmentListHead
+        put(&mut bytes, context + 0x20, &[12, 1]); // UnitShift, FirstDescriptorIndex
+        put_u64(&mut bytes, context + 0x28, !0xffffu64); // SegmentMask: 16 descriptors
+
+        fill(&mut bytes, SEGMENT, 0x300);
+        put_u64(&mut bytes, SEGMENT, context); // ListEntry back to the head: one segment
+        put_u64(
+            &mut bytes,
+            SEGMENT + 0x20,
+            SEGMENT ^ context ^ heap_key ^ super::super::decode::PAGE_SEGMENT_SIGNATURE,
+        );
+        for (index, flags) in [(1u64, RANGE_IN_USE), (2, DESCRIPTOR_FLAG_FIRST)] {
+            let descriptor = SEGMENT + 0x100 + index * 0x20;
+            put_u32(
+                &mut bytes,
+                descriptor,
+                super::super::decode::DESCRIPTOR_TREE_SIGNATURE,
+            );
+            put(&mut bytes, descriptor + 0x18, &[flags]);
+            put(&mut bytes, descriptor + 0x1f, &[1]);
+        }
+        SyntheticMemory::new(bytes, Vec::new())
+    }
+
+    /// A page range that is not a subsegment must be walked as page ranges, not rejected.
+    ///
+    /// This is glslang/win-kexp#90 at the smallest scale that shows it. Every allocated range
+    /// carries `RangeFlags` bit `0x01`, so reading that bit as "this is an LFH subsegment"
+    /// sends plain page-range allocations, VS subsegments and Verifier special pool alike
+    /// through the LFH decoder, which refuses the result and drops the range — silently, and
+    /// before any of its allocations can be indexed.
+    #[test]
+    fn test_a_plain_page_range_is_not_taken_for_an_lfh_subsegment() {
+        let heap_key = 0x55aa_1234_9876_0000;
+        let memory = segment_of_plain_page_ranges(heap_key);
+        let layout = synthetic_layout();
+        let mut discovery = Discovery::default();
+
+        discover_segment_context(
+            &memory,
+            &layout,
+            HEAP + 0x100,
+            0,
+            PoolKind::NonPagedNx,
+            HeapIdentity {
+                pool_state: STATE,
+                heap: HEAP,
+                special: false,
+            },
+            heap_key,
+            0xa5c3_1357,
+            1024,
+            &SharedChunks::default(),
+            &SharedChunks::default(),
+            &mut discovery,
+        )
+        .expect("the fixture is readable throughout");
+
+        assert!(
+            discovery.diagnostics.is_empty(),
+            "nothing here is a subsegment, so nothing should have been decoded as one: {:?}",
+            discovery.diagnostics
+        );
+        let described: Vec<_> = discovery
+            .regions
+            .iter()
+            .map(|region| (region.address, region.backend, region.states.as_slice()))
+            .collect();
+        assert_eq!(
+            described,
+            [
+                (
+                    SEGMENT + 0x1000,
+                    PoolBackend::Segment,
+                    [PoolState::Allocated].as_slice()
+                ),
+                (
+                    SEGMENT + 0x2000,
+                    PoolBackend::Segment,
+                    [PoolState::ReusableFree].as_slice()
+                ),
+            ]
+        );
+    }
+
     /// One page segment whose every descriptor is a committed LFH range.
     ///
     /// The shared fixture has five descriptors in a sixteen-slot array and only one of them
@@ -3529,11 +3635,7 @@ mod tests {
                 descriptor,
                 super::super::decode::DESCRIPTOR_TREE_SIGNATURE,
             );
-            put(
-                &mut bytes,
-                descriptor + 0x18,
-                &[DESCRIPTOR_FLAG_LFH | DESCRIPTOR_FLAG_COMMITTED | 0x0c],
-            );
+            put(&mut bytes, descriptor + 0x18, &[RANGE_LFH]);
             put(&mut bytes, descriptor + 0x1f, &[1]);
         }
         SyntheticMemory::new(bytes, Vec::new())


### PR DESCRIPTION
Closes #90 (pending the live re-measurement below).

## What the 5,532 rejections were

Not LFH subsegments. `_HEAP_PAGE_RANGE_DESCRIPTOR.RangeFlags` bit `0x01` means the
range is **in use** — the allocator sets it on *every* unit of *every* allocated range.
Reading it as "this is an LFH subsegment" sent VS subsegments, plain page-range and
large allocations, and Verifier special pool through the LFH decoder, which refused the
result and dropped the whole range **at region creation**, before any of its allocations
could be indexed. Bit `0x20`, read as "VS", is never set, so the VS decoder was
unreachable from a descriptor at all.

So this was not a diagnostic-noise issue: it was silent coverage loss of exactly the
kind `find_tag` is built to avoid, and the two facts fit each other — 5.5k stable
rejections, and no `rejecting VS subsegment` diagnostics in the live run despite VS
being a whole size class of the kernel pool.

## The kernel's own reading

Taken from `nt` on Server 26100 (the sample kernel dump in `windbg-mcp/docs/samples`
carries matching `ntkrnlmp` symbols, so this is reproducible without a live target):

| site | what it says |
|---|---|
| `nt!RtlpHpFreeHeap` | steps back `UnitOffset` to the range's first descriptor, then dispatches: `RangeFlags == 0x0b` → LFH, `== 0x0f` → `RtlpHpVsContextFree`, `flags & 3 == 3` → plain page range |
| `nt!RtlpHpSegLfhAllocate` | asks `RtlpHpSegPageRangeAllocate` for `0x08000000` |
| `nt!RtlpHpSegVsAllocate` | asks for `0x0c000000` |
| `nt!RtlpHpSegPageRangeAllocate` | masks the caller's request with `0x0c`, then ORs `0x01` into every unit of the range |

Hence `0x01 ALLOCATED`, `0x02 FIRST`, `0x04 VS`, `0x08 SUBSEGMENT`, and
`descriptor_backend` keys on the last two.

`0x02` is not "committed" either: `RtlpHpSegPageRangeCommit` never touches `RangeFlags`,
and the only site that sets `0x02` is the split path, on the remainder's *new first*
descriptor. Its two uses here were right for the wrong reason (a `TreeSignature` only
means anything on a first descriptor) and wrong for free ranges, which now read their
state from `ALLOCATED`.

The `identity.special` arm stays, and its comment is corrected: a special-pool range is
`0x03` like any other page-range allocation and can only be told apart by the heap it
came from. The narrow workaround that introduced that arm was this same bug seen through
one heap.

## What #90 actually asked for, kept

A rejected LFH header now names the check it failed and carries what it decoded:

```text
rejecting LFH subsegment 0xffff8c8f0d602000: the blocks overrun the range (block size 0x70,
256 blocks at offset 0x40 of a 0x1000 byte range, encoded 0xa5c31337)
```

The predicate is prose and the values are numbers, so `PoolDiagnostics` collapses each
predicate into its own shape with its own count while keeping a verbatim sample of each —
one live run now says how many headers failed *which* check. `header is not initialised`
is separated out because that is the shape of a race, not of a misdecode, and the raw
`EncodedData` is included so a rejected header can be re-decoded by hand against another
candidate mix without another walk of the target.

The README now also states that a live walk is **normally incomplete** — paged pool is
partly on disk — so `INCOMPLETE` is not read as a defect.

## Tests

70 pass, fmt clean, no new clippy warnings. Both halves are mutation-checked against the
old reading:

- `test_a_plain_page_range_is_not_taken_for_an_lfh_subsegment` fails if `0x01` is read as
  LFH, and fails again if `0x02` is read as committed;
- `test_pool_snapshot_walks_all_backends` fails under the old classification once the
  shared fixture carries real flag values;
- `test_range_flags_name_the_allocator_that_owns_the_range` pins the four combinations
  the kernel dispatches on;
- `test_lfh_rejections_name_their_predicate_and_carry_their_values` pins each predicate
  and the values in the message.

## Live measurement (2026-08-08, Server 26100 over KDNET)

Re-measured on the target from #90 with the live-kernel smoke tier. All three live tests
pass; the session detaches cleanly and the target keeps running.

| | before (#90) | with this change | |
|---|---|---|---|
| chunks walked | 437,732 | **530,680** | +92,948 (+21%) |
| allocated | 244,874 | **306,227** | +61,353 (+25%) |
| `rejecting implausible LFH metadata` | 5,532 | **0** | gone |
| `cannot read LFH subsegment … sparse` | 1,970 | **15** | −99% |
| diagnostics | 7,856 in 9 categories | 5,324 in 11 | −32% |
| walk time | 23.7s | 52.3s | 2.2× |

The ~92k newly-indexed chunks are the VS and page-range allocations that were being
dropped at region creation. The LFH-sparse collapse says the same thing from the other
side: most of those "paged-out LFH subsegments" were never LFH, and as VS or page ranges
they go through the partial-commit path instead. Different boots, so the totals are not
strictly comparable — but 5,532 → 0 is categorical, not statistical.

The walk now costs 52s of the 120s `DEFAULT_WALK_BUDGET`, because it is decoding regions
it used to discard. Headroom is 2.3× rather than 5×; still fine, worth knowing.

## Follow-ups this exposes (not in scope here)

Both are code that had never run against a real target before this change:

1. **884 `rejecting implausible VS chunk size`** — the VS chunk decoder, live on 26100 for
   the first time. The same question as #90, one backend over.
2. **`valid-region query made no progress`: 24 → 3,285** — and that path marks the *rest of
   the region* unreadable and breaks, so it truncates coverage rather than skipping a page.
   Now the largest remaining category.
