### PR TITLE
Close out the open pool issues: special-pool sizes, stalled region queries, VS refusals, and two cache keys

### DIFF
--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -603,6 +604,66 @@ fn next_target_identity() -> u64 {
     NEXT_TARGET_IDENTITY.fetch_add(1, Ordering::Relaxed)
 }
 
+/// The identity currently in force for each debug client, so one **outlives the wrapper it was
+/// issued to**.
+///
+/// A borrowed engine is built afresh around the same `IDebugClient6` for every extension
+/// command, so its identity has to be stable across those wrappers or each command misses every
+/// cache. Deriving it from the client pointer did that, and lost each wrapper's lifecycle with
+/// the wrapper: an `end_session` bumped a field on a value dropped moments later, so the next
+/// wrapper restored the original pointer-derived identity and could be served a snapshot
+/// gathered from the target before it. The identity lives here instead, where the bump survives.
+///
+/// An entry is only ever cache warmth. Forgetting one costs a re-resolve and a re-walk, never a
+/// stale answer, since a fresh identity matches nothing — which is why this can simply drop
+/// everything when it grows rather than needing an eviction policy to reason about.
+///
+/// **What it does not fix**: a client released and another allocated at the same address
+/// inherits the first one's identity. That was equally true of the pointer-derived scheme this
+/// replaces, and closing it needs an identity read from the debuggee rather than from the
+/// client holding it.
+fn client_identities() -> &'static Mutex<HashMap<usize, u64>> {
+    static IDENTITIES: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
+    IDENTITIES.get_or_init(Mutex::default)
+}
+
+/// How many clients' identities to remember before dropping the lot; see [`client_identities`]
+/// for why dropping them is safe. Sized well past the handful of clients any real host holds —
+/// the extension reuses exactly one — so reaching it means something is creating clients in a
+/// loop, and that is the case worth bounding.
+const MAX_REMEMBERED_CLIENTS: usize = 64;
+
+fn client_key(client: &IDebugClient6) -> usize {
+    client.as_raw() as usize
+}
+
+/// The identity in force for `client`, issuing one if this is the first wrapper to ask.
+fn identity_of(client: &IDebugClient6) -> u64 {
+    identity_for(client_key(client))
+}
+
+/// Issues a fresh identity for `client` and records it, so nothing cached against the target it
+/// is letting go of can be handed to a later wrapper around the same client.
+fn reissue_identity(client: &IDebugClient6) -> u64 {
+    reissue_for(client_key(client))
+}
+
+/// The two above, over the key rather than the COM pointer it comes from — which is all the
+/// registry deals in, and all a test of it needs.
+fn identity_for(key: usize) -> u64 {
+    let mut identities = client_identities().lock().unwrap();
+    if identities.len() >= MAX_REMEMBERED_CLIENTS {
+        identities.clear();
+    }
+    *identities.entry(key).or_insert_with(next_target_identity)
+}
+
+fn reissue_for(key: usize) -> u64 {
+    let identity = next_target_identity();
+    client_identities().lock().unwrap().insert(key, identity);
+    identity
+}
+
 pub struct DebugEngine {
     client: IDebugClient6,
     control: IDebugControl4,
@@ -662,11 +723,12 @@ impl DebugEngine {
         // We opened this session, so we own its teardown.
         let mut engine = Self::from_client_interface(client);
         engine.owns_session = true;
-        // Only an engine that opened its own session gets a distinct identity: it is
-        // long-lived, and a host may hold several against targets that share a kernel base.
+        // A client this new cannot be one anything holds a cached view of — whatever address
+        // it landed on. Reissuing rather than adopting whatever `identity_of` found there is
+        // what makes a recycled pointer harmless for the case we control.
         engine
             .target_identity
-            .store(next_target_identity(), Ordering::Release);
+            .store(reissue_identity(&engine.client), Ordering::Release);
         engine
     }
 
@@ -710,11 +772,12 @@ impl DebugEngine {
             .cast::<IDebugSymbols3>()
             .expect("[-] Failed to get debug symbols interface");
 
-        // Derived from the client rather than a counter: a borrowed engine is wrapped
-        // afresh per extension command, so a per-wrapper counter would miss the caches
-        // every time — while a shared constant would collide across two programmatic
-        // hosts holding unrelated targets that happen to share a kernel base.
-        let identity = client.as_raw() as u64;
+        // Looked up by client rather than counted per wrapper: a borrowed engine is wrapped
+        // afresh per extension command, so a per-wrapper counter would miss the caches every
+        // time — while a shared constant would collide across two programmatic hosts holding
+        // unrelated targets that happen to share a kernel base. See `client_identities` for
+        // why this is a registry and not the client pointer it used to be.
+        let identity = identity_of(&client);
         Self {
             client,
             control,
@@ -749,7 +812,7 @@ impl DebugEngine {
                 operation: "querying IDebugSymbols3".into(),
                 source,
             })?;
-        let identity = client.as_raw() as u64;
+        let identity = identity_of(&client);
         Ok(Self {
             client,
             control,
@@ -779,6 +842,11 @@ impl DebugEngine {
     /// Changes when the engine is replaced *or* when it releases its target, so a cache
     /// keyed on it cannot serve data gathered from a previous target. The kernel base is
     /// not sufficient on its own: two dumps from the same boot share it.
+    ///
+    /// Held against the *client* rather than in this wrapper — see [`client_identities`] — so
+    /// that a host which rebuilds its engine around one client, as a WinDbg extension does per
+    /// command, both keeps its caches and cannot lose a release that happened in an earlier
+    /// wrapper.
     pub fn target_identity(&self) -> u64 {
         self.target_identity.load(Ordering::Acquire)
     }
@@ -1773,8 +1841,9 @@ impl DebugEngine {
     ///   A guard wrapping one command is not exposed to this by a command that moves the thread
     ///   and moves it back, which is what `!analyze -v` was measured doing (see [`Self::scope`]):
     ///   what matters at the restore is where the thread ended up, not where it went.
-    /// - **A borrowed WinDbg client whose host switched targets.** There the identity is the
-    ///   client pointer, which does not change when WinDbg opens something else under it.
+    /// - **A borrowed WinDbg client whose host switched targets.** The identity is held per
+    ///   client and reissued when an `end_session` goes through *this* engine, so a change
+    ///   WinDbg makes on its own — opening another dump under an extension — does not move it.
     ///
     /// In both, the caller is the only one who can know, and a guard held across such a change
     /// restores a scope its target no longer means.
@@ -2499,9 +2568,11 @@ impl DebugEngine {
     /// reused for another target.
     pub fn end_session(&self) -> Result<(), DbgEngError> {
         // The target is going away, so anything cached against it must not be reused for
-        // whatever this engine holds next.
+        // whatever this engine holds next — nor by the next wrapper built around this same
+        // client, which is why the new identity is recorded against the client and not only
+        // in this engine's own field.
         self.target_identity
-            .store(next_target_identity(), Ordering::Release);
+            .store(reissue_identity(&self.client), Ordering::Release);
         // A live kernel left halted (at a break) and detached *passively* stays FROZEN —
         // one CPU halted, the rest spinning — because a passive detach never tells the
         // target to run. Resume it and actively detach instead, leaving it running.
@@ -2869,6 +2940,49 @@ mod tests {
     };
 
     use super::*;
+
+    /// glslang/win-kexp#82: a borrowed engine's lifecycle used to die with the wrapper.
+    ///
+    /// The identity was the client pointer, so it was stable across the per-command wrappers an
+    /// extension builds — which is what it was for — while an `end_session` bumped a field on a
+    /// value dropped moments later. Rebuild the wrapper around the same client and the original
+    /// pointer-derived identity came back, matching cache entries gathered from the target it
+    /// had just let go of.
+    ///
+    /// One test rather than four: the registry is process-global, so separate tests could clear
+    /// each other's entries through the cap below.
+    #[test]
+    fn a_clients_identity_outlives_the_wrapper_it_was_issued_to() {
+        // Keys no real client pointer can collide with: an `IDebugClient6` is a heap
+        // allocation, and these sit far below any address one lands at.
+        let (client, other) = (0x11, 0x22);
+
+        let first = identity_for(client);
+        assert_eq!(
+            identity_for(client),
+            first,
+            "a rebuilt wrapper keeps its caches"
+        );
+        assert_ne!(identity_for(other), first, "two clients are two targets");
+
+        // The case that was lost: the wrapper that ends the session is gone by the time the
+        // next one asks, so the bump has to be recorded against the client, not in the wrapper.
+        let after_release = reissue_for(client);
+        assert_ne!(after_release, first);
+        assert_eq!(identity_for(client), after_release);
+
+        // Forgetting an entry is safe by construction, and this is the claim that makes it so:
+        // identities come from a counter that never repeats, so a dropped entry costs a re-walk
+        // and can never resurrect a previous target's.
+        for filler in 0..MAX_REMEMBERED_CLIENTS {
+            identity_for(0x1000 + filler);
+        }
+        assert!(client_identities().lock().unwrap().len() <= MAX_REMEMBERED_CLIENTS);
+        assert!(
+            identity_for(client) >= after_release,
+            "a forgotten client is issued a later identity, never an earlier one"
+        );
+    }
 
     /// A `DEBUG_VALUE` carrying a value in the arm `type_code` names.
     fn tagged(type_code: u32, fill: impl FnOnce(&mut DEBUG_VALUE_0)) -> DEBUG_VALUE {

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -618,9 +618,11 @@ fn next_target_identity() -> u64 {
 /// stale answer, since a fresh identity matches nothing — which is why this can simply drop
 /// everything when it grows rather than needing an eviction policy to reason about.
 ///
-/// **What it does not fix**: a client released and another allocated at the same address
-/// inherits the first one's identity. That was equally true of the pointer-derived scheme this
-/// replaces, and closing it needs an identity read from the debuggee rather than from the
+/// **What it does not fix**: a client the *host* released, with another allocated at the same
+/// address, inherits the first one's identity. Every client this code creates itself reissues
+/// instead — see [`DebugEngine::new`] and [`DebugEngine::create_from_windbg_client`] — so what
+/// is left is the case we cannot observe. That was equally true of the pointer-derived scheme
+/// this replaces, and closing it needs an identity read from the debuggee rather than from the
 /// client holding it.
 fn client_identities() -> &'static Mutex<HashMap<usize, u64>> {
     static IDENTITIES: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
@@ -637,6 +639,18 @@ fn client_key(client: &IDebugClient6) -> usize {
     client.as_raw() as usize
 }
 
+/// The registry, recovered if a thread panicked while holding it.
+///
+/// Poisoning carries nothing here: the map holds `u64` and no invariant a panic could leave
+/// half-applied. Propagating it would, though — `from_client_interface` is infallible, so one
+/// unrelated panic would turn every later wrap into a second one. Same recovery as
+/// [`DebugEngine::release_deferred_inputs`].
+fn locked_identities() -> MutexGuard<'static, HashMap<usize, u64>> {
+    client_identities()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// The identity in force for `client`, issuing one if this is the first wrapper to ask.
 fn identity_of(client: &IDebugClient6) -> u64 {
     identity_for(client_key(client))
@@ -651,8 +665,12 @@ fn reissue_identity(client: &IDebugClient6) -> u64 {
 /// The two above, over the key rather than the COM pointer it comes from — which is all the
 /// registry deals in, and all a test of it needs.
 fn identity_for(key: usize) -> u64 {
-    let mut identities = client_identities().lock().unwrap();
-    if identities.len() >= MAX_REMEMBERED_CLIENTS {
+    let mut identities = locked_identities();
+    // Only a client we have never seen can push the map over its cap, and only then is
+    // anything dropped. Clearing before the lookup would take the identity of the very client
+    // being asked about — a live one, mid-session — and hand it a new one, which is a cache
+    // thrown away for the caller that arrived rather than for the ones that left.
+    if !identities.contains_key(&key) && identities.len() >= MAX_REMEMBERED_CLIENTS {
         identities.clear();
     }
     *identities.entry(key).or_insert_with(next_target_identity)
@@ -660,7 +678,7 @@ fn identity_for(key: usize) -> u64 {
 
 fn reissue_for(key: usize) -> u64 {
     let identity = next_target_identity();
-    client_identities().lock().unwrap().insert(key, identity);
+    locked_identities().insert(key, identity);
     identity
 }
 
@@ -756,7 +774,15 @@ impl DebugEngine {
         }
         .cast::<IDebugClient6>()
         .expect("[-] Failed to cast debug client");
-        Self::from_client_interface(new_client)
+        // `CreateClient` hands back a client this code just made, so — exactly as in `new` — it
+        // cannot be one anything holds a cached view of, whatever address it landed on.
+        // Adopting what `identity_of` found there would inherit a released client's identity
+        // the moment the allocator reused its address.
+        let engine = Self::from_client_interface(new_client);
+        engine
+            .target_identity
+            .store(reissue_identity(&engine.client), Ordering::Release);
+        engine
     }
 
     pub fn from_client_interface(client: IDebugClient6) -> Self {
@@ -2952,7 +2978,7 @@ mod tests {
     /// One test rather than four: the registry is process-global, so separate tests could clear
     /// each other's entries through the cap below.
     #[test]
-    fn a_clients_identity_outlives_the_wrapper_it_was_issued_to() {
+    fn test_a_clients_identity_outlives_the_wrapper_it_was_issued_to() {
         // Keys no real client pointer can collide with: an `IDebugClient6` is a heap
         // allocation, and these sit far below any address one lands at.
         let (client, other) = (0x11, 0x22);
@@ -2977,11 +3003,33 @@ mod tests {
         for filler in 0..MAX_REMEMBERED_CLIENTS {
             identity_for(0x1000 + filler);
         }
-        assert!(client_identities().lock().unwrap().len() <= MAX_REMEMBERED_CLIENTS);
+        assert!(locked_identities().len() <= MAX_REMEMBERED_CLIENTS);
         assert!(
             identity_for(client) >= after_release,
             "a forgotten client is issued a later identity, never an earlier one"
         );
+
+        // A client already known does not make room, because it does not need any. Clearing
+        // before the lookup would take the identity of the very client being asked about — a
+        // live one, mid-session — so the cap has to be reached with it present to see that.
+        let mut identities = locked_identities();
+        identities.clear();
+        identities.insert(client, after_release);
+        for filler in 1..MAX_REMEMBERED_CLIENTS {
+            identities.insert(0x2000 + filler, next_target_identity());
+        }
+        assert_eq!(identities.len(), MAX_REMEMBERED_CLIENTS);
+        drop(identities);
+        assert_eq!(
+            identity_for(client),
+            after_release,
+            "a client at the cap keeps the caches it is in the middle of using"
+        );
+        assert_eq!(locked_identities().len(), MAX_REMEMBERED_CLIENTS);
+
+        // A client it has never seen is what makes room, and pays for it with everything.
+        identity_for(0xbeef);
+        assert!(locked_identities().len() < MAX_REMEMBERED_CLIENTS);
     }
 
     /// A `DEBUG_VALUE` carrying a value in the arm `type_code` names.

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -408,6 +408,21 @@ impl Module {
     }
 }
 
+/// The kernel image a target is running: where it is loaded, and which build it is.
+///
+/// Hashable and comparable so it can key a cache of anything derived from the kernel's types
+/// and globals — which is why the build fields travel with the base rather than beside it. See
+/// [`DebugEngine::kernel_image`] for what each field is and why these three.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct KernelImage {
+    /// Where `nt` is loaded. Globals resolved against it are addresses, so this is part of the
+    /// identity of anything resolved, not merely of the lookup that found it.
+    pub base: u64,
+    pub size: u32,
+    pub timestamp: u32,
+    pub checksum: u32,
+}
+
 /// The bug check a target stopped on, as [`DebugEngine::bug_check`] reports it.
 ///
 /// The engine's own five values and nothing else: what each parameter *means* is per-code lore
@@ -811,6 +826,44 @@ impl DebugEngine {
             source,
         })?;
         Ok(base)
+    }
+
+    /// Where `nt` is loaded **and which build it is**.
+    ///
+    /// The base alone does not identify a kernel. Two targets from different Windows builds can
+    /// load `nt` at the same address — the debugger says nothing about the change — so anything
+    /// caching type offsets or globals against a base can serve one build's layout for another
+    /// and mis-decode every structure it reads, confidently. That is what this exists for; see
+    /// [`Self::kernel_base`] when only the address is wanted.
+    ///
+    /// `TimeDateStamp` and `SizeOfImage` are the identity a symbol server keys the *binary* on
+    /// — the `65F579991450000` in a downloaded `ntkrnlmp.exe` path is exactly this pair — so
+    /// they change with the build by construction. `CheckSum` comes along because it is in the
+    /// same read and narrows it further.
+    ///
+    /// One caveat worth knowing: a target whose headers the engine could not read reports these
+    /// as zero, and two such builds at one base are indistinguishable again. That is the state
+    /// this replaced, not a regression from it.
+    pub fn kernel_image(&self) -> Result<KernelImage, DbgEngError> {
+        let base = self.kernel_base()?;
+        let mut params = DEBUG_MODULE_PARAMETERS::default();
+        // Looked up by base rather than by index: `GetModuleByModuleName` hands back an
+        // address, and asking for the parameters of *that* module is one call, where finding
+        // its index first would be two and could race a module list that changed between them.
+        unsafe {
+            self.symbols
+                .GetModuleParameters(1, Some(&base), 0, &mut params)
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("reading the parameters of the kernel image at {base:#x}"),
+            source,
+        })?;
+        Ok(KernelImage {
+            base,
+            size: params.Size,
+            timestamp: params.TimeDateStamp,
+            checksum: params.Checksum,
+        })
     }
 
     pub fn symbol_offset(&self, name: &str) -> Result<u64, DbgEngError> {

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -691,8 +691,6 @@ pub struct DebugEngine {
     /// responsible for ending it on `Drop`. False when wrapping a borrowed WinDbg
     /// client, so going out of scope can't stop the host's active session.
     owns_session: bool,
-    /// Identifies the target this engine currently holds; see [`next_target_identity`].
-    target_identity: AtomicU64,
     /// Input buffers handed to DbgEng by a *deferred* call — `CreateProcessWide`, which
     /// spawns at the next `WaitForEvent` and reads the command line then, and the kernel
     /// connection string, whose link is likewise established during the wait.
@@ -744,9 +742,7 @@ impl DebugEngine {
         // A client this new cannot be one anything holds a cached view of — whatever address
         // it landed on. Reissuing rather than adopting whatever `identity_of` found there is
         // what makes a recycled pointer harmless for the case we control.
-        engine
-            .target_identity
-            .store(reissue_identity(&engine.client), Ordering::Release);
+        reissue_identity(&engine.client);
         engine
     }
 
@@ -779,9 +775,7 @@ impl DebugEngine {
         // Adopting what `identity_of` found there would inherit a released client's identity
         // the moment the allocator reused its address.
         let engine = Self::from_client_interface(new_client);
-        engine
-            .target_identity
-            .store(reissue_identity(&engine.client), Ordering::Release);
+        reissue_identity(&engine.client);
         engine
     }
 
@@ -798,12 +792,6 @@ impl DebugEngine {
             .cast::<IDebugSymbols3>()
             .expect("[-] Failed to get debug symbols interface");
 
-        // Looked up by client rather than counted per wrapper: a borrowed engine is wrapped
-        // afresh per extension command, so a per-wrapper counter would miss the caches every
-        // time — while a shared constant would collide across two programmatic hosts holding
-        // unrelated targets that happen to share a kernel base. See `client_identities` for
-        // why this is a registry and not the client pointer it used to be.
-        let identity = identity_of(&client);
         Self {
             client,
             control,
@@ -812,7 +800,6 @@ impl DebugEngine {
             // Default to "borrowed": constructors that wrap an existing WinDbg client
             // go through here, and only `new()` (which calls `DebugCreate`) sets this.
             owns_session: false,
-            target_identity: AtomicU64::new(identity),
             deferred_inputs: Mutex::new(Vec::new()),
             interrupt_raised: Arc::new(AtomicBool::new(false)),
         }
@@ -838,14 +825,12 @@ impl DebugEngine {
                 operation: "querying IDebugSymbols3".into(),
                 source,
             })?;
-        let identity = identity_of(&client);
         Ok(Self {
             client,
             control,
             dataspaces,
             symbols,
             owns_session: false,
-            target_identity: AtomicU64::new(identity),
             deferred_inputs: Mutex::new(Vec::new()),
             interrupt_raised: Arc::new(AtomicBool::new(false)),
         })
@@ -869,12 +854,24 @@ impl DebugEngine {
     /// keyed on it cannot serve data gathered from a previous target. The kernel base is
     /// not sufficient on its own: two dumps from the same boot share it.
     ///
-    /// Held against the *client* rather than in this wrapper — see [`client_identities`] — so
-    /// that a host which rebuilds its engine around one client, as a WinDbg extension does per
-    /// command, both keeps its caches and cannot lose a release that happened in an earlier
-    /// wrapper.
+    /// Read from the registry keyed on this engine's *client* — see [`client_identities`] —
+    /// rather than from a copy taken when this wrapper was built. Two things follow, and both
+    /// are the point:
+    ///
+    /// - a host that rebuilds its engine around one client, as a WinDbg extension does per
+    ///   command, keeps its caches across the rebuild *and* cannot lose a release an earlier
+    ///   wrapper performed;
+    /// - two wrappers coexisting around one client agree. A copy in each would not: an
+    ///   `end_session` through one would move that one and the registry, leaving the other
+    ///   answering with an identity whose target is gone, and a cache keyed on it would be
+    ///   served for whatever was opened next.
+    ///
+    /// A client whose entry was dropped to keep the registry bounded is issued a later
+    /// identity here, never an earlier one. That costs a re-walk, and — in the one case that
+    /// compares two reads, [`Self::set_scope`] — a restore refused rather than a restore onto
+    /// the wrong target. Both are the safe direction.
     pub fn target_identity(&self) -> u64 {
-        self.target_identity.load(Ordering::Acquire)
+        identity_of(&self.client)
     }
 
     pub fn read_memory(&self, address: u64, size: usize) -> Result<Vec<u8>, DbgEngError> {
@@ -2594,11 +2591,9 @@ impl DebugEngine {
     /// reused for another target.
     pub fn end_session(&self) -> Result<(), DbgEngError> {
         // The target is going away, so anything cached against it must not be reused for
-        // whatever this engine holds next — nor by the next wrapper built around this same
-        // client, which is why the new identity is recorded against the client and not only
-        // in this engine's own field.
-        self.target_identity
-            .store(reissue_identity(&self.client), Ordering::Release);
+        // whatever this engine holds next — nor by any other wrapper around this same client,
+        // which is why the identity is recorded against the client rather than in this engine.
+        reissue_identity(&self.client);
         // A live kernel left halted (at a break) and detached *passively* stays FROZEN —
         // one CPU halted, the rest spinning — because a passive detach never tells the
         // target to run. Resume it and actively detach instead, leaving it running.
@@ -3165,6 +3160,41 @@ mod tests {
         println!("Debug engine created successfully");
 
         // DebugEngine's Drop impl will handle cleanup and detach
+    }
+
+    /// The half of glslang/win-kexp#82 that a registry alone does not close, and the reason the
+    /// identity is not a field: two wrappers can be live around one client at once.
+    ///
+    /// With a copy in each, an `end_session` through one moves that one and the registry and
+    /// leaves the other answering with an identity whose target is gone — so a snapshot or
+    /// layout cached against it is served for whatever is opened next, which is the same stale
+    /// read the issue was about arriving through a second wrapper instead of a later one.
+    #[cfg(not(miri))]
+    #[test]
+    fn test_every_live_wrapper_sees_a_release_through_any_of_them() {
+        // Serialized like every other engine test: this one's `Drop` ends the process-wide
+        // debuggee session.
+        let _debuggee = one_debuggee();
+        let owner = DebugEngine::new();
+        // A second wrapper around the *same* client, which is what an extension builds per
+        // command. `clone` bumps the COM refcount and keeps the pointer, so both agree.
+        let borrowed = DebugEngine::from_client_interface(owner.client.clone());
+        let before = owner.target_identity();
+        assert_eq!(borrowed.target_identity(), before);
+
+        // There is no target to end, so the call itself fails. The identity moves before it
+        // tries, which is the half this is about.
+        let _ = owner.end_session();
+        assert_ne!(
+            owner.target_identity(),
+            before,
+            "a release moves the identity"
+        );
+        assert_eq!(
+            borrowed.target_identity(),
+            owner.target_identity(),
+            "a wrapper that did not perform the release still has to observe it"
+        );
     }
 
     /// Reads a debugger pseudo-register (`$t0`, …) as a number, via `? <expr>` — whose output

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -87,6 +87,15 @@ impl PoolSpan {
         address >= self.header_address && address < self.end()
     }
 
+    /// A span with **synthetic geometry**: `header_address == usable_address`, which no walker
+    /// ever emits — `walk_lfh`, `walk_vs` and `walk_page_ranges` all put the usable bytes a
+    /// pool header past the header.
+    ///
+    /// Fine for tests about tags, filters and identity. Not fine for a test about *geometry*,
+    /// and this has now hidden two bugs in `chunk_at`'s contiguity check by being the only
+    /// thing that satisfied it (glslang/win-kexp#85, then the gate that replaced it). Build a
+    /// backend-shaped span by hand for those, as `query`'s `lfh_allocation` and `vs_allocation`
+    /// do.
     #[cfg(test)]
     pub(crate) fn allocation(
         address: u64,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -14,7 +14,7 @@ pub mod query;
 
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
-pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics};
+pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics, WalkStalls};
 
 /// Exact allocator identity.  Values are deliberately not collapsed into just
 /// paged/nonpaged because crossing one of these boundaries creates false holes.

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -346,6 +346,97 @@ pub(crate) fn decode_pool_header(
     (header.block_size != 0 && header.pool_type <= 0x7f).then_some(header)
 }
 
+/// The low bits of a special-pool page's `Ulong1` that hold the requested byte count.
+///
+/// Thirteen, not the eight of `_POOL_HEADER.PreviousSize` — which is why a size below 0x100
+/// used to read correctly and everything above it wrapped. 0x1fff spans any allocation a page
+/// can hold several times over, so nothing a special-pool page can describe truncates.
+const SPECIAL_POOL_SIZE_MASK: u32 = 0x1fff;
+/// Set in the same word when Verifier is tracking the allocation, which puts eight more bytes
+/// of its own between the pool header and where the fill starts.
+const SPECIAL_POOL_TRACKED: u32 = 0x4000;
+
+/// What a Driver Verifier special-pool page records about the one allocation it holds.
+///
+/// Special pool reuses `_POOL_HEADER`'s bytes for its own fields, so the ordinary
+/// [`decode_pool_header`] reading of them is meaningless here: `BlockSize`'s byte holds the
+/// fill pattern, and the size spans `PreviousSize` *and* the low bits of `PoolIndex`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SpecialPoolHeader {
+    pub tag: u32,
+    /// The byte count the caller asked `ExAllocatePool` for. The block occupies
+    /// `next_multiple_of(16)` of that.
+    pub requested: u32,
+    /// Where the fill starts: past the pool header, and past Verifier's tracking block when
+    /// [`SPECIAL_POOL_TRACKED`] says there is one.
+    pub header_size: usize,
+    /// The byte the unused space either side of the block is filled with.
+    ///
+    /// Read from the page rather than assumed to be `0xfd`, because that is what the kernel
+    /// itself compares against — see [`decode_special_pool_header`].
+    pub fill: u8,
+}
+
+/// Decodes a special-pool page header the way `nt!ExpFreeHeapSpecialPool` does.
+///
+/// That function is the authority worth copying: it is handed the block pointer and
+/// **bug checks** (`0xc1`, subcode `0x21`) unless the page's own fields place the block exactly
+/// where the pointer says it is, so its reading *defines* a well-formed special-pool page.
+/// Measured on Server 26100.32995 (`nt` 0x65f57999), where it does, in order:
+///
+/// ```text
+///   movzx edx, word ptr [rbx]        ; the first half of Ulong1
+///   and   edx, 1FFFh                 ; ... is the requested size, in thirteen bits
+///   lea   r14, [rdx+0Fh]
+///   and   r14, 0FFFFFFFFFFFFFFF0h    ; the block occupies that, rounded up to 16
+///   cmp   r14, rbp                   ; rbp = 0x1000 - (block & 0xfff): or bug check 0xc1/0x21
+///   ...
+///   mov   ecx, dword ptr [rbx]
+///   lea   r8, [rbx+10h]
+///   and   r10d, 4000h                ; tracked by Verifier?
+///   je    ...
+///   lea   r8, [rbx+18h]              ; ... then its tracking block sits after the header
+///   ...
+///   mov   al, byte ptr [rbx+2]       ; the fill byte is recorded on the page, not assumed
+///   cmp   byte ptr [r8], al          ; and checked from the header's end up to the block
+/// ```
+///
+/// `Ulong1` overlays the bitfields from `PreviousSize` on, and the fill byte occupies
+/// `BlockSize`'s, so both are located from the PDB layout rather than from the constant
+/// offsets the kernel compiles in.
+///
+/// `None` means the page does not describe an allocation that could fit in it — an unreadable
+/// or garbage page, not a special-pool one.
+pub(crate) fn decode_special_pool_header(
+    bytes: &[u8],
+    offset: usize,
+    layout: PoolHeaderLayout,
+) -> Option<SpecialPoolHeader> {
+    range(bytes, offset, layout.size)?;
+    let word = read_u32(bytes, offset.checked_add(layout.previous_size)?)?;
+    let requested = word & SPECIAL_POOL_SIZE_MASK;
+    // The extra eight bytes are Verifier's, and on x64 `_POOL_HEADER` is 0x10, which is the
+    // `[rbx+10h]`/`[rbx+18h]` pair above.
+    let header_size = layout.size
+        + if word & SPECIAL_POOL_TRACKED != 0 {
+            8
+        } else {
+            0
+        };
+    let aligned = u64::from(requested).next_multiple_of(16);
+    // The kernel's own placement identity, which is the check it bug checks on. A page whose
+    // block could not share it with its own header is not a special-pool page we read correctly.
+    if requested == 0 || aligned + header_size as u64 > PAGE_SIZE {
+        return None;
+    }
+    Some(SpecialPoolHeader {
+        tag: read_u32(bytes, offset.checked_add(layout.tag)?)?,
+        requested,
+        header_size,
+        fill: *bytes.get(offset.checked_add(layout.block_size)?)?,
+    })
+}
+
 pub(crate) fn decode_rb_root(root: u64, tree_address: u64, encoded: bool) -> Option<u64> {
     let pointer = if encoded { root ^ tree_address } else { root } & !0xf;
     (pointer == 0 || is_kernel_pointer(pointer)).then_some(pointer)

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -171,14 +171,104 @@ pub(crate) fn valid_descriptor_tree_signature(signature: u32) -> bool {
 }
 
 /// Windows VS headers encode both size words with the heap key and header address.
-pub(crate) fn decode_vs_sizes(encoded: u64, header: u64, heap_key: u64) -> Option<VsSizes> {
+///
+/// Unconditional: whether the values are believable is [`decode_vs_chunk`]'s question, and a
+/// header refused there still has to be able to say what it decoded to.
+pub(crate) fn decode_vs_sizes(encoded: u64, header: u64, heap_key: u64) -> VsSizes {
     let decoded = encoded ^ heap_key ^ header;
-    let size = (decoded >> 16) as u16;
-    let previous_size = (decoded >> 32) as u16;
-    (size != 0).then_some(VsSizes {
+    VsSizes {
+        size: (decoded >> 16) as u16,
+        previous_size: (decoded >> 32) as u16,
+        allocated: (decoded >> 48) as u8 != 0,
+    }
+}
+
+/// One `_HEAP_VS_CHUNK_HEADER`, in bytes rather than in the sixteen-byte units it stores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VsChunk {
+    /// The chunk's whole extent, its own headers included.
+    pub size: usize,
+    /// What this header says the chunk *before* it measured.
+    ///
+    /// The kernel keeps the chain so a free can coalesce backwards, which makes it a
+    /// corroboration of the walk's own forward stride that costs nothing: walking forward, the
+    /// next chunk's `previous_size` must equal this chunk's `size`. It is also the check that
+    /// separates the two explanations for a refused header — a chain that holds either side of
+    /// one bad chunk is a header rewritten while we read it, a chain that never holds says the
+    /// field or the starting offset is wrong and everything decoded after it is fiction.
+    pub previous_size: usize,
+    pub allocated: bool,
+}
+
+/// Why a VS chunk header was not believed, and the decoded values that say so.
+///
+/// Same division of labour as [`LfhRejection`]: the failing predicate is prose with no digits
+/// in it, so `PoolDiagnostics` keeps the shapes apart while folding the numbers, and the values
+/// travel as numbers so a sample of each shape carries real ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VsRejection {
+    /// The predicate that failed, as prose with no digits in it.
+    pub reason: &'static str,
+    pub size: usize,
+    pub previous_size: usize,
+    /// The `Sizes` word as read, so a refused header can be re-decoded by hand against another
+    /// candidate mix without another walk of the target.
+    pub encoded: u64,
+}
+
+impl fmt::Display for VsRejection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} (size {:#x}, previous size {:#x}, encoded {:#018x})",
+            self.reason, self.size, self.previous_size, self.encoded
+        )
+    }
+}
+
+/// Decodes a VS chunk header, or says which plausibility check it failed.
+///
+/// `header_bytes` is the chunk header plus the pool header it carries — the smallest extent a
+/// chunk can occupy and still be one. `subsegment_end` is one past the last byte of the
+/// subsegment the chunk belongs to.
+///
+/// The end test is `>` and not `>=` deliberately: a subsegment's last chunk reaches its
+/// boundary exactly, and refusing that would reject a well-formed chunk from every subsegment
+/// that is fully occupied.
+pub(crate) fn decode_vs_chunk(
+    encoded: u64,
+    header_address: u64,
+    heap_key: u64,
+    header_bytes: usize,
+    subsegment_end: u64,
+) -> Result<VsChunk, VsRejection> {
+    let sizes = decode_vs_sizes(encoded, header_address, heap_key);
+    let size = usize::from(sizes.size).saturating_mul(16);
+    let previous_size = usize::from(sizes.previous_size).saturating_mul(16);
+    let reject = |reason| {
+        Err(VsRejection {
+            reason,
+            size,
+            previous_size,
+            encoded,
+        })
+    };
+    // Its own reason rather than a case of "smaller than its headers": a zero size is what an
+    // uninitialised or wrongly keyed word decodes to, and it is also the one value the walk
+    // could not stride by even if it believed it.
+    if size == 0 {
+        return reject("the size word decodes to zero");
+    }
+    if size < header_bytes {
+        return reject("the chunk is smaller than its own headers");
+    }
+    if header_address.saturating_add(size as u64) > subsegment_end {
+        return reject("the chunk runs past the end of its subsegment");
+    }
+    Ok(VsChunk {
         size,
         previous_size,
-        allocated: (decoded >> 48) as u8 != 0,
+        allocated: sizes.allocated,
     })
 }
 
@@ -568,7 +658,7 @@ mod tests {
             0x12_3456
         );
         assert_eq!(decode_descriptor_at(&wide_descriptor, 12, 8, 5, 2), None);
-        let decoded = decode_vs_sizes((4u64 << 16) ^ 0x1234 ^ 0x55, 0x1234, 0x55).unwrap();
+        let decoded = decode_vs_sizes((4u64 << 16) ^ 0x1234 ^ 0x55, 0x1234, 0x55);
         assert_eq!(decoded.size, 4);
         assert!(!decoded.allocated);
         let lfh_key = 0xa5c3_0010;

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
-use super::{PoolDiagnostics, PoolSpan, PoolState, snapshot::PoolSnapshot};
+use super::{PoolDiagnostics, PoolSpan, PoolState, snapshot::PoolSnapshot, snapshot::WalkStalls};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Direction {
@@ -33,6 +33,9 @@ pub(crate) struct PoolIndex {
     /// an index that outlives the walk is the only thing a caller ever sees, so a reason left
     /// behind here is a reason nobody can recover.
     pub budget_expired: bool,
+    /// Carried through from [`PoolSnapshot::stalls`], for the same reason the two flags above
+    /// are: the index is all a caller ever sees of the walk.
+    pub stalls: WalkStalls,
     row_postings: HashMap<RowIdentity, Vec<usize>>,
     span_rows: Vec<RowIdentity>,
 }
@@ -82,6 +85,7 @@ impl PoolIndex {
             diagnostics: snapshot.diagnostics,
             complete: snapshot.complete,
             budget_expired: snapshot.budget_expired,
+            stalls: snapshot.stalls,
             row_postings,
             span_rows,
         }
@@ -272,8 +276,7 @@ mod tests {
                 span(0x1080, tag, PoolState::Allocated, 2),
             ],
             complete: true,
-            budget_expired: false,
-            diagnostics: PoolDiagnostics::default(),
+            ..PoolSnapshot::default()
         };
         let index = PoolIndex::build(snapshot.clone());
         assert_eq!(index.postings[&tag], vec![1, 4]);
@@ -295,8 +298,7 @@ mod tests {
                 span(0x1080, other, PoolState::Allocated, 1),
             ],
             complete: true,
-            budget_expired: false,
-            diagnostics: PoolDiagnostics::default(),
+            ..PoolSnapshot::default()
         });
         assert_eq!(contextual.context_for_tag(tag), vec![0, 1, 2, 3, 4]);
         assert_eq!(contextual.successor(2), None);

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -36,6 +36,8 @@ pub(crate) struct PoolIndex {
     /// Carried through from [`PoolSnapshot::stalls`], for the same reason the two flags above
     /// are: the index is all a caller ever sees of the walk.
     pub stalls: WalkStalls,
+    /// Carried through from [`PoolSnapshot::refused_chunks`].
+    pub refused_chunks: u64,
     row_postings: HashMap<RowIdentity, Vec<usize>>,
     span_rows: Vec<RowIdentity>,
 }
@@ -86,6 +88,7 @@ impl PoolIndex {
             complete: snapshot.complete,
             budget_expired: snapshot.budget_expired,
             stalls: snapshot.stalls,
+            refused_chunks: snapshot.refused_chunks,
             row_postings,
             span_rows,
         }

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -309,7 +309,10 @@ mod tests {
         // Distinct targets, not just distinct generations: the cache keys on the whole
         // SessionKey so a snapshot cannot outlive the target it described.
         let session = |value: u64| super::super::layout::SessionKey {
-            kernel_base: 0x1000,
+            image: crate::dbgeng::KernelImage {
+                base: 0x1000,
+                ..Default::default()
+            },
             session: value,
             target: 1,
         };
@@ -368,7 +371,10 @@ mod tests {
         // thing that tells them apart.
         cache.invalidate();
         let same_base = |target: u64| super::super::layout::SessionKey {
-            kernel_base: 0x1000,
+            image: crate::dbgeng::KernelImage {
+                base: 0x1000,
+                ..Default::default()
+            },
             session: 1,
             target,
         };

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -4,14 +4,24 @@ use std::sync::{Mutex, OnceLock};
 use thiserror::Error;
 
 use super::decode::PoolHeaderLayout;
-use crate::dbgeng::{DbgEngError, DebugEngine};
+use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct SessionKey {
-    pub kernel_base: u64,
+    /// Where the kernel is loaded **and which build it is**, from
+    /// [crate::dbgeng::DebugEngine::kernel_image].
+    ///
+    /// The base alone is not enough for the layout cache, which is keyed on this and not on
+    /// `target`. A programmatic host that switches to a different Windows build whose kernel
+    /// happens to load at the same address receives no notification, so a base-keyed lookup
+    /// hands back the previous build's type offsets and globals and the walker decodes the new
+    /// target with them — silently, and confidently. Keyed on the image, entries are shared
+    /// across engines looking at the same build, which is what keeps the cache from growing one
+    /// entry per engine, and never shared across two builds.
+    pub image: KernelImage,
     pub session: u64,
     /// Which target this is, from [crate::dbgeng::DebugEngine::target_identity].
-    /// The kernel base does not distinguish two dumps from the same boot, and the
+    /// The kernel image does not distinguish two dumps from the same boot, and the
     /// generation only moves on debugger notifications a programmatic host never gets.
     pub target: u64,
 }
@@ -22,9 +32,31 @@ pub(crate) struct TypeLayout {
     pub fields: HashMap<&'static str, u32>,
 }
 
+/// What a resolved [`PoolLayout`] actually depends on: the kernel image it was read out of.
+///
+/// Deliberately not a whole [`SessionKey`]. A layout describes the *image*, not which target
+/// instance happens to be loaded, and keying it on the target inserted an entry per engine and
+/// per `end_session` that nothing ever pruned (glslang/win-kexp#84). Deriving the key here
+/// rather than asking each caller to blank a field is what keeps that from being one call
+/// site's discipline — there is no key a caller can hand this cache that reintroduces it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LayoutKey {
+    pub image: KernelImage,
+    pub session: u64,
+}
+
+impl From<SessionKey> for LayoutKey {
+    fn from(key: SessionKey) -> Self {
+        Self {
+            image: key.image,
+            session: key.session,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PoolLayout {
-    pub key: SessionKey,
+    pub key: LayoutKey,
     pub globals: HashMap<&'static str, u64>,
     pub types: HashMap<&'static str, TypeLayout>,
 }
@@ -315,7 +347,7 @@ impl PoolLayout {
         })
     }
 
-    pub(crate) fn resolve(symbols: &impl Symbols, key: SessionKey) -> Result<Self, LayoutError> {
+    pub(crate) fn resolve(symbols: &impl Symbols, key: LayoutKey) -> Result<Self, LayoutError> {
         let mut globals = HashMap::new();
         for &(canonical, aliases) in GLOBALS {
             let value = aliases
@@ -333,10 +365,10 @@ impl PoolLayout {
         }
         let mut types = HashMap::new();
         for spec in TYPES {
-            types.insert(spec.name, resolve_type(symbols, key.kernel_base, spec)?);
+            types.insert(spec.name, resolve_type(symbols, key.image.base, spec)?);
         }
         for spec in OPTIONAL_TYPES {
-            if let Ok(layout) = resolve_type(symbols, key.kernel_base, spec) {
+            if let Ok(layout) = resolve_type(symbols, key.image.base, spec) {
                 types.insert(spec.name, layout);
             }
         }
@@ -344,12 +376,12 @@ impl PoolLayout {
             let Some(layout) = types.get_mut(type_name) else {
                 continue;
             };
-            let Ok(type_id) = symbols.type_id(key.kernel_base, type_name) else {
+            let Ok(type_id) = symbols.type_id(key.image.base, type_name) else {
                 continue;
             };
             if let Some(offset) = aliases
                 .iter()
-                .find_map(|field| symbols.field(key.kernel_base, type_id, field).ok())
+                .find_map(|field| symbols.field(key.image.base, type_id, field).ok())
             {
                 layout.fields.insert(canonical, offset);
             }
@@ -364,7 +396,7 @@ impl PoolLayout {
 
 #[derive(Default)]
 pub(crate) struct LayoutCache {
-    entries: Mutex<HashMap<SessionKey, PoolLayout>>,
+    entries: Mutex<HashMap<LayoutKey, PoolLayout>>,
 }
 
 impl LayoutCache {
@@ -376,8 +408,9 @@ impl LayoutCache {
     pub(crate) fn get_or_resolve(
         &self,
         symbols: &impl Symbols,
-        key: SessionKey,
+        key: impl Into<LayoutKey>,
     ) -> Result<PoolLayout, LayoutError> {
+        let key = key.into();
         if let Some(layout) = self.entries.lock().unwrap().get(&key).cloned() {
             return Ok(layout);
         }
@@ -393,10 +426,15 @@ impl LayoutCache {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
 
     #[derive(Default)]
     struct FakeSymbols {
+        /// How many times a layout has actually been resolved through these symbols, so a
+        /// cache hit can be told from a re-resolution rather than inferred from equal results.
+        resolutions: Cell<usize>,
         fallback_aliases: bool,
         optional_fields: bool,
         missing_global: Option<&'static str>,
@@ -453,6 +491,7 @@ mod tests {
 
     impl Symbols for FakeSymbols {
         fn symbol(&self, name: &str) -> Result<u64, DbgEngError> {
+            self.resolutions.set(self.resolutions.get() + 1);
             if self.missing_global == Some(name) {
                 return Self::error();
             }
@@ -490,12 +529,67 @@ mod tests {
         }
     }
 
-    fn key() -> SessionKey {
-        SessionKey {
-            kernel_base: 0xffff_f800_0000_0000,
+    fn key() -> LayoutKey {
+        LayoutKey {
+            image: KernelImage {
+                base: 0xffff_f800_0000_0000,
+                size: 0x145_0000,
+                timestamp: 0x65f5_7999,
+                checksum: 0xc6f_ee6,
+            },
             session: 7,
-            target: 1,
         }
+    }
+
+    /// glslang/win-kexp#84 and #87 are the two ways one key can be wrong, and the image
+    /// answers both. Keyed on the target, the cache grew an entry per engine and per
+    /// `end_session` that nothing ever pruned. Keyed on the base alone — which is what fixing
+    /// that left — two Windows builds whose kernels load at the same address share a layout,
+    /// and nothing tells a programmatic host the target changed, so the walker decodes one
+    /// build with the other's type offsets and globals and says nothing about it.
+    #[test]
+    fn test_layouts_are_shared_by_image_and_never_across_builds() {
+        let symbols = FakeSymbols::default();
+        let cache = LayoutCache::default();
+        let resolve = |key: LayoutKey| {
+            let layout = cache.get_or_resolve(&symbols, key).unwrap();
+            (symbols.resolutions.get(), layout.key.image)
+        };
+        let through_an_engine = |key: SessionKey| {
+            let layout = cache.get_or_resolve(&symbols, key).unwrap();
+            (symbols.resolutions.get(), layout.key.image)
+        };
+
+        let (first, image) = resolve(key());
+        assert!(first > 0);
+        assert_eq!(image, key().image);
+
+        // The same image reached through a second engine, whose `SessionKey` carries a target
+        // of its own. One entry, shared: keying on the target is the growth #84 was about, and
+        // the narrowing that prevents it is the cache's, not the caller's.
+        assert_eq!(
+            through_an_engine(SessionKey {
+                image: key().image,
+                session: key().session,
+                target: 99,
+            }),
+            (first, key().image)
+        );
+
+        // The same *address*, a different build.
+        let other_build = KernelImage {
+            timestamp: 0x1122_3344,
+            ..key().image
+        };
+        let (again, resolved) = resolve(LayoutKey {
+            image: other_build,
+            ..key()
+        });
+        assert!(
+            again > first,
+            "a second build at one base must not be served the first build's layout"
+        );
+        assert_eq!(resolved, other_build);
     }
 
     fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -642,6 +642,48 @@ mod tests {
         assert_eq!(found.next.unwrap().display_tag, "Cccc");
     }
 
+    /// A VS chunk as `walk_vs` reports one: the physical `_POOL_HEADER` sits a chunk header
+    /// into the chunk, and the usable bytes a pool header past that. So the raw chunk start,
+    /// `header_address` and `usable_address` are three different addresses — the geometry
+    /// `PoolSpan::allocation` cannot build, and the reason glslang/win-kexp#85 went unnoticed.
+    fn vs_allocation(chunk: u64, chunk_size: u64, tag: &[u8; 4], heap_id: u64) -> PoolSpan {
+        const VS_HEADER: u64 = 0x10;
+        const POOL_HEADER: u64 = 0x10;
+        let raw_tag = u32::from_le_bytes(*tag);
+        PoolSpan {
+            header_address: chunk + VS_HEADER,
+            usable_address: chunk + VS_HEADER + POOL_HEADER,
+            size: chunk_size - VS_HEADER - POOL_HEADER,
+            raw_tag,
+            display_tag: crate::pool::decode::display_tag(raw_tag),
+            pool_kind: PoolKind::NonPagedNx,
+            numa_node: 0,
+            heap: heap(heap_id),
+            subsegment: Some(0x9000),
+            backend: PoolBackend::Vs,
+            state: PoolState::Allocated,
+            size_class: chunk_size as u32,
+        }
+    }
+
+    /// glslang/win-kexp#85: the contiguity check compared `end()` — which lands on the raw
+    /// chunk end — with the next span's `header_address`, which for a VS chunk is a chunk
+    /// header *past* its start. The two differ by exactly that header for every genuinely
+    /// adjacent pair, so `previous` and `next` came back `None` for every VS allocation there
+    /// is: the one question `chunk_at` exists to answer, disabled for a whole backend.
+    #[test]
+    fn test_vs_neighbours_are_reported_despite_their_chunk_header() {
+        let index = index_of(vec![
+            vs_allocation(0x1000, 0x100, b"Aaaa", 1),
+            vs_allocation(0x1100, 0x100, b"Bbbb", 1),
+            vs_allocation(0x1200, 0x100, b"Cccc", 1),
+        ]);
+        let found = neighbourhood_at(&index, 0x1150).expect("address is covered");
+        assert_eq!(found.chunk.display_tag, "Bbbb");
+        assert_eq!(found.previous.unwrap().display_tag, "Aaaa");
+        assert_eq!(found.next.unwrap().display_tag, "Cccc");
+    }
+
     /// Allocator slack separates these two: `walk_lfh` omits a slot that would straddle a
     /// page, so spans can share every allocator identity and still not touch. Reporting
     /// them as bordering would misstate the grooming geometry this API exists to describe.

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -335,16 +335,18 @@ pub(crate) fn prepare_index(
     // itself; the generation only has to move when the *target* changes, which is what
     // `invalidate_session` is for.
     let key = SessionKey {
-        kernel_base: engine.kernel_base()?,
+        image: engine.kernel_image()?,
         session: generation(),
         target: engine.target_identity(),
     };
-    // Layouts describe the *image*, not which target instance is loaded, so they are keyed
-    // without `target`. Including it inserted an entry per engine and per `end_session`
-    // that nothing ever pruned — the same unbounded growth removed above for `refresh`.
-    let layout_key = SessionKey { target: 0, ..key };
+    // The layout cache takes the same key and narrows it to a `LayoutKey` itself — a layout
+    // describes the *image*, not which target instance is loaded, and the two ways of getting
+    // that wrong are opposite. Keyed on the target it grew an entry per engine and per
+    // `end_session` that nothing pruned; keyed on the base alone, two Windows builds whose
+    // kernels load at one address share a layout, which is not a leak but wrong data reported
+    // confidently.
     let layout = LayoutCache::global()
-        .get_or_resolve(engine, layout_key)
+        .get_or_resolve(engine, key)
         .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
 
     // Keyed on the whole `SessionKey`: a programmatic host receives no session

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -220,6 +220,9 @@ pub struct PoolSnapshotReport {
     pub diagnostics: PoolDiagnostics,
     /// What the walk stepped over rather than gave up on, in bytes; see [`WalkStalls`].
     pub stalls: WalkStalls,
+    /// Chunk headers the walk refused and resynchronised past; see
+    /// [`crate::pool::PoolSnapshot::refused_chunks`] for why this is not read off a diagnostic.
+    pub refused_chunks: u64,
 }
 
 /// How much of the pool a walk covered.
@@ -296,6 +299,7 @@ fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
         },
         diagnostics: index.diagnostics.clone(),
         stalls: index.stalls,
+        refused_chunks: index.refused_chunks,
     }
 }
 

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -22,7 +22,7 @@ use super::decode::parse_tag;
 use super::index::{PoolIndex, SnapshotCache};
 use super::layout::{LayoutCache, SessionKey};
 use super::snapshot::{SnapshotError, SnapshotWalker, WalkStalls};
-use super::{PoolDiagnostics, PoolSpan, PoolState};
+use super::{PoolBackend, PoolDiagnostics, PoolSpan, PoolState};
 use crate::dbgeng::{DbgEngError, DebugEngine};
 
 const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
@@ -435,16 +435,20 @@ fn neighbourhood_at(index: &PoolIndex, address: u64) -> Option<PoolNeighbourhood
     // the identity check with a gap between them. Reporting those as bordering would
     // misstate the very geometry this API exists to describe.
     let chunk = index.spans[position].clone();
-    // Contiguity is only meaningful where `end()` and the next span's `header_address`
-    // measure the same boundary. LFH and Segment spans report `header_address ==
-    // usable_address`, so they do. A VS span carries a chunk header between the two, so the
-    // comparison is off by its width and would reject *every* genuine VS neighbour. The gap
-    // this guards against — a slot the allocator skipped because it would straddle a page —
-    // only arises in LFH, so restricting the check there loses nothing.
+    // Contiguity compares one span's end with the next one's start. `end()` is the raw chunk
+    // end for every backend, and `header_address` is the raw chunk *start* for every backend
+    // but VS, where the chunk header sits in front of the pool header this records. Comparing
+    // across that offset would reject every genuine VS neighbour, so VS is exempt and LFH —
+    // the only backend where the allocator leaves slack — keeps the check.
+    //
+    // Exempting it by backend, and not by testing `header_address == usable_address` as this
+    // did: no walker emits a span where those are equal. `walk_lfh` and `walk_page_ranges` put
+    // the usable bytes a pool header past the header exactly as `walk_vs` does, so that test
+    // was false for every real span and the check it gated never ran outside the fixtures.
+    // Only the `#[cfg(test)]` `PoolSpan::allocation` builds spans it held for.
     let touching = |left: &PoolSpan, right: &PoolSpan| {
-        let comparable = left.header_address == left.usable_address
-            && right.header_address == right.usable_address;
-        !comparable || left.end() == right.header_address
+        // `predecessor`/`successor` pair spans from one backend, so testing either is both.
+        left.backend == PoolBackend::Vs || left.end() == right.header_address
     };
     Some(PoolNeighbourhood {
         previous: index
@@ -515,7 +519,7 @@ fn summarize_tags(index: &PoolIndex) -> Vec<PoolTagSummary> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pool::{HeapIdentity, PoolBackend, PoolKind};
+    use crate::pool::{HeapIdentity, PoolKind};
 
     fn heap(id: u64) -> HeapIdentity {
         HeapIdentity {
@@ -684,15 +688,43 @@ mod tests {
         assert_eq!(found.next.unwrap().display_tag, "Cccc");
     }
 
+    /// An LFH block as `walk_lfh` reports one: the slot start is the header, and the usable
+    /// bytes begin a pool header past it. `PoolSpan::allocation` puts both at the same
+    /// address, which no walker ever does.
+    fn lfh_allocation(slot: u64, unit: u64, tag: &[u8; 4], heap_id: u64) -> PoolSpan {
+        const POOL_HEADER: u64 = 0x10;
+        let raw_tag = u32::from_le_bytes(*tag);
+        PoolSpan {
+            header_address: slot,
+            usable_address: slot + POOL_HEADER,
+            size: unit - POOL_HEADER,
+            raw_tag,
+            display_tag: crate::pool::decode::display_tag(raw_tag),
+            pool_kind: PoolKind::NonPagedNx,
+            numa_node: 0,
+            heap: heap(heap_id),
+            subsegment: Some(0x8000),
+            backend: PoolBackend::Lfh,
+            state: PoolState::Allocated,
+            size_class: unit as u32,
+        }
+    }
+
     /// Allocator slack separates these two: `walk_lfh` omits a slot that would straddle a
     /// page, so spans can share every allocator identity and still not touch. Reporting
     /// them as bordering would misstate the grooming geometry this API exists to describe.
+    ///
+    /// With **real** LFH geometry, which is the whole point. Gating the check on
+    /// `header_address == usable_address` — as it was — turned it off for every span a walker
+    /// emits, since all of them put the usable bytes a pool header past the header. The
+    /// fixture was the only thing that ever satisfied the gate, so the check passed its test
+    /// and did nothing on a target.
     #[test]
     fn test_neighbours_must_actually_touch() {
         let index = index_of(vec![
-            allocation(0x1000, 0x100, b"Aaaa", PoolKind::NonPagedNx, 1),
-            // 0x1100..0x1200 is slack the allocator skipped.
-            allocation(0x1200, 0x100, b"Bbbb", PoolKind::NonPagedNx, 1),
+            lfh_allocation(0x1000, 0x100, b"Aaaa", 1),
+            // 0x1100..0x1200 is the slot the allocator skipped.
+            lfh_allocation(0x1200, 0x100, b"Bbbb", 1),
         ]);
         let found = neighbourhood_at(&index, 0x1250).expect("address is covered");
         assert_eq!(found.chunk.display_tag, "Bbbb");
@@ -700,6 +732,15 @@ mod tests {
             found.previous.is_none(),
             "slack between spans must not count as bordering"
         );
+
+        // And the check has to stay off the other foot: two LFH slots that really do abut are
+        // neighbours, or the fix for the above is just the VS bug moved one backend over.
+        let index = index_of(vec![
+            lfh_allocation(0x1000, 0x100, b"Aaaa", 1),
+            lfh_allocation(0x1100, 0x100, b"Bbbb", 1),
+        ]);
+        let found = neighbourhood_at(&index, 0x1150).expect("address is covered");
+        assert_eq!(found.previous.unwrap().display_tag, "Aaaa");
     }
 
     #[test]

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -21,7 +21,7 @@ use windows::Win32::System::Diagnostics::Debug::Extensions::{
 use super::decode::parse_tag;
 use super::index::{PoolIndex, SnapshotCache};
 use super::layout::{LayoutCache, SessionKey};
-use super::snapshot::{SnapshotError, SnapshotWalker};
+use super::snapshot::{SnapshotError, SnapshotWalker, WalkStalls};
 use super::{PoolDiagnostics, PoolSpan, PoolState};
 use crate::dbgeng::{DbgEngError, DebugEngine};
 
@@ -218,6 +218,8 @@ pub struct PoolSnapshotReport {
     /// the messages it carries verbatim are a capped sample, so counting them measures the
     /// cap rather than the target.
     pub diagnostics: PoolDiagnostics,
+    /// What the walk stepped over rather than gave up on, in bytes; see [`WalkStalls`].
+    pub stalls: WalkStalls,
 }
 
 /// How much of the pool a walk covered.
@@ -293,6 +295,7 @@ fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
             (false, false) => WalkCoverage::Partial,
         },
         diagnostics: index.diagnostics.clone(),
+        stalls: index.stalls,
     }
 }
 
@@ -519,9 +522,8 @@ mod tests {
     fn index_of(spans: Vec<PoolSpan>) -> PoolIndex {
         PoolIndex::build(crate::pool::PoolSnapshot {
             spans,
-            diagnostics: PoolDiagnostics::default(),
             complete: true,
-            budget_expired: false,
+            ..crate::pool::PoolSnapshot::default()
         })
     }
 
@@ -682,10 +684,8 @@ mod tests {
     #[test]
     fn test_empty_walk_still_reports_why() {
         let index = PoolIndex::build(crate::pool::PoolSnapshot {
-            spans: Vec::new(),
             diagnostics: PoolDiagnostics::from_iter(["cannot read pool node 0 heap 2".to_string()]),
-            complete: false,
-            budget_expired: false,
+            ..crate::pool::PoolSnapshot::default()
         });
         let report = report_of(&index);
         assert_eq!(report.total_chunks, 0);
@@ -709,10 +709,9 @@ mod tests {
     fn test_coverage_says_which_way_a_walk_fell_short() {
         let walked = |complete, budget_expired| {
             report_of(&PoolIndex::build(crate::pool::PoolSnapshot {
-                spans: Vec::new(),
-                diagnostics: PoolDiagnostics::default(),
                 complete,
                 budget_expired,
+                ..crate::pool::PoolSnapshot::default()
             }))
             .coverage
         };

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -411,6 +411,7 @@ mod tests {
             spans,
             complete: true,
             budget_expired: false,
+            stalls: Default::default(),
             diagnostics: PoolDiagnostics::from_iter([
                 "per-session paged heaps are not included".to_string()
             ]),
@@ -502,6 +503,7 @@ mod tests {
             spans: many,
             complete: true,
             budget_expired: false,
+            stalls: Default::default(),
             diagnostics: PoolDiagnostics::default(),
         });
         let dml_chunks = render_pool_map(

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -412,6 +412,7 @@ mod tests {
             complete: true,
             budget_expired: false,
             stalls: Default::default(),
+            refused_chunks: 0,
             diagnostics: PoolDiagnostics::from_iter([
                 "per-session paged heaps are not included".to_string()
             ]),
@@ -504,6 +505,7 @@ mod tests {
             complete: true,
             budget_expired: false,
             stalls: Default::default(),
+            refused_chunks: 0,
             diagnostics: PoolDiagnostics::default(),
         });
         let dml_chunks = render_pool_map(

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1593,6 +1593,30 @@ pub(crate) struct PoolSnapshot {
     /// the snapshot, both look like a short list — so the reason travels as a field rather than
     /// being inferred downstream from the diagnostic it also writes.
     pub budget_expired: bool,
+    /// What the walk stepped over rather than gave up on; see [`WalkStalls`].
+    pub stalls: WalkStalls,
+}
+
+/// What valid-region queries that could not advance cost the walk, and what stepping over them
+/// bought.
+///
+/// Numbers rather than another diagnostic, because a diagnostic can only say how *often* the
+/// walk stalled and that was never the question. A walk that steps over one page and a walk
+/// that abandons everything behind it emit the same line the same number of times; what
+/// separates them is how much memory the decision covered — which the walk knows at the moment
+/// it decides, and used to throw away.
+///
+/// `recovered_bytes` is what the change is judged by: committed memory read *after* a stall in
+/// the same region, which is precisely the coverage a walk that gave up at the first stall
+/// reported as nothing at all.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WalkStalls {
+    /// How many times a query could not advance and the walk stepped over a page.
+    pub pages: u64,
+    /// Bytes filed as unreadable by those steps.
+    pub skipped_bytes: u64,
+    /// Bytes of committed memory read after a stall, in the regions that stalled.
+    pub recovered_bytes: u64,
 }
 
 pub(crate) struct SnapshotWalker<'a, M> {
@@ -1697,6 +1721,17 @@ const DISCOVERY_BUDGET_SHARE: (u32, u32) = (2, 3);
 /// from the other side. The budget is a ceiling on effort, not a promise about return latency:
 /// it exists so the engine cannot run for *minutes* after its caller has given up.
 const EXTENT_READ_CHUNK: usize = 256 * 1024;
+
+/// How many pages in a row a region may refuse to advance over before the walk gives up on
+/// the rest of it.
+///
+/// Every one of these is a debugger round trip, and on a live KD link a round trip is the
+/// expensive unit — so this is not sized for how large a hole might be, but for how much
+/// probing a *dead* region is worth before its remainder is written off. Eight covers the
+/// shape the live samples actually show, a single unreadable page part-way through a
+/// committed region, with room to spare; a region that is dead all the way down costs eight
+/// queries rather than one per page of its length.
+const MAX_CONSECUTIVE_STALLS: u32 = 8;
 
 /// Splits a walk budget into the deadline discovery works to and the one the whole walk
 /// works to. `None` in gives `None` out for both: no budget, no deadlines.
@@ -1829,6 +1864,8 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     ) -> Result<(), SnapshotError> {
         let requested_end = region.address.saturating_add(region.size as u64);
         let mut cursor = region.address;
+        let mut consecutive_stalls = 0u32;
+        let mut stalled_here = false;
         while cursor < requested_end {
             check_budget(self.memory)?;
             let remaining = requested_end.saturating_sub(cursor).min(usize::MAX as u64) as usize;
@@ -1856,12 +1893,51 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 .saturating_add(reported_size as u64)
                 .min(requested_end);
             if valid_end <= valid_base {
+                // Two states used to arrive here as one, and only the second is a problem.
+                //
+                // The engine placing the next valid region beyond the end of what was asked
+                // about is the region *finishing*: its tail has already been filed as
+                // unreadable by the branch above, there is nothing behind it to lose, and the
+                // loop is done. Reporting that as a failure to advance is what made this the
+                // walk's largest diagnostic category — 3,285 lines on a live 26100 walk —
+                // while describing nothing wrong.
+                if valid_base >= requested_end {
+                    break;
+                }
+                // The rest is a real stall: a valid region was reported inside the span and it
+                // ends at or before where the cursor already is. Step over a page and ask
+                // again, rather than giving up on every committed page behind it — the
+                // samples show these firing part-way through regions of 0x10fd0 and 0x3afc0
+                // bytes, not at their tails.
+                //
+                // The advance is **unconditional**. A query that keeps answering the same way
+                // would otherwise spin here without end, which is the reason this used to
+                // abandon the region outright.
+                let skip = PAGE_SIZE.min(requested_end - valid_base);
                 snapshot.diagnostics.push(format!(
-                    "valid-region query made no progress at {cursor:#x}"
+                    "valid-region query made no progress at {valid_base:#x}; stepping over a page"
                 ));
-                self.unreadable(region, valid_base, requested_end - valid_base, snapshot);
-                break;
+                self.unreadable(region, valid_base, skip, snapshot);
+                snapshot.stalls.pages += 1;
+                snapshot.stalls.skipped_bytes = snapshot.stalls.skipped_bytes.saturating_add(skip);
+                stalled_here = true;
+                consecutive_stalls += 1;
+                cursor = valid_base.saturating_add(skip);
+                // Bounded, so a region that is dead all the way down still costs a fixed
+                // number of queries rather than one per page of its length. Consecutive:
+                // the single unreadable page in the middle of a live region — the shape these
+                // samples actually have — resets it and costs one extra query.
+                if consecutive_stalls > MAX_CONSECUTIVE_STALLS {
+                    snapshot.diagnostics.push(format!(
+                        "region {:#x}+{:#x}: giving up after consecutive pages that would not advance",
+                        region.address, region.size
+                    ));
+                    self.unreadable(region, cursor, requested_end - cursor, snapshot);
+                    break;
+                }
+                continue;
             }
+            consecutive_stalls = 0;
             let bytes = match self.read_extent(valid_base, (valid_end - valid_base) as usize) {
                 Ok(bytes) => bytes,
                 // Out of time is not "this memory would not read". Left to the arm below it
@@ -1877,10 +1953,19 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                     continue;
                 }
             };
+            if stalled_here {
+                // Committed memory read on the far side of a stall — the coverage the old
+                // `break` discarded, counted so the change can be judged by what it recovers
+                // rather than by whether a diagnostic category shrank.
+                snapshot.stalls.recovered_bytes = snapshot
+                    .stalls
+                    .recovered_bytes
+                    .saturating_add(bytes.len() as u64);
+            }
             // Verifier special pool is page-granular and its ranges are indistinguishable
             // from any other plain page range by their flags, so this has to come *before*
             // the backend dispatch. Walked as page ranges instead, the pool header plus
-            // 0xfd fill decodes as garbage and every allocation in the heap silently
+            // its fill decodes as garbage and every allocation in the heap silently
             // disappears from the snapshot.
             if region.heap.special {
                 self.walk_special_pool(region, valid_base, &bytes, snapshot);
@@ -2356,10 +2441,8 @@ mod tests {
             traversal_limit: 1000,
         };
         let mut snapshot = PoolSnapshot {
-            spans: Vec::new(),
-            diagnostics: PoolDiagnostics::default(),
             complete: true,
-            budget_expired: false,
+            ..PoolSnapshot::default()
         };
         walker.walk_lfh(&region, 0x1f80, &memory.bytes, &mut snapshot);
 
@@ -2777,6 +2860,224 @@ mod tests {
             reusable_chunks: Arc::default(),
             cached_chunks: Arc::default(),
         }
+    }
+
+    /// A memory source with gaps in it, answering `valid_region` two ways the debugger does.
+    ///
+    /// A **hole** is a page with nothing committed: the query looks past it and names where the
+    /// next committed run begins, which the walk records and steps over. A **stall** is the
+    /// query naming the address it was given and reporting no length with it — no answer the
+    /// walk can advance on, and the shape behind the 3,285 `valid-region query made no
+    /// progress` lines a live 26100 walk emitted.
+    struct HoleyMemory {
+        base: u64,
+        bytes: Vec<u8>,
+        holes: HashSet<u64>,
+        stalls: HashSet<u64>,
+        queries: Cell<usize>,
+    }
+
+    impl HoleyMemory {
+        fn new(base: u64, bytes: Vec<u8>) -> Self {
+            Self {
+                base,
+                bytes,
+                holes: HashSet::new(),
+                stalls: HashSet::new(),
+                queries: Cell::new(0),
+            }
+        }
+
+        fn end(&self) -> u64 {
+            self.base + self.bytes.len() as u64
+        }
+
+        fn committed(&self, page: u64) -> bool {
+            page >= self.base
+                && page < self.end()
+                && !self.holes.contains(&page)
+                && !self.stalls.contains(&page)
+        }
+    }
+
+    impl PoolMemory for HoleyMemory {
+        fn read_exact(&self, address: u64, size: usize) -> Result<Vec<u8>, SnapshotError> {
+            let offset = (address - self.base) as usize;
+            self.bytes
+                .get(offset..offset + size)
+                .map(<[u8]>::to_vec)
+                .ok_or_else(|| SnapshotError::InvalidData {
+                    detail: format!("read past the fixture at {address:#x}+{size:#x}"),
+                })
+        }
+
+        fn valid_region(&self, address: u64, size: usize) -> Result<(u64, usize), SnapshotError> {
+            self.queries.set(self.queries.get() + 1);
+            let page = address & !(PAGE_SIZE - 1);
+            if self.stalls.contains(&page) {
+                return Ok((address, 0));
+            }
+            let mut next = page;
+            while next < self.end() && !self.committed(next) {
+                next += PAGE_SIZE;
+            }
+            if next >= self.end() {
+                // Nothing committed from here on, so the engine names a base past the span
+                // that was asked about. That is the region *ending*, not a failure to advance.
+                return Ok((self.end(), 0));
+            }
+            let base = next.max(address);
+            let mut run = next;
+            while self.committed(run) {
+                run += PAGE_SIZE;
+            }
+            Ok((base, (run.min(address + size as u64) - base) as usize))
+        }
+
+        fn interrupted(&self) -> Result<bool, SnapshotError> {
+            Ok(false)
+        }
+    }
+
+    /// Three special-pool pages, so each committed page the walk reaches shows up as exactly
+    /// one span at a known address — which is what makes "did it walk past the gap" checkable.
+    fn special_pages(count: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for _ in 0..count {
+            bytes.extend_from_slice(&special_page(0x68, false));
+        }
+        bytes
+    }
+
+    fn walk_holey(memory: &HoleyMemory, region: &PoolRegion) -> PoolSnapshot {
+        let layout = vs_layout(false);
+        let walker = SnapshotWalker {
+            memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+        let mut snapshot = PoolSnapshot {
+            complete: true,
+            ..PoolSnapshot::default()
+        };
+        walker.walk_region(region, &mut snapshot).unwrap();
+        snapshot
+    }
+
+    /// glslang/win-kexp#94. One page the query cannot advance over used to cost every
+    /// committed page behind it: the walk filed the rest of the region as unreadable and
+    /// `break`ed, while the sibling case one branch above — a query reporting a *gap* —
+    /// recorded the hole and carried on. The samples show these firing part-way through
+    /// regions tens of pages long, so what was given up on was not a tail.
+    #[test]
+    fn test_a_stalled_query_costs_a_page_not_the_region() {
+        let mut memory = HoleyMemory::new(SPECIAL_PAGE, special_pages(4));
+        memory.stalls.insert(SPECIAL_PAGE + 0x1000);
+        let snapshot = walk_holey(&memory, &special_region(SPECIAL_PAGE, 4));
+
+        let allocated: Vec<_> = snapshot
+            .spans
+            .iter()
+            .filter(|span| span.state == PoolState::Allocated)
+            .map(|span| span.usable_address)
+            .collect();
+        assert_eq!(
+            allocated,
+            [
+                SPECIAL_PAGE + 0xf90,
+                SPECIAL_PAGE + 0x2f90,
+                SPECIAL_PAGE + 0x3f90
+            ],
+            "the pages behind the stalled one must still be walked"
+        );
+        assert!(
+            snapshot
+                .spans
+                .iter()
+                .any(|span| span.state == PoolState::Unreadable
+                    && span.header_address == SPECIAL_PAGE + 0x1000
+                    && span.size == PAGE_SIZE),
+            "the page that stalled is still filed as unreadable"
+        );
+        assert!(!snapshot.complete);
+        assert_eq!(
+            snapshot.stalls,
+            WalkStalls {
+                pages: 1,
+                skipped_bytes: PAGE_SIZE,
+                // Two pages of committed memory on the far side of the stall — what the old
+                // `break` reported as nothing at all.
+                recovered_bytes: 2 * PAGE_SIZE,
+            }
+        );
+    }
+
+    /// The reason the `break` was there in the first place: the advance has to be
+    /// unconditional or a query that keeps answering the same way spins forever. Unconditional
+    /// *and* bounded — a region that is dead all the way down costs a fixed number of queries,
+    /// not one per page of its length, which on a live KD link is the cost that matters.
+    #[test]
+    fn test_a_region_that_never_advances_is_given_up_on() {
+        let pages = 4096;
+        let mut memory = HoleyMemory::new(SPECIAL_PAGE, vec![0u8; pages * PAGE_SIZE as usize]);
+        for page in 0..pages as u64 {
+            memory.stalls.insert(SPECIAL_PAGE + page * PAGE_SIZE);
+        }
+        let snapshot = walk_holey(&memory, &special_region(SPECIAL_PAGE, pages));
+
+        assert!(
+            memory.queries.get() <= MAX_CONSECUTIVE_STALLS as usize + 1,
+            "a dead region cost {} queries",
+            memory.queries.get()
+        );
+        assert!(!snapshot.complete);
+        assert_eq!(snapshot.stalls.pages, u64::from(MAX_CONSECUTIVE_STALLS) + 1);
+        // Every byte of it is accounted for as unreadable, whether stepped over or written off.
+        let unreadable: u64 = snapshot
+            .spans
+            .iter()
+            .filter(|span| span.state == PoolState::Unreadable)
+            .map(|span| span.size)
+            .sum();
+        assert_eq!(unreadable, pages as u64 * PAGE_SIZE);
+    }
+
+    /// The other half of the fix, and the larger half of the 3,285: a region simply running
+    /// out of committed pages arrived at the same branch and was reported as a failure to
+    /// advance. Nothing is behind it to lose — the hole branch has already filed the tail —
+    /// so there is nothing to report.
+    #[test]
+    fn test_a_region_running_out_of_committed_pages_is_not_a_stall() {
+        let mut memory = HoleyMemory::new(SPECIAL_PAGE, special_pages(4));
+        memory.holes.insert(SPECIAL_PAGE + 0x3000);
+        let snapshot = walk_holey(&memory, &special_region(SPECIAL_PAGE, 4));
+
+        assert_eq!(snapshot.stalls, WalkStalls::default());
+        assert!(
+            !snapshot
+                .diagnostics
+                .examples()
+                .iter()
+                .any(|message| message.contains("made no progress")),
+            "{:?}",
+            snapshot.diagnostics.examples()
+        );
+        assert!(
+            snapshot
+                .diagnostics
+                .examples()
+                .iter()
+                .any(|message| message.contains("only committed through")),
+            "the tail is still reported as the unreadable space it is"
+        );
+        assert_eq!(
+            snapshot
+                .spans
+                .iter()
+                .filter(|span| span.state == PoolState::Allocated)
+                .count(),
+            3
+        );
     }
 
     /// Special pool is page-granular, so one page that does not decode says nothing about the

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -2602,10 +2602,9 @@ mod tests {
             types.insert("_HEAP_VS_SLOT_MAP", type_layout(4, &[("SlotRef", 0)]));
         }
         PoolLayout {
-            key: crate::pool::layout::SessionKey {
-                kernel_base: 0,
+            key: crate::pool::layout::LayoutKey {
+                image: crate::dbgeng::KernelImage::default(),
                 session: 1,
-                target: 1,
             },
             globals: HashMap::new(),
             types,
@@ -2702,10 +2701,9 @@ mod tests {
     fn test_vs_roots_reports_when_neither_shape_resolves() {
         let memory = FlatMemory::new(VS_CONTEXT, 0x100);
         let layout = PoolLayout {
-            key: crate::pool::layout::SessionKey {
-                kernel_base: 0,
+            key: crate::pool::layout::LayoutKey {
+                image: crate::dbgeng::KernelImage::default(),
                 session: 1,
-                target: 1,
             },
             globals: HashMap::new(),
             types: HashMap::new(),
@@ -3362,7 +3360,7 @@ mod tests {
             DESCRIPTOR_FLAG_ALLOCATED, DESCRIPTOR_FLAG_FIRST, DESCRIPTOR_FLAG_SUBSEGMENT,
             DESCRIPTOR_FLAG_VS,
         },
-        layout::{SessionKey, TypeLayout},
+        layout::{LayoutKey, TypeLayout},
     };
 
     /// `RangeFlags` for an in-use page range: allocated, and the range's first descriptor.
@@ -3741,10 +3739,12 @@ mod tests {
             type_layout(0x20, &[("Va", 0), ("Key", 8), ("NumberOfBytes", 0x10)]),
         );
         PoolLayout {
-            key: SessionKey {
-                kernel_base: K,
+            key: LayoutKey {
+                image: crate::dbgeng::KernelImage {
+                    base: K,
+                    ..crate::dbgeng::KernelImage::default()
+                },
                 session: 1,
-                target: 1,
             },
             globals: [
                 ("ExPoolState", STATE),

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1938,7 +1938,10 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 // number of queries rather than one per page of its length. Consecutive:
                 // the single unreadable page in the middle of a live region — the shape these
                 // samples actually have — resets it and costs one extra query.
-                if consecutive_stalls > MAX_CONSECUTIVE_STALLS {
+                //
+                // `>=`, so the count is the number of queries the limit permits and not one
+                // short of it: the check runs after the page it counts has been stepped over.
+                if consecutive_stalls >= MAX_CONSECUTIVE_STALLS {
                     snapshot.diagnostics.push(format!(
                         "region {:#x}+{:#x}: giving up after consecutive pages that would not advance",
                         region.address, region.size
@@ -3252,13 +3255,13 @@ mod tests {
         }
         let snapshot = walk_holey(&memory, &special_region(SPECIAL_PAGE, pages));
 
-        assert!(
-            memory.queries.get() <= MAX_CONSECUTIVE_STALLS as usize + 1,
-            "a dead region cost {} queries",
-            memory.queries.get()
+        assert_eq!(
+            memory.queries.get(),
+            MAX_CONSECUTIVE_STALLS as usize,
+            "a dead region costs the limit in queries, and not one more"
         );
         assert!(!snapshot.complete);
-        assert_eq!(snapshot.stalls.pages, u64::from(MAX_CONSECUTIVE_STALLS) + 1);
+        assert_eq!(snapshot.stalls.pages, u64::from(MAX_CONSECUTIVE_STALLS));
         // Every byte of it is accounted for as unreadable, whether stepped over or written off.
         let unreadable: u64 = snapshot
             .spans

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -5,11 +5,11 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use super::decode::{
-    PAGE_SIZE, PoolHeaderLayout, adjust_page_end_header, big_page_probe, decode_descriptor_at,
-    decode_large_allocation, decode_lfh_subsegment, decode_pool_header, decode_rb_root,
-    decode_slist_header_next, decode_vs_sizes, descriptor_backend, lfh_bitmap_state, read_u16,
-    read_u32, read_u64, valid_descriptor_tree_signature, valid_page_segment_signature,
-    valid_vs_signature,
+    PAGE_SIZE, PoolHeaderLayout, SpecialPoolHeader, adjust_page_end_header, big_page_probe,
+    decode_descriptor_at, decode_large_allocation, decode_lfh_subsegment, decode_pool_header,
+    decode_rb_root, decode_slist_header_next, decode_special_pool_header, decode_vs_sizes,
+    descriptor_backend, lfh_bitmap_state, read_u16, read_u32, read_u64,
+    valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
 use super::{
     HeapIdentity, PoolBackend, PoolKind, PoolSpan, PoolState,
@@ -1611,46 +1611,53 @@ struct SpecialPlacement {
     approximate: bool,
 }
 
-/// The byte Driver Verifier fills unused special-pool space with.
-const SPECIAL_POOL_FILL: u8 = 0xfd;
-
-/// Where a special-pool block sits inside its page, and how big it is.
+/// Where a special-pool block sits inside its page, and whether the page corroborates it.
 ///
-/// Returns `(usable_address, size)`. The block is normally butted against the page end at
-/// `page + PAGE_SIZE - align_up(size, 16)`; the 16-byte rounding matters, since a plain
-/// `PAGE_SIZE - size` lands 8 bytes past the real block for a 0x68 allocation.
+/// The block is butted against the page end at `page + PAGE_SIZE - align_up(size, 16)`; the
+/// 16-byte rounding matters, since a plain `PAGE_SIZE - size` lands 8 bytes past the real
+/// block for a 0x68 allocation.
 ///
-/// The size comes from `_POOL_HEADER.PreviousSize`, which is **8 bits wide and so cannot
-/// describe every legal block**. A 0x140 allocation stores 0x40 there, and a bare range
-/// check cannot tell that from a genuine 0x40 — both fit the page comfortably. The
-/// placement is therefore corroborated against the fill: everything between the header and
-/// the block must be Verifier's `0xfd`. A truncated size puts the block too close to the
-/// page end, leaving real data where fill should be, and is rejected.
+/// The size arrives already decoded, from the thirteen bits the kernel keeps it in — see
+/// [`decode_special_pool_header`]. That is what makes this a corroboration rather than the
+/// load-bearing check it used to be: read as `_POOL_HEADER.PreviousSize`'s eight bits, a 0x140
+/// allocation reported 0x40 and nothing but the fill could tell that from a genuine 0x40. A
+/// value that cannot wrap has no such twin, so a page that fails the check below is a page we
+/// misread or one being written as we read it, not an ambiguity to resolve.
 ///
-/// The same check declines rather than lies in the two other cases that break the
-/// assumption: a page read only in part (nothing corroborates the tail), and a
-/// start-aligned page (`nt!MmSpecialPoolCatchOverruns` clear), where the block sits
-/// against the *preceding* guard page instead.
+/// Both runs of fill the kernel checks on free are checked here, against the fill byte the page
+/// itself records: from the header's end up to the block, and from the block's end to the page
+/// end. The second is the alignment padding — up to 15 bytes, and evidence the old check left
+/// on the floor.
+///
+/// It declines rather than lies in the two cases that break the placement rule: a page read
+/// only in part (nothing corroborates the tail), and a start-aligned page
+/// (`nt!MmSpecialPoolCatchOverruns` clear), where the block sits against the *preceding* guard
+/// page instead.
 ///
 /// The fallback reports the whole page after the header. An over-broad chunk still answers
 /// "was this freed, and which tag owned it"; a confidently wrong offset does not.
 fn special_pool_placement(
     page: u64,
-    requested: u64,
-    header_size: u64,
+    header: SpecialPoolHeader,
     page_bytes: &[u8],
 ) -> SpecialPlacement {
     let available = page_bytes.len() as u64;
-    let aligned = requested.next_multiple_of(16);
-    if requested != 0 && available == PAGE_SIZE && aligned + header_size <= PAGE_SIZE {
-        let start = (PAGE_SIZE - aligned) as usize;
-        if page_bytes[header_size as usize..start]
+    let header_size = header.header_size as u64;
+    // Both hold by construction — `decode_special_pool_header` returns `None` otherwise — so
+    // the slicing below cannot be out of range once the page is known to be whole.
+    let aligned = u64::from(header.requested).next_multiple_of(16);
+    let start = (PAGE_SIZE - aligned) as usize;
+    if available == PAGE_SIZE {
+        let leading = &page_bytes[header.header_size..start];
+        let padding = &page_bytes[start + header.requested as usize..];
+        if leading
             .iter()
-            .all(|byte| *byte == SPECIAL_POOL_FILL)
+            .chain(padding)
+            .all(|byte| *byte == header.fill)
         {
             return SpecialPlacement {
                 usable: page + PAGE_SIZE - aligned,
-                size: requested,
+                size: u64::from(header.requested),
                 approximate: false,
             };
         }
@@ -2004,15 +2011,20 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
 
     /// Decodes a Driver Verifier special-pool region, one allocation per page.
     ///
-    /// Special pool gives every allocation its own page: a `_POOL_HEADER` at the page
-    /// start, `0xfd` fill, then the caller's block pushed up against the page end so an
-    /// overrun lands on the following guard page. The guard page is unmapped, which is
-    /// why `valid_region` stops after the data page and why a *freed* allocation simply
-    /// vanishes — both are the mechanism working, not read failures.
+    /// Special pool gives every allocation its own page: a header at the page start, fill,
+    /// then the caller's block pushed up against the page end so an overrun lands on the
+    /// following guard page. The guard page is unmapped, which is why `valid_region` stops
+    /// after the data page and why a *freed* allocation simply vanishes — both are the
+    /// mechanism working, not read failures.
     ///
     /// The block is placed at `page + PAGE_SIZE - align_up(size, 16)`; the 16-byte
     /// alignment is easy to miss, and dropping it puts the reported address 8 bytes past
     /// the real one (`0xf98` instead of `0xf90` for a 0x68 allocation).
+    ///
+    /// The page is read by [`decode_special_pool_header`] rather than by the ordinary
+    /// [`decode_pool_header`]: special pool reuses those header bytes for a size, a fill
+    /// pattern and a tracking flag, so the generic reading's plausibility guard is testing
+    /// fields that are not there.
     fn walk_special_pool(
         &self,
         region: &PoolRegion,
@@ -2020,7 +2032,6 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         bytes: &[u8],
         snapshot: &mut PoolSnapshot,
     ) {
-        let header_size = region.pool_header.size as u64;
         let mut page = base.next_multiple_of(PAGE_SIZE);
         while let Some(offset) = page.checked_sub(base).map(|delta| delta as usize) {
             if offset >= bytes.len() {
@@ -2028,13 +2039,14 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             }
             let available = (bytes.len() - offset).min(PAGE_SIZE as usize);
             let page_bytes = &bytes[offset..offset + available];
-            let Some(header) = decode_pool_header(bytes, offset, region.pool_header) else {
+            let Some(header) = decode_special_pool_header(bytes, offset, region.pool_header) else {
                 // Special pool is page-granular: one undecodable page says nothing about
                 // the next, so stopping here would silently drop the rest of the region —
                 // and leaving `complete` set would cache that truncated result and re-serve
                 // it. Every other rejection path in this file reports and continues.
                 snapshot.diagnostics.push(format!(
-                    "special-pool page {page:#x}: pool header did not decode; page skipped"
+                    "special-pool page {page:#x}: header describes no block the page could \
+                     hold; page skipped"
                 ));
                 snapshot.complete = false;
                 let Some(next) = page.checked_add(PAGE_SIZE) else {
@@ -2046,12 +2058,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             // An untagged page is not an allocation. Freed special-pool pages are
             // unmapped rather than zeroed, so anything readable here should carry a tag.
             if header.tag != 0 {
-                let placement = special_pool_placement(
-                    page,
-                    u64::from(header.previous_size),
-                    header_size,
-                    page_bytes,
-                );
+                let placement = special_pool_placement(page, header, page_bytes);
                 // Say so when the size is a bound rather than a measurement. Otherwise a
                 // conservative page-sized range is indistinguishable from a real
                 // allocation: `tag_census` would fold it into `total_bytes` — reporting a
@@ -2574,6 +2581,20 @@ mod tests {
     }
 
     const SPECIAL_PAGE: u64 = 0xffff_8c8f_13a0_2000;
+    /// The byte Driver Verifier fills unused special-pool space with. A *fixture* value now,
+    /// not a constant the walker knows: the page records its own fill byte, and the decoder
+    /// reads it from there.
+    const VERIFIER_FILL: u8 = 0xfd;
+    /// `_POOL_HEADER` as Server 26100 x64 declares it: `PreviousSize`/`PoolIndex` share the
+    /// USHORT at +0, `BlockSize`/`PoolType` the one at +2, and `Ulong1` overlays all four.
+    const X64_POOL_HEADER: PoolHeaderLayout = PoolHeaderLayout {
+        size: 0x10,
+        previous_size: 0,
+        pool_index: 0,
+        block_size: 2,
+        pool_type: 2,
+        tag: 4,
+    };
 
     /// `(usable, size, approximate)` — flattened so the assertions below stay readable and
     /// so every case states whether the size was corroborated or merely bounded.
@@ -2581,14 +2602,25 @@ mod tests {
         (placement.usable, placement.size, placement.approximate)
     }
 
-    /// A special-pool page holding a block of `requested` bytes: header, then Verifier
-    /// fill, then the block itself pushed against the page end.
-    fn special_page(requested: usize, header_size: usize) -> Vec<u8> {
-        let mut page = vec![0u8; PAGE_SIZE as usize];
-        let start = PAGE_SIZE as usize - requested.next_multiple_of(16);
-        page[header_size..start].fill(SPECIAL_POOL_FILL);
-        page[start..].fill(0x41);
+    /// A special-pool page as the kernel writes one: the requested size in the low thirteen
+    /// bits of `Ulong1`, the fill byte in `BlockSize`'s, the tag at +4, fill from the header's
+    /// end to the block, the block against the page end, and fill again over the alignment
+    /// padding behind it.
+    fn special_page(requested: u32, tracked: bool) -> Vec<u8> {
+        let mut page = vec![VERIFIER_FILL; PAGE_SIZE as usize];
+        let word = requested | if tracked { 0x4000 } else { 0 } | (u32::from(VERIFIER_FILL) << 16);
+        page[..4].copy_from_slice(&word.to_le_bytes());
+        page[4..8].copy_from_slice(b"Tsp1");
+        let start = PAGE_SIZE as usize - (requested as usize).next_multiple_of(16);
+        page[start..start + requested as usize].fill(0x41);
         page
+    }
+
+    /// Decodes a fixture page and places its block, which is the path the walk takes.
+    fn place(page: &[u8]) -> SpecialPlacement {
+        let header =
+            decode_special_pool_header(page, 0, X64_POOL_HEADER).expect("page describes a block");
+        special_pool_placement(SPECIAL_PAGE, header, page)
     }
 
     /// The real values read off Server 26100.32995: a 0x68 message in special pool sits at
@@ -2597,43 +2629,87 @@ mod tests {
     #[test]
     fn test_special_pool_block_is_pushed_against_the_page_end() {
         assert_eq!(
-            placed(special_pool_placement(
-                SPECIAL_PAGE,
-                0x68,
-                0x10,
-                &special_page(0x68, 0x10)
-            )),
+            placed(place(&special_page(0x68, false))),
             (SPECIAL_PAGE + 0xf90, 0x68, false)
         );
         // Already a multiple of 16: no rounding, block ends exactly at the page end.
         assert_eq!(
-            placed(special_pool_placement(
-                SPECIAL_PAGE,
-                0x40,
-                0x10,
-                &special_page(0x40, 0x10)
-            )),
+            placed(place(&special_page(0x40, false))),
             (SPECIAL_PAGE + 0xfc0, 0x40, false)
         );
     }
 
-    /// The case a range check cannot catch: `PreviousSize` is 8 bits, so a 0x140 block
-    /// stores 0x40 there — a value that fits the page perfectly well and is indistinguishable
-    /// from a real 0x40 by size alone. Only the fill gives it away: placing a 0x40 block at
-    /// the page end would leave the real block's bytes sitting where fill should be.
+    /// The bug behind glslang/win-kexp#83, and the reason the size is no longer read as
+    /// `_POOL_HEADER.PreviousSize`: eight bits cannot hold 0x140, so that allocation used to
+    /// present as a 0x40 one — a value that fits the page perfectly well and that no range
+    /// check could tell from a genuine 0x40. Thirteen bits hold anything a page can, so the
+    /// two are now different numbers rather than the same one.
     #[test]
-    fn test_special_pool_detects_a_truncated_size_via_the_fill() {
-        // The page really holds 0x140 bytes of data; the header claims 0x40.
-        let page = special_page(0x140, 0x10);
+    fn test_special_pool_reads_a_size_that_does_not_fit_eight_bits() {
+        let page = special_page(0x140, false);
         assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, 0x40, 0x10, &page)),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true),
-            "a truncated PreviousSize must fall back, not report a block at the page end"
+            page[0], 0x40,
+            "the low byte alone is the value that used to be read"
         );
-        // Sanity: told the truth, the same page resolves precisely.
         assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, 0x140, 0x10, &page)),
-            (SPECIAL_PAGE + 0xec0, 0x140, false)
+            placed(place(&page)),
+            (SPECIAL_PAGE + 0xec0, 0x140, false),
+            "the block is 0x140 bytes at page+0xec0, not 0x40 bytes at page+0xfc0"
+        );
+        // The largest block a page can hold, which is where the mask has to stop being generous.
+        assert_eq!(
+            placed(place(&special_page(0xff0, false))),
+            (SPECIAL_PAGE + 0x10, 0xff0, false)
+        );
+    }
+
+    /// Verifier tracking puts eight bytes of its own between the pool header and the fill, and
+    /// the page says so in `Ulong1`. Reading the fill from +0x10 there would compare tracking
+    /// data against the fill byte and give up on a page that is perfectly well formed.
+    #[test]
+    fn test_special_pool_skips_verifiers_tracking_block() {
+        let mut page = special_page(0x68, true);
+        page[0x10..0x18].copy_from_slice(&0xdead_beef_u64.to_le_bytes());
+        let header = decode_special_pool_header(&page, 0, X64_POOL_HEADER).unwrap();
+        assert_eq!(header.header_size, 0x18);
+        assert_eq!(header.requested, 0x68);
+        assert_eq!(header.tag, u32::from_le_bytes(*b"Tsp1"));
+        assert_eq!(
+            placed(special_pool_placement(SPECIAL_PAGE, header, &page)),
+            (SPECIAL_PAGE + 0xf90, 0x68, false)
+        );
+    }
+
+    /// The corroboration the old check left on the floor: the kernel compares the alignment
+    /// padding behind the block against the fill too, and up to fifteen bytes of evidence is
+    /// worth having when the alternative is trusting the leading run alone.
+    #[test]
+    fn test_special_pool_checks_the_padding_behind_the_block() {
+        let mut page = special_page(0x68, false);
+        page[PAGE_SIZE as usize - 1] = 0x41;
+        assert_eq!(
+            placed(place(&page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
+        );
+    }
+
+    /// The fill byte comes off the page, so a page filled with something else still resolves
+    /// precisely — and one whose fill disagrees with its own recorded byte does not.
+    #[test]
+    fn test_special_pool_uses_the_fill_byte_the_page_records() {
+        let mut page = special_page(0x68, false);
+        page[0x10..0xf90].fill(0xc0);
+        page[0xff8..].fill(0xc0);
+        page[2] = 0xc0;
+        assert_eq!(
+            placed(place(&page)),
+            (SPECIAL_PAGE + 0xf90, 0x68, false),
+            "0xfd is Verifier's default, not part of the format"
+        );
+        page[2] = VERIFIER_FILL;
+        assert_eq!(
+            placed(place(&page)),
+            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
         );
     }
 
@@ -2642,37 +2718,113 @@ mod tests {
     /// declines instead of reporting a bogus address.
     #[test]
     fn test_special_pool_declines_a_start_aligned_page() {
-        let mut page = vec![0u8; PAGE_SIZE as usize];
+        let mut page = special_page(0x68, false);
+        page[0xf90..].fill(VERIFIER_FILL);
         page[0x10..0x78].fill(0x41); // block immediately after the header
-        page[0x78..].fill(SPECIAL_POOL_FILL); // fill trails it
         assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &page)),
+            placed(place(&page)),
             (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
         );
     }
 
+    /// A page that describes no block a page could hold is not one we read correctly, and the
+    /// walk skips it rather than reporting a span from it.
     #[test]
-    fn test_special_pool_falls_back_when_the_size_is_untrustworthy() {
-        let page = special_page(0x68, 0x10);
-        assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, 0, 0x10, &page)),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
-        );
-        // A request that cannot share the page with its own header is not believable.
-        assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, PAGE_SIZE, 0x10, &page)),
-            (SPECIAL_PAGE + 0x10, PAGE_SIZE - 0x10, true)
-        );
+    fn test_special_pool_header_refuses_an_impossible_block() {
+        let mut page = special_page(0x68, false);
+        page[..4].copy_from_slice(&(u32::from(VERIFIER_FILL) << 16).to_le_bytes());
+        assert!(decode_special_pool_header(&page, 0, X64_POOL_HEADER).is_none());
+        // 0x1000 bytes cannot share a 0x1000 byte page with the header in front of them, and
+        // the mask reaches 0x1fff, so this is a value the field can really hold.
+        page[..4].copy_from_slice(&(0x1000 | (u32::from(VERIFIER_FILL) << 16)).to_le_bytes());
+        assert!(decode_special_pool_header(&page, 0, X64_POOL_HEADER).is_none());
+        // Tracked, and one alignment step too large to leave room for the tracking block.
+        page[..4]
+            .copy_from_slice(&(0xfe8 | 0x4000 | (u32::from(VERIFIER_FILL) << 16)).to_le_bytes());
+        assert!(decode_special_pool_header(&page, 0, X64_POOL_HEADER).is_none());
     }
 
     /// A partially readable page corroborates nothing about where the block sits, so the
     /// end-of-page placement must not be used and the size must not exceed what was read.
     #[test]
     fn test_special_pool_fallback_respects_the_readable_length() {
-        let partial = vec![SPECIAL_POOL_FILL; 0x200];
+        let mut partial = special_page(0x68, false);
+        partial.truncate(0x200);
+        assert_eq!(placed(place(&partial)), (SPECIAL_PAGE + 0x10, 0x1f0, true));
+    }
+
+    fn special_region(address: u64, pages: usize) -> PoolRegion {
+        PoolRegion {
+            address,
+            size: pages * PAGE_SIZE as usize,
+            pool_kind: PoolKind::SpecialNonPagedNx,
+            numa_node: 0,
+            heap: HeapIdentity {
+                pool_state: 0,
+                heap: 0,
+                special: true,
+            },
+            subsegment: None,
+            backend: PoolBackend::Segment,
+            unit_size: PAGE_SIZE as u32,
+            bitmap: Vec::new(),
+            heap_key: 0,
+            pool_header: X64_POOL_HEADER,
+            vs_header_size: 0,
+            vs_sizes_offset: 0,
+            known_tag: None,
+            states: Vec::new(),
+            reusable_chunks: Arc::default(),
+            cached_chunks: Arc::default(),
+        }
+    }
+
+    /// Special pool is page-granular, so one page that does not decode says nothing about the
+    /// next. Abandoning the region there — which is what this did before glslang/win-kexp#86 —
+    /// dropped every later allocation *and* left `complete` set, so the truncated snapshot was
+    /// the one cached and re-served.
+    #[test]
+    fn test_a_bad_special_pool_page_costs_that_page_only() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&special_page(0x68, false));
+        bytes.extend_from_slice(&vec![0u8; PAGE_SIZE as usize]); // decodes as nothing
+        bytes.extend_from_slice(&special_page(0x140, false));
+        let region = special_region(SPECIAL_PAGE, 3);
+        let memory = FlatMemory::new(SPECIAL_PAGE, bytes.len());
+        let layout = vs_layout(false);
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+        let mut snapshot = PoolSnapshot {
+            complete: true,
+            ..PoolSnapshot::default()
+        };
+        walker.walk_special_pool(&region, SPECIAL_PAGE, &bytes, &mut snapshot);
+
+        let found: Vec<_> = snapshot
+            .spans
+            .iter()
+            .map(|span| (span.usable_address, span.size))
+            .collect();
         assert_eq!(
-            placed(special_pool_placement(SPECIAL_PAGE, 0x68, 0x10, &partial)),
-            (SPECIAL_PAGE + 0x10, 0x1f0, true)
+            found,
+            [
+                (SPECIAL_PAGE + 0xf90, 0x68),
+                (SPECIAL_PAGE + 0x2000 + 0xec0, 0x140)
+            ],
+            "the page after the bad one must still be walked"
+        );
+        assert!(!snapshot.complete, "a skipped page is not a complete walk");
+        assert!(
+            snapshot
+                .diagnostics
+                .examples()
+                .iter()
+                .any(|message| message.contains(&format!("{:#x}", SPECIAL_PAGE + 0x1000))),
+            "the diagnostic has to name the page that was skipped: {:?}",
+            snapshot.diagnostics.examples()
         );
     }
     use crate::pool::{

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1916,17 +1916,26 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                     break;
                 }
                 // The rest is a real stall: a valid region was reported inside the span and it
-                // ends at or before where the cursor already is. Step over a page and ask
-                // again, rather than giving up on every committed page behind it — the
-                // samples show these firing part-way through regions of 0x10fd0 and 0x3afc0
+                // ends at or before where the cursor already is. Step over the page it stalled
+                // on and ask again, rather than giving up on every committed page behind it —
+                // the samples show these firing part-way through regions of 0x10fd0 and 0x3afc0
                 // bytes, not at their tails.
                 //
-                // The advance is **unconditional**. A query that keeps answering the same way
-                // would otherwise spin here without end, which is the reason this used to
-                // abandon the region outright.
-                let skip = PAGE_SIZE.min(requested_end - valid_base);
+                // To the next page **boundary**, not a page's worth of bytes: a region begins
+                // wherever the allocator put it (`…de6030`, `…e02130` in those same samples),
+                // so a stall at a page offset of 0xfd0 would otherwise write off 0x30 bytes of
+                // the page that stalled and 0xfd0 bytes of the page after it — discarding a
+                // healthy page to skip a bad one, which is this whole branch's mistake in
+                // miniature. Every stall after the first is aligned by construction.
+                //
+                // The advance is **unconditional**: the boundary is always past `valid_base`,
+                // and `requested_end` is too — the check above returned otherwise — so this
+                // cannot be zero. A query that keeps answering the same way would spin here
+                // without end, which is the reason this used to abandon the region outright.
+                let page_end = (valid_base & !(PAGE_SIZE - 1)).saturating_add(PAGE_SIZE);
+                let skip = page_end.min(requested_end) - valid_base;
                 snapshot.diagnostics.push(format!(
-                    "valid-region query made no progress at {valid_base:#x}; stepping over a page"
+                    "valid-region query made no progress at {valid_base:#x}; stepping over the                      rest of the page"
                 ));
                 self.unreadable(region, valid_base, skip, snapshot);
                 snapshot.stalls.pages += 1;
@@ -3239,6 +3248,38 @@ mod tests {
                 // `break` reported as nothing at all.
                 recovered_bytes: 2 * PAGE_SIZE,
             }
+        );
+    }
+
+    /// A region begins wherever the allocator put it — `…de6030` and `…e02130` in the live
+    /// samples — so a stall can land at any page offset. Advancing a page's *worth of bytes*
+    /// from there writes off the tail of the page that stalled and the head of the page after
+    /// it, discarding a healthy page in order to skip a bad one: this branch's own mistake, in
+    /// miniature. The other stall tests miss it because their region is page-aligned.
+    #[test]
+    fn test_a_stall_part_way_through_a_page_does_not_swallow_the_next_one() {
+        let mut memory = HoleyMemory::new(SPECIAL_PAGE, special_pages(3));
+        memory.stalls.insert(SPECIAL_PAGE);
+        // Starting 0x30 bytes short of the second page, as an unaligned region does.
+        let mut region = special_region(SPECIAL_PAGE, 3);
+        region.address = SPECIAL_PAGE + 0xfd0;
+        region.size = 3 * PAGE_SIZE as usize - 0xfd0;
+        let snapshot = walk_holey(&memory, &region);
+
+        assert_eq!(
+            snapshot.stalls.skipped_bytes, 0x30,
+            "only the rest of the page that stalled is written off"
+        );
+        let allocated: Vec<_> = snapshot
+            .spans
+            .iter()
+            .filter(|span| span.state == PoolState::Allocated)
+            .map(|span| span.usable_address)
+            .collect();
+        assert_eq!(
+            allocated,
+            [SPECIAL_PAGE + 0x1f90, SPECIAL_PAGE + 0x2f90],
+            "the page immediately after the stall is healthy and must still be walked"
         );
     }
 

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use super::decode::{
     PAGE_SIZE, PoolHeaderLayout, SpecialPoolHeader, adjust_page_end_header, big_page_probe,
     decode_descriptor_at, decode_large_allocation, decode_lfh_subsegment, decode_pool_header,
-    decode_rb_root, decode_slist_header_next, decode_special_pool_header, decode_vs_sizes,
+    decode_rb_root, decode_slist_header_next, decode_special_pool_header, decode_vs_chunk,
     descriptor_backend, lfh_bitmap_state, read_u16, read_u32, read_u64,
     valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
@@ -1595,6 +1595,17 @@ pub(crate) struct PoolSnapshot {
     pub budget_expired: bool,
     /// What the walk stepped over rather than gave up on; see [`WalkStalls`].
     pub stalls: WalkStalls,
+    /// Chunk headers a backend decoder refused and resynchronised past, across the whole walk.
+    ///
+    /// A count, because the diagnostic that names them cannot be one. `PoolDiagnostics`
+    /// collapses messages by shape, and a refusal is reported once per extent — so the figure
+    /// beside that line counts *extents that contained a refusal*, which reads like a chunk
+    /// count and is not one. On the walk that raised glslang/win-kexp#93 the difference was
+    /// between "884" and a number nothing recorded.
+    ///
+    /// Only `walk_vs` feeds it today; LFH subsegments are refused during discovery, one per
+    /// subsegment, where the count and the message already agree.
+    pub refused_chunks: u64,
 }
 
 /// What valid-region queries that could not advance cost the walk, and what stepping over them
@@ -2228,10 +2239,27 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         }
     }
 
+    /// Decodes one committed extent of a VS subsegment, chunk by chunk.
+    ///
+    /// A refused header costs more than itself: the walk no longer knows where the next one
+    /// starts, so it advances sixteen bytes and tries again, and every header after it in the
+    /// extent is decoded at a *guessed* offset rather than at the end of the previous chunk.
+    /// One header rewritten while we read it and one systematically misdecoded field therefore
+    /// look identical from a count — which is why what is reported here is the count of
+    /// **chunks** refused rather than of extents that contained a refusal, the failing
+    /// predicate in its own words, and the `Sizes` word as read.
     fn walk_vs(&self, region: &PoolRegion, base: u64, bytes: &[u8], snapshot: &mut PoolSnapshot) {
         let mut offset = ((16 - (base as usize & 0xf)) & 0xf).min(bytes.len());
         let mut chunks = 0usize;
-        let mut reported_corruption = false;
+        let header_bytes = region.vs_header_size + region.pool_header.size;
+        let subsegment_end = region.address.saturating_add(region.size as u64);
+        let mut refused = 0u64;
+        let mut resync_from = None;
+        let mut chain_breaks = 0u64;
+        // What the *next* header must record as its previous size, or `None` where there is
+        // nothing to compare against: at the start of an extent, and after a resynchronisation,
+        // where the walk no longer knows which chunk it is standing on.
+        let mut previous_chunk = None;
         while offset
             .saturating_add(region.vs_header_size)
             .saturating_add(region.pool_header.size)
@@ -2242,32 +2270,46 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             let Some(encoded) = read_u64(bytes, offset + region.vs_sizes_offset) else {
                 break;
             };
-            let Some(sizes) = decode_vs_sizes(encoded, header_address, region.heap_key) else {
-                if !reported_corruption {
-                    snapshot.diagnostics.push(format!(
-                        "rejecting corrupt VS metadata beginning at {header_address:#x}"
-                    ));
-                    reported_corruption = true;
+            let chunk = match decode_vs_chunk(
+                encoded,
+                header_address,
+                region.heap_key,
+                header_bytes,
+                subsegment_end,
+            ) {
+                Ok(chunk) => chunk,
+                Err(rejection) => {
+                    if refused == 0 {
+                        snapshot.diagnostics.push(format!(
+                            "refusing VS chunk at {header_address:#x}: {rejection}"
+                        ));
+                    }
+                    refused += 1;
+                    resync_from.get_or_insert(header_address);
+                    previous_chunk = None;
+                    snapshot.complete = false;
+                    offset = offset.saturating_add(16);
+                    continue;
                 }
-                snapshot.complete = false;
-                offset = offset.saturating_add(16);
-                continue;
             };
-            let chunk_size = (sizes.size as usize).saturating_mul(16);
-            if chunk_size < region.vs_header_size + region.pool_header.size
-                || header_address.saturating_add(chunk_size as u64)
-                    > region.address.saturating_add(region.size as u64)
+            if let Some(expected) = previous_chunk
+                && chunk.previous_size != expected
             {
-                if !reported_corruption {
+                // Not a refusal: the chunk itself is plausible, and the chain disagreeing says
+                // the *stride* that reached it is wrong. Reported so one live run can tell a
+                // header rewritten under us from a walk decoding the wrong field, which is the
+                // question a refusal count on its own cannot answer.
+                if chain_breaks == 0 {
                     snapshot.diagnostics.push(format!(
-                        "rejecting implausible VS chunk size {chunk_size:#x} at {header_address:#x}"
+                        "VS chunk at {header_address:#x} records a previous size of \
+                         {:#x} where the chunk before it measured {expected:#x}",
+                        chunk.previous_size
                     ));
-                    reported_corruption = true;
                 }
+                chain_breaks += 1;
                 snapshot.complete = false;
-                offset = offset.saturating_add(16);
-                continue;
             }
+            let chunk_size = chunk.size;
             if offset.saturating_add(chunk_size) > bytes.len() {
                 snapshot.complete = false;
                 break;
@@ -2286,7 +2328,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 PoolState::CachedFree
             } else if region.reusable_chunks.contains(&header_address) {
                 PoolState::ReusableFree
-            } else if sizes.allocated {
+            } else if chunk.allocated {
                 PoolState::Allocated
             } else {
                 PoolState::ReusableFree
@@ -2304,9 +2346,21 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             );
             span.size_class = chunk_size.min(u32::MAX as usize) as u32;
             snapshot.spans.push(span);
-            let _ = sizes.previous_size;
+            previous_chunk = Some(chunk_size);
             offset += chunk_size;
             chunks += 1;
+        }
+        if let Some(from) = resync_from {
+            snapshot.refused_chunks = snapshot.refused_chunks.saturating_add(refused);
+            snapshot.diagnostics.push(format!(
+                "{refused} VS chunk headers refused, resynchronising from {from:#x}"
+            ));
+        }
+        if chain_breaks > 0 {
+            snapshot.diagnostics.push(format!(
+                "{chain_breaks} VS chunks disagreed with the size of the chunk before them, \
+                 from {base:#x}"
+            ));
         }
         if chunks >= self.traversal_limit {
             snapshot.complete = false;
@@ -2860,6 +2914,181 @@ mod tests {
             reusable_chunks: Arc::default(),
             cached_chunks: Arc::default(),
         }
+    }
+
+    const VS_BASE: u64 = 0x2000;
+    const VS_HEAP_KEY: u64 = 0x1234_5678_9abc_def0;
+
+    fn vs_region(size: usize) -> PoolRegion {
+        PoolRegion {
+            address: VS_BASE,
+            size,
+            pool_kind: PoolKind::NonPagedNx,
+            numa_node: 0,
+            heap: HeapIdentity {
+                pool_state: 0,
+                heap: 0,
+                special: false,
+            },
+            subsegment: Some(VS_BASE),
+            backend: PoolBackend::Vs,
+            unit_size: 0,
+            bitmap: Vec::new(),
+            heap_key: VS_HEAP_KEY,
+            pool_header: X64_POOL_HEADER,
+            vs_header_size: 0x10,
+            vs_sizes_offset: 0,
+            known_tag: None,
+            states: Vec::new(),
+            reusable_chunks: Arc::default(),
+            cached_chunks: Arc::default(),
+        }
+    }
+
+    /// VS chunks laid end to end from [`VS_BASE`]: each carries its `Sizes` word, then the pool
+    /// header, then its data. `(size, previous)` are both bytes, and `previous` is written as
+    /// given so the chain can be broken on purpose.
+    fn vs_extent(chunks: &[(usize, usize)]) -> Vec<u8> {
+        let mut bytes = vec![0u8; chunks.iter().map(|(size, _)| size).sum()];
+        let mut offset = 0;
+        for &(size, previous) in chunks {
+            let decoded =
+                ((size as u64 / 16) << 16) | ((previous as u64 / 16) << 32) | (1u64 << 48);
+            let encoded = decoded ^ VS_HEAP_KEY ^ (VS_BASE + offset as u64);
+            bytes[offset..offset + 8].copy_from_slice(&encoded.to_le_bytes());
+            let pool = offset + 0x10;
+            bytes[pool..pool + 4].copy_from_slice(&0x0001_0000u32.to_le_bytes());
+            bytes[pool + 4..pool + 8].copy_from_slice(b"VS!!");
+            offset += size;
+        }
+        bytes
+    }
+
+    fn walk_vs_extent(bytes: &[u8]) -> PoolSnapshot {
+        let region = vs_region(bytes.len());
+        let memory = FlatMemory::new(VS_BASE, bytes.len());
+        let layout = vs_layout(false);
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+        let mut snapshot = PoolSnapshot {
+            complete: true,
+            ..PoolSnapshot::default()
+        };
+        walker.walk_vs(&region, VS_BASE, bytes, &mut snapshot);
+        snapshot
+    }
+
+    /// glslang/win-kexp#93: "884x rejecting implausible VS chunk size # at #" counted the
+    /// *extents* that contained a refusal, because the message was latched behind a bool. How
+    /// many chunks were refused was reported nowhere — and a refusal is not free, since the
+    /// walk then advances sixteen bytes at a time and decodes every later header in the extent
+    /// at a guessed offset.
+    #[test]
+    fn test_vs_refusals_are_counted_as_chunks_not_as_extents() {
+        let mut bytes = vs_extent(&[(0x40, 0), (0x40, 0x40), (0x40, 0x40)]);
+        bytes.extend_from_slice(&[0u8; 0x40]); // three more header-sized strides of nothing
+        let snapshot = walk_vs_extent(&bytes);
+
+        assert_eq!(snapshot.spans.len(), 3);
+        assert_eq!(snapshot.refused_chunks, 3);
+        assert!(!snapshot.complete);
+        let examples = snapshot.diagnostics.examples();
+        assert_eq!(
+            examples
+                .iter()
+                .filter(|message| message.starts_with("refusing VS chunk at"))
+                .count(),
+            1,
+            "the detail is a sample, not one line per refusal: {examples:?}"
+        );
+        assert!(
+            examples.iter().any(|message| message
+                == "3 VS chunk headers refused, resynchronising from 0x20c0"),
+            "{examples:?}"
+        );
+    }
+
+    /// One predicate covered two different failures and printed one sentence for both, so a
+    /// live run could not say which was happening. Distinct prose keeps them distinct shapes
+    /// under diagnostic collapse while the numbers still fold.
+    #[test]
+    fn test_vs_says_which_check_a_chunk_failed() {
+        let refuse = |size: usize, end: u64| {
+            let decoded = (size as u64 / 16) << 16;
+            decode_vs_chunk(
+                decoded ^ VS_HEAP_KEY ^ VS_BASE,
+                VS_BASE,
+                VS_HEAP_KEY,
+                0x20,
+                end,
+            )
+            .unwrap_err()
+        };
+        assert_eq!(refuse(0, 0x3000).reason, "the size word decodes to zero");
+        assert_eq!(
+            refuse(0x10, 0x3000).reason,
+            "the chunk is smaller than its own headers"
+        );
+        assert_eq!(
+            refuse(0x100, 0x2080).reason,
+            "the chunk runs past the end of its subsegment"
+        );
+        // The word as read travels with the refusal, so a header can be re-decoded by hand
+        // against another candidate mix without another walk of the target.
+        assert_eq!(
+            refuse(0x10, 0x3000).encoded,
+            (1u64 << 16) ^ VS_HEAP_KEY ^ VS_BASE
+        );
+        // A subsegment's last chunk reaches its boundary exactly, and refusing that would drop
+        // a well-formed chunk from every subsegment that is fully occupied.
+        assert_eq!(
+            decode_vs_chunk(
+                ((0x80u64 / 16) << 16) ^ VS_HEAP_KEY ^ VS_BASE,
+                VS_BASE,
+                VS_HEAP_KEY,
+                0x20,
+                VS_BASE + 0x80,
+            )
+            .unwrap()
+            .size,
+            0x80
+        );
+    }
+
+    /// The corroboration the decoder had in hand and threw away (`let _ = sizes.previous_size`).
+    /// It is what tells the two explanations for a refusal apart: a chain that holds either
+    /// side of one bad chunk is a header rewritten while we read it, while a chain that never
+    /// holds says the stride itself is wrong and the chunks behind it are fiction.
+    #[test]
+    fn test_vs_reports_a_chunk_that_disagrees_with_its_predecessor() {
+        let snapshot = walk_vs_extent(&vs_extent(&[(0x40, 0), (0x40, 0x40), (0x40, 0x20)]));
+
+        assert_eq!(
+            snapshot.spans.len(),
+            3,
+            "the chunk itself is still plausible"
+        );
+        assert_eq!(snapshot.refused_chunks, 0);
+        assert!(!snapshot.complete);
+        let examples = snapshot.diagnostics.examples();
+        assert!(
+            examples.iter().any(|message| message
+                == "VS chunk at 0x2080 records a previous size of 0x20 where the chunk before it measured 0x40"),
+            "{examples:?}"
+        );
+        assert!(
+            examples
+                .iter()
+                .any(|message| message.starts_with("1 VS chunks disagreed")),
+            "{examples:?}"
+        );
+        // A chain that holds says nothing at all.
+        let quiet = walk_vs_extent(&vs_extent(&[(0x40, 0), (0x40, 0x40), (0x40, 0x40)]));
+        assert!(quiet.complete);
+        assert!(quiet.diagnostics.is_empty(), "{:?}", quiet.diagnostics);
     }
 
     /// A memory source with gaps in it, answering `valid_region` two ways the debugger does.

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -166,6 +166,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
         let snapshot = crate::pool::PoolSnapshot {
             complete: filtered.complete,
             budget_expired: filtered.budget_expired,
+            stalls: filtered.stalls,
             spans: filtered.spans,
             diagnostics: filtered.diagnostics,
         };

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -167,6 +167,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
             complete: filtered.complete,
             budget_expired: filtered.budget_expired,
             stalls: filtered.stalls,
+            refused_chunks: filtered.refused_chunks,
             spans: filtered.spans,
             diagnostics: filtered.diagnostics,
         };


### PR DESCRIPTION
Every open `pool:` issue, and the two `dbgeng` ones they lean on. Six commits, one per issue, each readable on its own.

## What each one was

**#83 — the special-pool size was read from eight bits that cannot hold it.**
`special_pool_placement` took the size from `_POOL_HEADER.PreviousSize`, so a 0x140 allocation presented as a 0x40 one, and nothing but Verifier's fill could tell that from a genuine 0x40 — a content heuristic over driver-controlled bytes.

`nt!ExpFreeHeapSpecialPool` says where the size really lives. It is handed the block pointer and bug checks (`0xc1`/`0x21`) unless the page's own fields place the block exactly there, so its reading *defines* a well-formed special-pool page. Measured on Server 26100.32995 (`nt` 0x65f57999): the size is the low **thirteen** bits of `Ulong1`, Verifier's tracking block adds eight bytes to the header when bit 0x4000 is set, and the fill byte is *recorded on the page* in `BlockSize`'s byte rather than being 0xfd by definition. Thirteen bits hold anything a page can, so the value can no longer wrap and the fill check goes back to being corroboration — now over both runs the kernel checks, not just the leading one.

**#94 — a stalled region query cost the region, not the page.**
3,285 lines on a live 26100 walk, the largest category. Two states were arriving at one branch: the engine naming a base beyond the span asked about is the region *ending* (its tail already filed, nothing behind it — likely most of the 3,285), and that is now silent. What is left steps over one page and asks again, unconditionally so it cannot spin, bounded at eight consecutive pages so a dead region costs a fixed number of round trips.

**#93 — 884 counted extents, not chunks.**
The message was latched behind a bool, so what was reported was *extents containing a refusal*. `decode_vs_chunk` now answers the way `decode_lfh_subsegment` does — failing predicate as digit-free prose, values as numbers, the `Sizes` word as read — with a per-extent tally and a walk total. `PreviousSize` was decoded and thrown away (`let _ =`); it is now checked against the walk's own stride, which is what separates a header rewritten under us from a stride that is simply wrong.

**#87 — two builds at one kernel base shared a layout.** Keyed on `KernelImage` (base + `TimeDateStamp`/`SizeOfImage`/`CheckSum`, the identity a symbol server keys the binary on), entries are shared across engines on one build and never across builds.

**#82 — a borrowed identity died with its wrapper.** Held in a process-global registry keyed by client, so an `end_session` bump survives the per-command wrapper that made it.

**#84, #85, #86** were fixed by ce8bce2 and left open. All three are verified here and, more to the point, *pinned*:
- #84's rule lived in one caller as a `SessionKey { target: 0, .. }` before the call. Writing the test found that the cache still keyed on the whole session when called directly, so the narrowing moved into `LayoutCache`.
- #85 needed a VS-shaped fixture, which is why it was missed: every test built spans with `PoolSpan::allocation`, whose LFH geometry never reproduces the offset. Added, and confirmed to fail against the pre-fix comparison.
- #86's page-granular skip had no test either. Added.

## Measurement

`WalkStalls` (pages stepped over, bytes skipped, **bytes read on the far side of a stall**) and `refused_chunks` travel on the snapshot, the index and the report. The recovered figure is the one #94 is judged by — it is exactly what the old `break` reported as nothing at all — and neither can be read off a diagnostic, because `PoolDiagnostics` collapses the numbers that would carry them.

## Downstream

`PoolSnapshotReport` gained two fields. windbg-mcp's own code is unaffected; three of its **test** fixtures construct the struct and need the new fields, which is a follow-up there once this is on `main`. Surfacing the two figures through `pool_diagnostics` is the obvious next step and is where a live run can size the fix.

## Verified

`cargo test` (94 + 2, all passing), `cargo clippy --all-targets` (one pre-existing warning in `process.rs`), `cargo fmt`. The live 26100 numbers this reports against still need a KDNET run — the fixtures pin the behaviour, not the field counts.

Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Closes #93
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added kernel image details, including base address, size, timestamp and checksum.
  - Added pool-walking diagnostics for stalls, skipped data, recovered bytes and refused chunks.
  - Added special-pool analysis and clearer virtual-store chunk validation.
  - Exposed walk-stall diagnostics for reporting and troubleshooting.

- **Bug Fixes**
  - Improved scanning beyond stalled pages and interrupted regions.
  - Improved layout reuse across matching kernel images while separating different builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->