### PR TITLE
Two more measurements behind the scope claims

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1693,8 +1693,10 @@ impl DebugEngine {
     ///
     /// - **A different process or thread is current.** A scope is engine-global, not per-thread,
     ///   so a scope captured while one process was current is restored as-is while another is —
-    ///   which is what `.cxr` does deliberately, and is wrong only if the caller did not mean
-    ///   it. (`!analyze -v` does not move the current thread; that was measured.)
+    ///   which is what `.cxr` does deliberately, and is wrong only if the caller did not mean it.
+    ///   A guard wrapping one command is not exposed to this by a command that moves the thread
+    ///   and moves it back, which is what `!analyze -v` was measured doing (see [`Self::scope`]):
+    ///   what matters at the restore is where the thread ended up, not where it went.
     /// - **A borrowed WinDbg client whose host switched targets.** There the identity is the
     ///   client pointer, which does not change when WinDbg opens something else under it.
     ///

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1583,18 +1583,21 @@ impl DebugEngine {
     /// Reads the engine's current [`Scope`], so it can be put back later.
     ///
     /// **What this is for.** Commands move the scope, and some move it as a side effect of
-    /// answering an unrelated question. Measured against dbgeng `10.0.29547.1002`, on a `0x13A`
-    /// kernel bug check and on a user-mode access violation: `!analyze -v` ends with the scope
-    /// at the target's *default*, so a session that had frame 3 selected is on frame 0
-    /// afterwards, and one that had `.ecxr`'s context selected has lost it. Nothing was written
-    /// to the debuggee — but two identical stack reads either side of the analysis describe
-    /// different things, which is the same problem for a host that has to report which of its
-    /// calls mutate state. Saving the scope first and restoring it after makes the analysis
-    /// observably scope-neutral.
+    /// answering an unrelated question. Measured against dbgeng `10.0.29547.1002` on four
+    /// targets — a `0x13A` kernel bug check, a `0xD1` driver fault, a `0x9F` power-state
+    /// watchdog, and a user-mode access violation: `!analyze -v` ends with the scope at the
+    /// target's *default*, so a session that had frame 3 selected is on frame 0 afterwards, and
+    /// one that had `.ecxr`'s context selected has lost it. Nothing was written to the debuggee
+    /// — but two identical stack reads either side of the analysis describe different things,
+    /// which is the same problem for a host that has to report which of its calls mutate state.
+    /// Saving the scope first and restoring it after makes the analysis observably
+    /// scope-neutral.
     ///
-    /// The current thread and process are *not* part of a scope, and were measured not to need
-    /// restoring alongside one: the `~0s` an analysis prints in its `STACK_COMMAND` is advice
-    /// for an operator to type, and running `!analyze -v` left the selected thread alone.
+    /// The current thread and process are *not* part of a scope, and do not need restoring
+    /// alongside one — for a better reason than "the analysis leaves them alone". It does move
+    /// them: on the `0x9F`, where the thread `!analyze` blames is not the one the dump opens on,
+    /// its output says `Implicit thread is now ffffe284fe4dd040` partway through. It puts them
+    /// back before it returns, which the scope is precisely what it does *not* do.
     ///
     /// **Sizing the context blob.** `GetScope` neither reports nor negotiates the size of the
     /// context it wants: it rejects a buffer smaller than the target's `CONTEXT` with


### PR DESCRIPTION
Follow-up to #99 (issue #98). Documentation only — no code change.

**The fixture #98 asked for now exists.** A `0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL` was produced deliberately on a lab VM (`notmyfaultc64 /crash 0x01`, with the machine's owner's approval) to test the one case the merged PR could not: a bug check that carries a faulting context rather than a bare `.cxr` reset. It behaves like the others — from a default scope `!analyze -v` moves nothing; from `.frame 3` (`myfault+0x1e35`, the faulting driver frame) it comes back on frame 0, and the guard restores it. Three kernel bug checks and a user-mode AV now say the same thing, so the issue's expected direction — an exception context selected and *left* selected — has not been observed on any target.

**And the `0x9F` corrects the thread note I added in #99.** I wrote that `!analyze -v` "left the selected thread alone". That was true of the end state and wrong about the mechanism, and the `0x9F` is where the difference shows, because the thread it blames is not the one the dump opens on:

```
BEFORE      Implicit thread is now ffffe284`fe4e7040   nt!KeBugCheckEx ...
!analyze    Implicit thread is now ffffe284`fe4dd040   <- FAULTING_THREAD, mid-analysis
AFTER       Implicit thread is now ffffe284`fe4e7040   nt!KeBugCheckEx ...  (identical stack)
```

It moves the implicit thread and **puts it back**. That is a sharper statement of why a scope guard needs no thread half — the analysis restores the thread and does not restore the scope — so the doc now says that instead.

This also fixes a downstream comment in `windbg-mcp`, whose `crash_triage` orders its reads after the `!analyze` on the belief that the analysis leaves the blamed context selected; it does not, and the reads describe the dump's default context. That change rides in the `windbg-mcp` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)