### PR TITLE
Add version-aware segment heap walking

### DIFF
--- a/examples/user_heap_smoke.rs
+++ b/examples/user_heap_smoke.rs
@@ -1,0 +1,166 @@
+//! Opt-in live x64 smoke helper for the typed user Segment Heap walker.
+//!
+//! `cargo run --example user_heap_smoke` launches a child under DbgEng. The child creates a
+//! Segment Heap and allocations spanning the usual size regimes, then breaks in; the controller
+//! lists roots and verifies that every returned pointer is covered. This requires DbgEng and the
+//! matching `ntdll` PDB on the configured symbol path.
+
+use std::ffi::CString;
+use std::hint::black_box;
+use std::time::Duration;
+
+use win_kexp::dbgeng::DebugEngine;
+use win_kexp::heap::{self, HeapAllocation, HeapBackend, HeapKind, HeapWalk};
+use windows::Win32::System::Diagnostics::Debug::{DebugBreak, OutputDebugStringA};
+use windows::Win32::System::Memory::{HEAP_FLAGS, HeapAlloc, HeapCreate};
+use windows::core::PCSTR;
+
+const SEGMENT_HEAP_FLAG: HEAP_FLAGS = HEAP_FLAGS(0x100);
+
+fn target() {
+    let heap = unsafe { HeapCreate(SEGMENT_HEAP_FLAG, 0, 0) }.expect("create Segment Heap");
+    let mut keep_alive = Vec::new();
+    // Exercise the 0x20 bucket until it transitions to LFH, then retain the last slot as the
+    // LFH witness. The other sizes exercise the three progressively larger paths.
+    for _ in 0..32 {
+        keep_alive.push(unsafe { HeapAlloc(heap, HEAP_FLAGS(0), 0x20) } as u64);
+    }
+    let mut allocations = vec![("lfh", *keep_alive.last().unwrap())];
+    allocations.extend(
+        [("vs", 0x400usize), ("segment", 0x4000), ("large", 0x20_000)]
+            .into_iter()
+            .map(|(backend, size)| {
+                let pointer = unsafe { HeapAlloc(heap, HEAP_FLAGS(0), size) } as u64;
+                assert_ne!(pointer, 0, "allocate {size:#x}");
+                keep_alive.push(pointer);
+                (backend, pointer)
+            }),
+    );
+    // A debugger captures OutputDebugString without needing to inherit the target's console.
+    let message = CString::new(format!(
+        "WIN_KEXP_HEAP={:#x} ALLOCS={}\n",
+        heap.0 as usize,
+        allocations
+            .iter()
+            .map(|(backend, pointer)| format!("{backend}:{pointer:#x}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    ))
+    .unwrap();
+    unsafe { OutputDebugStringA(PCSTR(message.as_ptr().cast())) };
+    black_box((&heap, &keep_alive));
+    unsafe { DebugBreak() };
+    std::thread::sleep(Duration::from_secs(30));
+}
+
+fn expected(output: &str) -> (u64, Vec<(HeapBackend, u64)>) {
+    let marker = output
+        .lines()
+        .find_map(|line| line.split_once("WIN_KEXP_HEAP=").map(|(_, tail)| tail))
+        .expect("the target emitted no heap witness");
+    let (heap, allocations) = marker
+        .split_once(" ALLOCS=")
+        .expect("malformed heap witness");
+    let parse_hex = |value: &str| {
+        u64::from_str_radix(value.trim().trim_start_matches("0x"), 16)
+            .expect("malformed witness address")
+    };
+    let allocations = allocations
+        .trim()
+        .split(',')
+        .map(|entry| {
+            let (backend, address) = entry.split_once(':').expect("malformed allocation witness");
+            let backend = match backend {
+                "lfh" => HeapBackend::Lfh,
+                "vs" => HeapBackend::Vs,
+                "segment" => HeapBackend::Segment,
+                "large" => HeapBackend::Large,
+                other => panic!("unknown witness backend {other}"),
+            };
+            (backend, parse_hex(address))
+        })
+        .collect();
+    (parse_hex(heap), allocations)
+}
+
+fn verify(heap: u64, expected: &[(HeapBackend, u64)], allocations: &[HeapAllocation], phase: &str) {
+    for &(backend, pointer) in expected {
+        let allocation = allocations
+            .iter()
+            .find(|allocation| allocation.heap == heap && allocation.contains(pointer))
+            .unwrap_or_else(|| panic!("{phase}: pointer {pointer:#x} is not covered"));
+        assert_eq!(
+            allocation.backend, backend,
+            "{phase}: pointer {pointer:#x} used an unexpected backend"
+        );
+    }
+}
+
+fn load_ntdll_symbols(engine: &DebugEngine) -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("{}", engine.execute_command(".reload /f ntdll.dll")?);
+    eprintln!("{}", engine.execute_command("lm m ntdll")?);
+    Ok(())
+}
+
+fn controller() -> Result<(), Box<dyn std::error::Error>> {
+    let executable = std::env::current_exe()?;
+    let engine = DebugEngine::new();
+    let symbol_path = std::env::var("WIN_KEXP_USER_HEAP_SYMBOLS")
+        .or_else(|_| std::env::var("_NT_SYMBOL_PATH"))
+        .unwrap_or_else(|_| {
+            "srv*C:\\ProgramData\\dbg\\sym*https://msdl.microsoft.com/download/symbols".into()
+        });
+    engine.set_symbol_path(&symbol_path)?;
+    engine.launch_process(&format!("\"{}\" --target", executable.display()))?;
+    let run = engine.execute_and_wait("g", 30_000)?;
+    eprintln!("{}", run.output);
+    let (heap, witnesses) = expected(&run.output);
+    load_ntdll_symbols(&engine)?;
+    let listed = heap::list(
+        &engine,
+        HeapWalk::refreshed().within(Duration::from_secs(30)),
+    )?;
+    assert!(
+        listed
+            .found
+            .iter()
+            .any(|root| root.kind == HeapKind::Segment),
+        "the child created no detected Segment Heap: {:?}",
+        listed.found
+    );
+    let allocations = heap::allocations(&engine, HeapWalk::cached())?;
+    verify(heap, &witnesses, &allocations.found, "live target");
+    eprintln!(
+        "{} roots, {} chunks, coverage {:?}, layout {} ({})",
+        listed.found.len(),
+        allocations.found.len(),
+        allocations.walk.coverage,
+        allocations.layout.fingerprint,
+        allocations.layout.semantic_family.as_str()
+    );
+
+    let dump = std::env::temp_dir().join(format!("win-kexp-user-heap-{}.dmp", std::process::id()));
+    engine.execute_command(&format!(".dump /ma \"{}\"", dump.display()))?;
+    engine.end_session()?;
+    heap::invalidate_caches();
+    engine.open_dump(&dump.display().to_string())?;
+    engine.wait_for_event(30_000)?;
+    load_ntdll_symbols(&engine)?;
+    let from_dump = heap::allocations(
+        &engine,
+        HeapWalk::refreshed().within(Duration::from_secs(30)),
+    )?;
+    verify(heap, &witnesses, &from_dump.found, "full-memory dump");
+    engine.end_session()?;
+    std::fs::remove_file(&dump)?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::args().any(|argument| argument == "--target") {
+        target();
+        Ok(())
+    } else {
+        controller()
+    }
+}

--- a/examples/user_heap_smoke.rs
+++ b/examples/user_heap_smoke.rs
@@ -3,7 +3,9 @@
 //! `cargo run --example user_heap_smoke` launches a child under DbgEng. The child creates a
 //! Segment Heap and allocations spanning the usual size regimes, then breaks in; the controller
 //! lists roots and verifies that every returned pointer is covered. This requires DbgEng and the
-//! matching `ntdll` PDB on the configured symbol path.
+//! matching `ntdll` PDB. Set `WIN_KEXP_USER_HEAP_SYMBOLS` to a WinDbg symbol path such as
+//! `srv*C:\ProgramData\dbg\sym*https://msdl.microsoft.com/download/symbols`; when it is unset,
+//! the helper uses `_NT_SYMBOL_PATH` and then that public-server path.
 
 use std::ffi::CString;
 use std::hint::black_box;
@@ -23,7 +25,9 @@ fn target() {
     // Exercise the 0x20 bucket until it transitions to LFH, then retain the last slot as the
     // LFH witness. The other sizes exercise the three progressively larger paths.
     for _ in 0..32 {
-        keep_alive.push(unsafe { HeapAlloc(heap, HEAP_FLAGS(0), 0x20) } as u64);
+        let pointer = unsafe { HeapAlloc(heap, HEAP_FLAGS(0), 0x20) } as u64;
+        assert_ne!(pointer, 0, "allocate 0x20");
+        keep_alive.push(pointer);
     }
     let mut allocations = vec![("lfh", *keep_alive.last().unwrap())];
     allocations.extend(

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,59 @@
+//! Version-aware provenance shared by the kernel-pool and user Segment Heap walkers.
+
+use crate::dbgeng::ModuleIdentity;
+
+/// Which structurally validated VS representation a schema contains.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum VsSemanticFamily {
+    /// The VS context owns its free tree and delay-free state directly.
+    #[default]
+    Inline,
+    /// VS state is reached through the context's affinity-slot map.
+    AffinitySlots,
+}
+
+impl VsSemanticFamily {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Inline => "inline_vs",
+            Self::AffinitySlots => "affinity_slot_vs",
+        }
+    }
+}
+
+/// The image, PDB, and validated structural family used to decode an allocator.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct LayoutProvenance {
+    pub module: ModuleIdentity,
+    /// A deterministic digest of every resolved type size, field offset, and optional-field
+    /// presence used by the decoder. It deliberately contains no build-number policy.
+    pub fingerprint: String,
+    pub semantic_family: VsSemanticFamily,
+}
+
+/// Stable FNV-1a fingerprint over an already canonicalized stream of schema facts.
+///
+/// This is an identity token, not a cryptographic authenticator. Callers sort facts before
+/// feeding them so map iteration order never changes the value.
+pub(crate) fn fingerprint<'a>(facts: impl IntoIterator<Item = &'a str>) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for fact in facts {
+        for byte in fact.as_bytes().iter().copied().chain([0xff]) {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_fingerprint_is_stable_and_boundary_aware() {
+        assert_eq!(fingerprint(["a", "b"]), fingerprint(["a", "b"]));
+        assert_ne!(fingerprint(["ab"]), fingerprint(["a", "b"]));
+        assert_ne!(fingerprint(["a", "b"]), fingerprint(["b", "a"]));
+    }
+}

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -15,14 +15,15 @@ use windows::Win32::System::Diagnostics::Debug::Extensions::{
     DEBUG_BREAKPOINT_DATA, DEBUG_BREAKPOINT_DEFERRED, DEBUG_BREAKPOINT_ENABLED,
     DEBUG_BREAKPOINT_ONE_SHOT, DEBUG_CLASS_KERNEL, DEBUG_ENGOPT_INITIAL_BREAK,
     DEBUG_EVENT_BREAKPOINT, DEBUG_EXECUTE_ECHO, DEBUG_INTERRUPT_ACTIVE, DEBUG_KERNEL_SMALL_DUMP,
-    DEBUG_MODULE_PARAMETERS, DEBUG_MODULE_USER_MODE, DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL,
-    DEBUG_REGISTER_DESCRIPTION, DEBUG_REGISTER_SUB_REGISTER, DEBUG_STACK_FRAME, DEBUG_STATUS_GO,
-    DEBUG_STATUS_NO_DEBUGGEE, DEBUG_SYMTYPE_CODEVIEW, DEBUG_SYMTYPE_COFF, DEBUG_SYMTYPE_DEFERRED,
-    DEBUG_SYMTYPE_DIA, DEBUG_SYMTYPE_EXPORT, DEBUG_SYMTYPE_NONE, DEBUG_SYMTYPE_PDB,
-    DEBUG_SYMTYPE_SYM, DEBUG_VALUE, DEBUG_VALUE_FLOAT32, DEBUG_VALUE_FLOAT64, DEBUG_VALUE_FLOAT80,
-    DEBUG_VALUE_FLOAT82, DEBUG_VALUE_FLOAT128, DEBUG_VALUE_INT8, DEBUG_VALUE_INT16,
-    DEBUG_VALUE_INT32, DEBUG_VALUE_INT64, DEBUG_VALUE_VECTOR64, DEBUG_VALUE_VECTOR128,
-    IDebugBreakpoint, IDebugBreakpoint2, IDebugClient6, IDebugControl4, IDebugDataSpaces4,
+    DEBUG_MODNAME_SYMBOL_FILE, DEBUG_MODULE_PARAMETERS, DEBUG_MODULE_USER_MODE,
+    DEBUG_OUTCTL_THIS_CLIENT, DEBUG_OUTPUT_NORMAL, DEBUG_REGISTER_DESCRIPTION,
+    DEBUG_REGISTER_SUB_REGISTER, DEBUG_STACK_FRAME, DEBUG_STATUS_GO, DEBUG_STATUS_NO_DEBUGGEE,
+    DEBUG_SYMTYPE_CODEVIEW, DEBUG_SYMTYPE_COFF, DEBUG_SYMTYPE_DEFERRED, DEBUG_SYMTYPE_DIA,
+    DEBUG_SYMTYPE_EXPORT, DEBUG_SYMTYPE_NONE, DEBUG_SYMTYPE_PDB, DEBUG_SYMTYPE_SYM, DEBUG_VALUE,
+    DEBUG_VALUE_FLOAT32, DEBUG_VALUE_FLOAT64, DEBUG_VALUE_FLOAT80, DEBUG_VALUE_FLOAT82,
+    DEBUG_VALUE_FLOAT128, DEBUG_VALUE_INT8, DEBUG_VALUE_INT16, DEBUG_VALUE_INT32,
+    DEBUG_VALUE_INT64, DEBUG_VALUE_VECTOR64, DEBUG_VALUE_VECTOR128, IDebugBreakpoint,
+    IDebugBreakpoint2, IDebugClient6, IDebugControl4, IDebugDataSpaces4,
     IDebugEventContextCallbacks, IDebugOutputCallbacks, IDebugRegisters, IDebugSymbols3,
     IDebugSystemObjects,
 };
@@ -333,9 +334,10 @@ pub struct Register {
 }
 
 /// How much symbol information the engine has for a module — the `lm` "symbols" column.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum SymbolKind {
     /// No symbols at all.
+    #[default]
     None,
     /// Symbols have not been loaded yet; the engine will fetch them when something needs them.
     /// The most consequential value here, because it is *not* a statement that symbols are
@@ -366,6 +368,12 @@ impl SymbolKind {
             DEBUG_SYMTYPE_DIA => Self::Dia,
             other => Self::Other(other),
         }
+    }
+
+    /// Whether this symbol provider exposes private type information suitable for allocator
+    /// layout resolution.
+    pub fn has_type_info(self) -> bool {
+        matches!(self, Self::Pdb | Self::Dia)
     }
 }
 
@@ -400,6 +408,25 @@ pub struct Module {
     /// the engine's list it came from — the distinction decides whether `base` is where the image
     /// *is* or where it *was*.
     pub unloaded: bool,
+}
+
+/// Stable identity and symbol provenance for one loaded image.
+///
+/// The PE tuple is what DbgEng and symbol servers use to distinguish builds; the base is
+/// included because resolved globals are addresses in this particular target. `symbol_file`
+/// is the exact file DbgEng selected for the module, rather than a path inferred from the
+/// configured symbol search path.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct ModuleIdentity {
+    pub name: String,
+    pub image_name: String,
+    pub loaded_image_name: String,
+    pub symbol_file: String,
+    pub symbols: SymbolKind,
+    pub base: u64,
+    pub size: u32,
+    pub timestamp: u32,
+    pub checksum: u32,
 }
 
 impl Module {
@@ -998,6 +1025,82 @@ impl DebugEngine {
         }
         .map_err(|source| DbgEngError::Context {
             operation: format!("resolving field {}", field.to_string_lossy()),
+            source,
+        })
+    }
+
+    /// Resolve a field's PDB type id and byte offset in one DbgEng call.
+    pub fn field_type_and_offset(
+        &self,
+        module: u64,
+        type_id: u32,
+        field: &str,
+    ) -> Result<(u32, u32), DbgEngError> {
+        let field = CString::new(field).map_err(|_| DbgEngError::InvalidCommand)?;
+        let mut field_type = 0u32;
+        let mut offset = 0u32;
+        unsafe {
+            self.symbols.GetFieldTypeAndOffset(
+                module,
+                type_id,
+                PCSTR::from_raw(field.as_ptr().cast()),
+                Some(&mut field_type),
+                Some(&mut offset),
+            )
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!(
+                "resolving type and offset of field {}",
+                field.to_string_lossy()
+            ),
+            source,
+        })?;
+        Ok((field_type, offset))
+    }
+
+    /// Enumerate the named fields DbgEng exposes for a PDB type.
+    ///
+    /// DbgEng has no field-count getter. Its documented enumeration contract is consecutive
+    /// indices ending at the first failed `GetFieldName`, so a corrupt provider cannot turn
+    /// this into an unbounded loop.
+    pub fn field_names(&self, module: u64, type_id: u32) -> Result<Vec<String>, DbgEngError> {
+        const MAX_FIELDS: u32 = 4096;
+        let mut fields = Vec::new();
+        for index in 0..MAX_FIELDS {
+            let name = read_engine_string(|buffer, size| unsafe {
+                self.symbols
+                    .GetFieldName(module, type_id, index, buffer, size)
+            });
+            match name {
+                Ok(name) if !name.is_empty() => fields.push(name),
+                Ok(_) | Err(_) => break,
+            }
+        }
+        Ok(fields)
+    }
+
+    /// The PEB of DbgEng's current process.
+    pub fn current_process_peb(&self) -> Result<u64, DbgEngError> {
+        let objects: IDebugSystemObjects =
+            self.client.cast().map_err(|source| DbgEngError::Context {
+                operation: "obtaining the system-objects interface".into(),
+                source,
+            })?;
+        unsafe { objects.GetCurrentProcessPeb() }.map_err(|source| DbgEngError::Context {
+            operation: "reading the current process PEB".into(),
+            source,
+        })
+    }
+
+    /// The operating-system process id of DbgEng's current process.
+    pub fn current_process_system_id(&self) -> Result<u32, DbgEngError> {
+        let objects: IDebugSystemObjects =
+            self.client.cast().map_err(|source| DbgEngError::Context {
+                operation: "obtaining the system-objects interface".into(),
+                source,
+            })?;
+        unsafe { objects.GetCurrentProcessSystemId() }.map_err(|source| DbgEngError::Context {
+            operation: "reading the current process id".into(),
             source,
         })
     }
@@ -2006,6 +2109,69 @@ impl DebugEngine {
     pub fn modules(&self) -> Result<Vec<Module>, DbgEngError> {
         let (loaded, _) = self.module_counts()?;
         self.module_range(0, loaded)
+    }
+
+    /// Locate a loaded module by the name used to qualify its symbols.
+    pub fn module(&self, name: &str) -> Result<Module, DbgEngError> {
+        let name = CString::new(name).map_err(|_| DbgEngError::InvalidCommand)?;
+        let mut index = 0u32;
+        let mut base = 0u64;
+        unsafe {
+            self.symbols.GetModuleByModuleName(
+                PCSTR::from_raw(name.as_ptr().cast()),
+                0,
+                Some(&mut index),
+                Some(&mut base),
+            )
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("locating module {}", name.to_string_lossy()),
+            source,
+        })?;
+        let mut params = DEBUG_MODULE_PARAMETERS::default();
+        unsafe {
+            self.symbols
+                .GetModuleParameters(1, Some(&base), 0, &mut params)
+        }
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("reading parameters of module at {base:#x}"),
+            source,
+        })?;
+        Ok(self.named_module(index, &params))
+    }
+
+    /// The exact PDB or symbol file DbgEng selected for `module_base`.
+    pub fn module_symbol_file(&self, module_base: u64) -> Result<String, DbgEngError> {
+        read_engine_string(|buffer, size| unsafe {
+            self.symbols.GetModuleNameString(
+                DEBUG_MODNAME_SYMBOL_FILE,
+                DEBUG_ANY_ID,
+                module_base,
+                buffer,
+                size,
+            )
+        })
+        .map_err(|source| DbgEngError::Context {
+            operation: format!("reading the symbol file for module at {module_base:#x}"),
+            source,
+        })
+    }
+
+    /// Image and symbol identity for a loaded module.
+    pub fn module_identity(&self, name: &str) -> Result<ModuleIdentity, DbgEngError> {
+        let module = self.module(name)?;
+        let symbol_file = self.module_symbol_file(module.base)?;
+        Ok(ModuleIdentity {
+            name: module.name,
+            image_name: module.image_name,
+            loaded_image_name: module.loaded_image_name,
+            symbol_file,
+            symbols: module.symbols,
+            base: module.base,
+            size: module.size,
+            timestamp: module.timestamp,
+            checksum: module.checksum,
+        })
     }
 
     /// The modules that have **unloaded**, which the engine keeps a bounded tail of and `lm`
@@ -3124,6 +3290,10 @@ mod tests {
             SymbolKind::None
         );
         assert_eq!(SymbolKind::from_engine(4242), SymbolKind::Other(4242));
+        assert!(SymbolKind::Pdb.has_type_info());
+        assert!(SymbolKind::Dia.has_type_info());
+        assert!(!SymbolKind::Export.has_type_info());
+        assert!(!SymbolKind::Deferred.has_type_info());
     }
 
     #[test]

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -1063,7 +1063,7 @@ impl DebugEngine {
     /// DbgEng has no field-count getter. Its documented enumeration contract is consecutive
     /// indices ending at the first failed `GetFieldName`, so a corrupt provider cannot turn
     /// this into an unbounded loop.
-    pub fn field_names(&self, module: u64, type_id: u32) -> Result<Vec<String>, DbgEngError> {
+    pub fn field_names(&self, module: u64, type_id: u32) -> Vec<String> {
         const MAX_FIELDS: u32 = 4096;
         let mut fields = Vec::new();
         for index in 0..MAX_FIELDS {
@@ -1076,7 +1076,7 @@ impl DebugEngine {
                 Ok(_) | Err(_) => break,
             }
         }
-        Ok(fields)
+        fields
     }
 
     /// The PEB of DbgEng's current process.

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -381,11 +381,74 @@ fn read_root_signatures(
     (decode(segment_offset), decode(nt_offset))
 }
 
+struct RootEnumeration {
+    roots: Vec<HeapRoot>,
+    total: Option<usize>,
+    budget_expired: bool,
+}
+
+impl RootEnumeration {
+    fn expired(roots: Vec<HeapRoot>, total: Option<usize>) -> Self {
+        Self {
+            roots,
+            total,
+            budget_expired: true,
+        }
+    }
+
+    fn complete(roots: Vec<HeapRoot>, total: usize) -> Self {
+        Self {
+            roots,
+            total: Some(total),
+            budget_expired: false,
+        }
+    }
+}
+
+fn root_read_budget_expired(
+    engine: &DebugEngine,
+    deadline: Option<Instant>,
+) -> Result<bool, HeapQueryError> {
+    if engine.interrupted()? {
+        return Err(HeapQueryError::Interrupted);
+    }
+    Ok(deadline.is_some_and(|deadline| Instant::now() >= deadline))
+}
+
+fn truncated_root_snapshot(
+    classified: usize,
+    total: Option<usize>,
+    budget: Option<Duration>,
+) -> PoolSnapshot {
+    let mut snapshot = PoolSnapshot {
+        complete: false,
+        budget_expired: true,
+        ..PoolSnapshot::default()
+    };
+    let allowed = budget.map_or_else(
+        || "walk budget".into(),
+        |budget| format!("{budget:?} budget"),
+    );
+    let coverage = total.map_or_else(
+        || format!("{classified} roots classified before the PEB heap count was read"),
+        |total| format!("{classified} of {total} PEB heap roots classified"),
+    );
+    snapshot.diagnostics.push(format!(
+        "the walk ran out of its {allowed} while enumerating heap roots: {coverage}; what is \
+         missing is unknown, not absent"
+    ));
+    snapshot
+}
+
 fn enumerate_roots(
     engine: &DebugEngine,
     layout: &PoolLayout,
     peb: u64,
-) -> Result<Vec<HeapRoot>, HeapQueryError> {
+    deadline: Option<Instant>,
+) -> Result<RootEnumeration, HeapQueryError> {
+    if root_read_budget_expired(engine, deadline)? {
+        return Ok(RootEnumeration::expired(Vec::new(), None));
+    }
     let count = read_u32(
         engine,
         peb + layout
@@ -396,6 +459,9 @@ fn enumerate_roots(
         return Err(HeapQueryError::InvalidPeb(format!(
             "NumberOfHeaps is {count}, maximum is {MAX_PROCESS_HEAPS}"
         )));
+    }
+    if root_read_budget_expired(engine, deadline)? {
+        return Ok(RootEnumeration::expired(Vec::new(), Some(count)));
     }
     let array = read_u64(
         engine,
@@ -409,12 +475,15 @@ fn enumerate_roots(
         ));
     }
     if count == 0 {
-        return Ok(Vec::new());
+        return Ok(RootEnumeration::complete(Vec::new(), 0));
     }
     if !user_pointer(array) {
         return Err(HeapQueryError::InvalidPeb(format!(
             "ProcessHeaps {array:#x} is outside the x64 user address range"
         )));
+    }
+    if root_read_budget_expired(engine, deadline)? {
+        return Ok(RootEnumeration::expired(Vec::new(), Some(count)));
     }
     let bytes = engine.read_memory(array, count.saturating_mul(8))?;
     let segment_offset = layout
@@ -451,6 +520,9 @@ fn enumerate_roots(
             });
             continue;
         }
+        if root_read_budget_expired(engine, deadline)? {
+            return Ok(RootEnumeration::expired(roots, Some(count)));
+        }
         let (segment, nt) = read_root_signatures(engine, address, segment_offset, nt_offset);
         let (kind, reason) = classify_root(segment, nt);
         roots.push(HeapRoot {
@@ -461,7 +533,7 @@ fn enumerate_roots(
             reason,
         });
     }
-    Ok(roots)
+    Ok(RootEnumeration::complete(roots, count))
 }
 
 fn scope_of(roots: &[HeapRoot]) -> HeapScope {
@@ -603,23 +675,37 @@ fn walk_snapshot(
         return Ok(snapshot);
     }
 
-    let roots = enumerate_roots(engine, &schema.layout, target.peb)?;
-    let scope = scope_of(&roots);
-    let remaining = walk
-        .budget
-        .map(|budget| budget.saturating_sub(started.elapsed()));
-    let pool = walk_user_segment_heaps(
-        engine,
-        &schema.layout,
-        target.peb,
-        &scope.segment_heaps_walked,
-        remaining,
-        1_000_000,
-    )
-    .map_err(|error| match error {
-        SnapshotError::Interrupted => HeapQueryError::Interrupted,
-        other => HeapQueryError::Walk(other.to_string()),
-    })?;
+    // The absolute deadline keeps schema resolution and PEB enumeration inside the caller's
+    // one budget. An unrepresentably large duration has the same unbounded meaning as the
+    // shared walker gives it.
+    let deadline = walk.budget.and_then(|budget| started.checked_add(budget));
+    let RootEnumeration {
+        roots,
+        total,
+        budget_expired,
+    } = enumerate_roots(engine, &schema.layout, target.peb, deadline)?;
+    let mut scope = scope_of(&roots);
+    let pool = if budget_expired {
+        // These roots were identified but no allocator region was walked after the deadline.
+        scope.segment_heaps_walked.clear();
+        truncated_root_snapshot(roots.len(), total, walk.budget)
+    } else {
+        let remaining = walk
+            .budget
+            .map(|budget| budget.saturating_sub(started.elapsed()));
+        walk_user_segment_heaps(
+            engine,
+            &schema.layout,
+            target.peb,
+            &scope.segment_heaps_walked,
+            remaining,
+            1_000_000,
+        )
+        .map_err(|error| match error {
+            SnapshotError::Interrupted => HeapQueryError::Interrupted,
+            other => HeapQueryError::Walk(other.to_string()),
+        })?
+    };
     let (allocations, report, diagnostics) = from_pool_snapshot(pool);
     let snapshot = HeapSnapshot {
         roots,
@@ -864,6 +950,20 @@ mod tests {
         assert_eq!(scope.nt_heaps_skipped, vec![2]);
         assert_eq!(scope.unknown_heaps_skipped, vec![3]);
         assert_eq!(scope.unreadable_heaps_skipped, vec![4]);
+    }
+
+    #[test]
+    fn test_root_enumeration_deadline_reports_partial_coverage() {
+        let snapshot = truncated_root_snapshot(3, Some(12), Some(Duration::from_secs(2)));
+        let (allocations, walk, diagnostics) = from_pool_snapshot(snapshot);
+
+        assert!(allocations.is_empty());
+        assert_eq!(walk.coverage, WalkCoverage::BudgetExpired);
+        assert_eq!(walk.diagnostic_count, 1);
+        assert_eq!(diagnostics.examples.len(), 1);
+        assert!(diagnostics.examples[0].contains("2s budget"));
+        assert!(diagnostics.examples[0].contains("3 of 12 PEB heap roots classified"));
+        assert!(diagnostics.examples[0].contains("unknown, not absent"));
     }
 
     #[test]

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,867 @@
+//! Typed, version-aware queries over user-mode Segment Heaps.
+//!
+//! Root discovery is user-specific (PEB and `ntdll`); page-segment, LFH, VS, backend, and
+//! large-allocation decoding is shared with the kernel-pool walker.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+use windows::Win32::System::Diagnostics::Debug::Extensions::{
+    DEBUG_STATUS_BREAK, DEBUG_STATUS_NO_DEBUGGEE,
+};
+
+use crate::allocator::LayoutProvenance;
+use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage};
+use crate::pool::layout::{LayoutKey, PoolLayout};
+use crate::pool::query::WalkCoverage;
+use crate::pool::snapshot::{PoolSnapshot, SnapshotError, walk_user_segment_heaps};
+use crate::pool::{DiagnosticShape, PoolBackend, PoolState, WalkStalls};
+
+const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
+const SEGMENT_HEAP_SIGNATURE: u32 = 0xddee_ddee;
+const NT_HEAP_SIGNATURE: u32 = 0xeeff_eeff;
+const MAX_PROCESS_HEAPS: usize = 4096;
+pub const DEFAULT_WALK_BUDGET: Duration = Duration::from_secs(120);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeapWalk {
+    pub refresh: bool,
+    pub budget: Option<Duration>,
+}
+
+impl HeapWalk {
+    pub fn cached() -> Self {
+        Self {
+            refresh: false,
+            budget: Some(DEFAULT_WALK_BUDGET),
+        }
+    }
+
+    pub fn refreshed() -> Self {
+        Self {
+            refresh: true,
+            ..Self::cached()
+        }
+    }
+
+    pub fn within(self, budget: Duration) -> Self {
+        Self {
+            budget: Some(budget),
+            ..self
+        }
+    }
+}
+
+impl From<bool> for HeapWalk {
+    fn from(refresh: bool) -> Self {
+        if refresh {
+            Self::refreshed()
+        } else {
+            Self::cached()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HeapKind {
+    Segment,
+    Nt,
+    Unknown,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeapRoot {
+    pub index: usize,
+    pub address: u64,
+    pub kind: HeapKind,
+    pub supported: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HeapBackend {
+    Lfh,
+    Vs,
+    Segment,
+    Large,
+}
+
+impl From<PoolBackend> for HeapBackend {
+    fn from(value: PoolBackend) -> Self {
+        match value {
+            PoolBackend::Lfh => Self::Lfh,
+            PoolBackend::Vs => Self::Vs,
+            PoolBackend::Segment => Self::Segment,
+            PoolBackend::Large => Self::Large,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HeapState {
+    Allocated,
+    ReusableFree,
+    CachedFree,
+    Unreadable,
+}
+
+impl From<PoolState> for HeapState {
+    fn from(value: PoolState) -> Self {
+        match value {
+            PoolState::Allocated => Self::Allocated,
+            PoolState::ReusableFree => Self::ReusableFree,
+            PoolState::CachedFree => Self::CachedFree,
+            PoolState::Unreadable => Self::Unreadable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeapAllocation {
+    pub heap: u64,
+    pub backend: HeapBackend,
+    pub state: HeapState,
+    pub header_address: u64,
+    pub user_address: u64,
+    pub capacity: u64,
+    /// Exact only when the selected schema validates the allocator's unused-byte metadata.
+    pub requested_size: Option<u64>,
+    pub subsegment: Option<u64>,
+    pub size_class: u32,
+}
+
+impl HeapAllocation {
+    pub fn end(&self) -> u64 {
+        self.user_address.saturating_add(self.capacity)
+    }
+
+    pub fn contains(&self, address: u64) -> bool {
+        address >= self.header_address && address < self.end()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HeapScope {
+    pub segment_heaps_walked: Vec<u64>,
+    pub nt_heaps_skipped: Vec<u64>,
+    pub unknown_heaps_skipped: Vec<u64>,
+    pub unreadable_heaps_skipped: Vec<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeapWalkReport {
+    pub coverage: WalkCoverage,
+    pub total_chunks: usize,
+    pub allocated_chunks: usize,
+    pub diagnostic_count: usize,
+    pub unreadable_gaps: usize,
+    pub refused_headers: u64,
+    pub stalls: WalkStalls,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeapDiagnosticReport {
+    pub categories: Vec<DiagnosticShape>,
+    pub examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeapNeighbourhood {
+    pub allocation: HeapAllocation,
+    /// Signed displacement from `user_address`; addresses in the allocator header are negative.
+    pub offset: i64,
+    pub previous: Option<HeapAllocation>,
+    pub next: Option<HeapAllocation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HeapCensusRow {
+    pub heap: u64,
+    pub backend: HeapBackend,
+    pub state: HeapState,
+    pub size_class: u32,
+    pub chunks: usize,
+    pub total_capacity: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct HeapAnswer<T> {
+    pub found: T,
+    pub layout: LayoutProvenance,
+    pub scope: HeapScope,
+    pub walk: HeapWalkReport,
+}
+
+#[derive(Debug, Error)]
+pub enum HeapQueryError {
+    #[error("heap queries require a user-mode target")]
+    NotUserTarget,
+    #[error("no debuggee is loaded")]
+    NoDebuggee,
+    #[error("the target is running; break in before walking heaps")]
+    TargetRunning,
+    #[error("heap walking supports x64 targets only (machine {machine:#x})")]
+    UnsupportedArchitecture { machine: u32 },
+    #[error("invalid PEB heap metadata: {0}")]
+    InvalidPeb(String),
+    #[error(
+        "missing or unsupported ntdll allocator layout ({0}); run `.reload /f ntdll.dll` and retry"
+    )]
+    Layout(String),
+    #[error("the heap walk was interrupted on request")]
+    Interrupted,
+    #[error("walking the heap failed: {0}")]
+    Walk(String),
+    #[error(transparent)]
+    Engine(#[from] DbgEngError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SnapshotKey {
+    target: u64,
+    peb: u64,
+    image: KernelImage,
+    generation: u64,
+}
+
+#[derive(Debug, Clone)]
+struct HeapSnapshot {
+    roots: Vec<HeapRoot>,
+    allocations: Vec<HeapAllocation>,
+    layout: LayoutProvenance,
+    scope: HeapScope,
+    walk: HeapWalkReport,
+    diagnostics: HeapDiagnosticReport,
+}
+
+#[derive(Default)]
+struct SnapshotCache {
+    entry: Mutex<Option<(SnapshotKey, HeapSnapshot)>>,
+}
+
+impl SnapshotCache {
+    fn get(&self, key: SnapshotKey) -> Option<HeapSnapshot> {
+        self.entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|(cached, _)| *cached == key)
+            .map(|(_, snapshot)| snapshot.clone())
+    }
+
+    fn put(&self, key: SnapshotKey, snapshot: HeapSnapshot) {
+        *self
+            .entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((key, snapshot));
+    }
+
+    fn invalidate(&self) {
+        *self
+            .entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+}
+
+fn snapshots() -> &'static SnapshotCache {
+    static CACHE: OnceLock<SnapshotCache> = OnceLock::new();
+    CACHE.get_or_init(SnapshotCache::default)
+}
+
+#[derive(Default)]
+struct UserLayoutCache {
+    entries: Mutex<HashMap<LayoutKey, PoolLayout>>,
+}
+
+impl UserLayoutCache {
+    fn global() -> &'static Self {
+        static CACHE: OnceLock<UserLayoutCache> = OnceLock::new();
+        CACHE.get_or_init(UserLayoutCache::default)
+    }
+
+    fn get_or_resolve(
+        &self,
+        engine: &DebugEngine,
+        key: LayoutKey,
+    ) -> Result<PoolLayout, HeapQueryError> {
+        if let Some(layout) = self
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&key)
+            .cloned()
+        {
+            return Ok(layout);
+        }
+        let layout = PoolLayout::resolve_user(engine, key)
+            .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(key, layout.clone());
+        Ok(layout)
+    }
+
+    fn invalidate(&self) {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+}
+
+/// Drop the user-heap snapshot while retaining the image-keyed `ntdll` schema.
+pub fn invalidate_snapshot() {
+    snapshots().invalidate();
+}
+
+/// Drop every user-heap snapshot and resolved `ntdll` schema.
+pub fn invalidate_caches() {
+    invalidate_snapshot();
+    UserLayoutCache::global().invalidate();
+}
+
+fn read_u32(engine: &DebugEngine, address: u64) -> Result<u32, DbgEngError> {
+    Ok(u32::from_le_bytes(
+        engine.read_memory(address, 4)?.try_into().unwrap(),
+    ))
+}
+
+fn read_u64(engine: &DebugEngine, address: u64) -> Result<u64, DbgEngError> {
+    Ok(u64::from_le_bytes(
+        engine.read_memory(address, 8)?.try_into().unwrap(),
+    ))
+}
+
+fn user_pointer(address: u64) -> bool {
+    (0x1_0000..0x0000_8000_0000_0000).contains(&address)
+}
+
+fn classify_root(
+    segment: Result<u32, String>,
+    nt: Result<u32, String>,
+) -> (HeapKind, Option<String>) {
+    match (segment, nt) {
+        (Ok(SEGMENT_HEAP_SIGNATURE), Ok(NT_HEAP_SIGNATURE)) => (
+            HeapKind::Unknown,
+            Some("root ambiguously matches both Segment and NT heap signatures".into()),
+        ),
+        (Ok(SEGMENT_HEAP_SIGNATURE), _) => (HeapKind::Segment, None),
+        (_, Ok(NT_HEAP_SIGNATURE)) => (
+            HeapKind::Nt,
+            Some("classic NT heap decoding is outside the v1 Segment Heap walker".into()),
+        ),
+        (Err(segment), Err(nt)) => (
+            HeapKind::Unreadable,
+            Some(format!(
+                "cannot read Segment signature ({segment}) or NT signature ({nt})"
+            )),
+        ),
+        _ => (
+            HeapKind::Unknown,
+            Some("root matches neither the PDB-resolved Segment nor NT heap signature".into()),
+        ),
+    }
+}
+
+fn enumerate_roots(
+    engine: &DebugEngine,
+    layout: &PoolLayout,
+    peb: u64,
+) -> Result<Vec<HeapRoot>, HeapQueryError> {
+    let count = read_u32(
+        engine,
+        peb + layout
+            .field("_PEB", "NumberOfHeaps")
+            .map_err(|error| HeapQueryError::Layout(error.to_string()))? as u64,
+    )? as usize;
+    if count > MAX_PROCESS_HEAPS {
+        return Err(HeapQueryError::InvalidPeb(format!(
+            "NumberOfHeaps is {count}, maximum is {MAX_PROCESS_HEAPS}"
+        )));
+    }
+    let array = read_u64(
+        engine,
+        peb + layout
+            .field("_PEB", "ProcessHeaps")
+            .map_err(|error| HeapQueryError::Layout(error.to_string()))? as u64,
+    )?;
+    if count != 0 && array == 0 {
+        return Err(HeapQueryError::InvalidPeb(
+            "ProcessHeaps is null while NumberOfHeaps is nonzero".into(),
+        ));
+    }
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+    if !user_pointer(array) {
+        return Err(HeapQueryError::InvalidPeb(format!(
+            "ProcessHeaps {array:#x} is outside the x64 user address range"
+        )));
+    }
+    let bytes = engine.read_memory(array, count.saturating_mul(8))?;
+    let segment_offset = layout
+        .field("_SEGMENT_HEAP", "Signature")
+        .map_err(|error| HeapQueryError::Layout(error.to_string()))?
+        as u64;
+    let nt_offset = layout
+        .field("_HEAP", "Signature")
+        .map_err(|error| HeapQueryError::Layout(error.to_string()))? as u64;
+    let mut roots = Vec::with_capacity(count);
+    for (index, entry) in bytes.chunks_exact(8).enumerate() {
+        let address = u64::from_le_bytes(entry.try_into().unwrap());
+        if address == 0 {
+            roots.push(HeapRoot {
+                index,
+                address,
+                kind: HeapKind::Unknown,
+                supported: false,
+                reason: Some("null heap root".into()),
+            });
+            continue;
+        }
+        if !user_pointer(address) {
+            roots.push(HeapRoot {
+                index,
+                address,
+                kind: HeapKind::Unknown,
+                supported: false,
+                reason: Some("heap root is outside the x64 user address range".into()),
+            });
+            continue;
+        }
+        let segment = address
+            .checked_add(segment_offset)
+            .ok_or_else(|| "Segment signature address overflow".into())
+            .and_then(|address| read_u32(engine, address).map_err(|error| error.to_string()));
+        let nt = address
+            .checked_add(nt_offset)
+            .ok_or_else(|| "NT signature address overflow".into())
+            .and_then(|address| read_u32(engine, address).map_err(|error| error.to_string()));
+        let (kind, reason) = classify_root(segment, nt);
+        roots.push(HeapRoot {
+            index,
+            address,
+            kind,
+            supported: kind == HeapKind::Segment,
+            reason,
+        });
+    }
+    Ok(roots)
+}
+
+fn scope_of(roots: &[HeapRoot]) -> HeapScope {
+    let mut scope = HeapScope::default();
+    for root in roots {
+        match root.kind {
+            HeapKind::Segment => scope.segment_heaps_walked.push(root.address),
+            HeapKind::Nt => scope.nt_heaps_skipped.push(root.address),
+            HeapKind::Unknown => scope.unknown_heaps_skipped.push(root.address),
+            HeapKind::Unreadable => scope.unreadable_heaps_skipped.push(root.address),
+        }
+    }
+    scope
+}
+
+fn from_pool_snapshot(
+    snapshot: PoolSnapshot,
+) -> (Vec<HeapAllocation>, HeapWalkReport, HeapDiagnosticReport) {
+    let allocations: Vec<_> = snapshot
+        .spans
+        .iter()
+        .map(|span| HeapAllocation {
+            heap: span.heap.heap,
+            backend: span.backend.into(),
+            state: span.state.into(),
+            header_address: span.header_address,
+            user_address: span.usable_address,
+            capacity: span.size,
+            requested_size: span.requested_size,
+            subsegment: span.subsegment,
+            size_class: span.size_class,
+        })
+        .collect();
+    let walk = HeapWalkReport {
+        coverage: match (snapshot.complete, snapshot.budget_expired) {
+            (true, _) => WalkCoverage::Complete,
+            (false, true) => WalkCoverage::BudgetExpired,
+            (false, false) => WalkCoverage::Partial,
+        },
+        total_chunks: allocations.len(),
+        allocated_chunks: allocations
+            .iter()
+            .filter(|allocation| allocation.state == HeapState::Allocated)
+            .count(),
+        diagnostic_count: snapshot.diagnostics.emitted(),
+        unreadable_gaps: allocations
+            .iter()
+            .filter(|allocation| allocation.state == HeapState::Unreadable)
+            .count(),
+        refused_headers: snapshot.refused_chunks,
+        stalls: snapshot.stalls,
+    };
+    let diagnostics = HeapDiagnosticReport {
+        categories: snapshot.diagnostics.shapes().to_vec(),
+        examples: snapshot.diagnostics.examples().to_vec(),
+    };
+    (allocations, walk, diagnostics)
+}
+
+fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQueryError> {
+    let started = Instant::now();
+    if engine.is_kernel_target()? {
+        return Err(HeapQueryError::NotUserTarget);
+    }
+    match engine.execution_status()? {
+        DEBUG_STATUS_NO_DEBUGGEE => return Err(HeapQueryError::NoDebuggee),
+        DEBUG_STATUS_BREAK => {}
+        _ => return Err(HeapQueryError::TargetRunning),
+    }
+    let machine = engine.processor_type()?;
+    if machine != IMAGE_FILE_MACHINE_AMD64 {
+        return Err(HeapQueryError::UnsupportedArchitecture { machine });
+    }
+    let peb = engine.current_process_peb()?;
+    if peb == 0 {
+        return Err(HeapQueryError::InvalidPeb(
+            "DbgEng returned a null PEB".into(),
+        ));
+    }
+    let loaded_module = engine.module("ntdll")?;
+    let image = KernelImage {
+        base: loaded_module.base,
+        size: loaded_module.size,
+        timestamp: loaded_module.timestamp,
+        checksum: loaded_module.checksum,
+    };
+    let generation = crate::pool::query::generation();
+    let layout_key = LayoutKey {
+        image,
+        session: generation,
+    };
+    let layout = UserLayoutCache::global().get_or_resolve(engine, layout_key)?;
+    // Type lookups above force a deferred module to load. Check provenance afterwards so
+    // export-only symbols fail explicitly without preventing the normal deferred-load path.
+    let module = engine.module_identity("ntdll")?;
+    if !module.symbols.has_type_info() || module.symbol_file.is_empty() {
+        return Err(HeapQueryError::Layout(
+            "DbgEng did not load private PDB type information for ntdll".into(),
+        ));
+    }
+    let provenance = layout
+        .provenance(module)
+        .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
+    let key = SnapshotKey {
+        target: engine.target_identity(),
+        peb,
+        image,
+        generation,
+    };
+    if walk.refresh {
+        snapshots().invalidate();
+    } else if let Some(snapshot) = snapshots().get(key) {
+        return Ok(snapshot);
+    }
+
+    let roots = enumerate_roots(engine, &layout, peb)?;
+    let scope = scope_of(&roots);
+    let remaining = walk
+        .budget
+        .map(|budget| budget.saturating_sub(started.elapsed()));
+    let pool = walk_user_segment_heaps(
+        engine,
+        &layout,
+        peb,
+        &scope.segment_heaps_walked,
+        remaining,
+        1_000_000,
+    )
+    .map_err(|error| match error {
+        SnapshotError::Interrupted => HeapQueryError::Interrupted,
+        other => HeapQueryError::Walk(other.to_string()),
+    })?;
+    let (allocations, report, diagnostics) = from_pool_snapshot(pool);
+    let snapshot = HeapSnapshot {
+        roots,
+        allocations,
+        layout: provenance,
+        scope,
+        walk: report,
+        diagnostics,
+    };
+    if snapshot.walk.coverage == WalkCoverage::Complete {
+        snapshots().put(key, snapshot.clone());
+    }
+    Ok(snapshot)
+}
+
+fn answer<T>(snapshot: &HeapSnapshot, found: T) -> HeapAnswer<T> {
+    HeapAnswer {
+        found,
+        layout: snapshot.layout.clone(),
+        scope: snapshot.scope.clone(),
+        walk: snapshot.walk.clone(),
+    }
+}
+
+pub fn list(
+    engine: &DebugEngine,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<Vec<HeapRoot>>, HeapQueryError> {
+    let snapshot = prepare(engine, walk.into())?;
+    Ok(answer(&snapshot, snapshot.roots.clone()))
+}
+
+pub fn allocations(
+    engine: &DebugEngine,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<Vec<HeapAllocation>>, HeapQueryError> {
+    let snapshot = prepare(engine, walk.into())?;
+    Ok(answer(&snapshot, snapshot.allocations.clone()))
+}
+
+pub fn chunk_at(
+    engine: &DebugEngine,
+    address: u64,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<Option<HeapNeighbourhood>>, HeapQueryError> {
+    let snapshot = prepare(engine, walk.into())?;
+    let found = neighbourhood_at(&snapshot.allocations, address);
+    Ok(answer(&snapshot, found))
+}
+
+fn neighbourhood_at(allocations: &[HeapAllocation], address: u64) -> Option<HeapNeighbourhood> {
+    let position = allocations
+        .iter()
+        .position(|allocation| allocation.contains(address))?;
+    let allocation = allocations[position].clone();
+    let same_heap = |candidate: &HeapAllocation| {
+        candidate.heap == allocation.heap
+            && candidate.backend == allocation.backend
+            && candidate.subsegment == allocation.subsegment
+            && candidate.state != HeapState::Unreadable
+    };
+    let previous = position
+        .checked_sub(1)
+        .and_then(|index| allocations.get(index))
+        .filter(|candidate| same_heap(candidate) && candidate.end() == allocation.header_address)
+        .cloned();
+    let next = allocations
+        .get(position + 1)
+        .filter(|candidate| same_heap(candidate) && allocation.end() == candidate.header_address)
+        .cloned();
+    Some(HeapNeighbourhood {
+        offset: i64::try_from(i128::from(address) - i128::from(allocation.user_address)).unwrap_or(
+            if address < allocation.user_address {
+                i64::MIN
+            } else {
+                i64::MAX
+            },
+        ),
+        allocation,
+        previous,
+        next,
+    })
+}
+
+fn census_of(allocations: &[HeapAllocation]) -> Vec<HeapCensusRow> {
+    let mut rows: HashMap<(u64, HeapBackend, HeapState, u32), HeapCensusRow> = HashMap::new();
+    for allocation in allocations {
+        let key = (
+            allocation.heap,
+            allocation.backend,
+            allocation.state,
+            allocation.size_class,
+        );
+        let row = rows.entry(key).or_insert(HeapCensusRow {
+            heap: allocation.heap,
+            backend: allocation.backend,
+            state: allocation.state,
+            size_class: allocation.size_class,
+            chunks: 0,
+            total_capacity: 0,
+        });
+        row.chunks += 1;
+        row.total_capacity = row.total_capacity.saturating_add(allocation.capacity);
+    }
+    let mut rows: Vec<_> = rows.into_values().collect();
+    rows.sort_by(|left, right| {
+        right
+            .total_capacity
+            .cmp(&left.total_capacity)
+            .then_with(|| right.chunks.cmp(&left.chunks))
+            .then_with(|| left.cmp(right))
+    });
+    rows
+}
+
+pub fn census(
+    engine: &DebugEngine,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<Vec<HeapCensusRow>>, HeapQueryError> {
+    let snapshot = prepare(engine, walk.into())?;
+    let found = census_of(&snapshot.allocations);
+    Ok(answer(&snapshot, found))
+}
+
+pub fn diagnostics(
+    engine: &DebugEngine,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<HeapDiagnosticReport>, HeapQueryError> {
+    let snapshot = prepare(engine, walk.into())?;
+    Ok(answer(&snapshot, snapshot.diagnostics.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allocation(heap: u64, backend: HeapBackend, address: u64, capacity: u64) -> HeapAllocation {
+        HeapAllocation {
+            heap,
+            backend,
+            state: HeapState::Allocated,
+            header_address: address,
+            user_address: address + 0x10,
+            capacity,
+            requested_size: None,
+            subsegment: Some(heap + 0x1000),
+            size_class: capacity as u32,
+        }
+    }
+
+    #[test]
+    fn test_segment_and_nt_signatures_are_not_interchangeable() {
+        assert_ne!(SEGMENT_HEAP_SIGNATURE, NT_HEAP_SIGNATURE);
+        assert_eq!(SEGMENT_HEAP_SIGNATURE, 0xddee_ddee);
+        assert_eq!(NT_HEAP_SIGNATURE, 0xeeff_eeff);
+    }
+
+    #[test]
+    fn test_root_classification_skips_nt_unknown_unreadable_and_ambiguous_roots() {
+        assert_eq!(
+            classify_root(Ok(SEGMENT_HEAP_SIGNATURE), Ok(0)),
+            (HeapKind::Segment, None)
+        );
+        assert_eq!(classify_root(Ok(0), Ok(NT_HEAP_SIGNATURE)).0, HeapKind::Nt);
+        assert_eq!(classify_root(Ok(0), Ok(0)).0, HeapKind::Unknown);
+        assert_eq!(
+            classify_root(Err("first read".into()), Err("second read".into())).0,
+            HeapKind::Unreadable
+        );
+        assert_eq!(
+            classify_root(Ok(SEGMENT_HEAP_SIGNATURE), Ok(NT_HEAP_SIGNATURE)).0,
+            HeapKind::Unknown,
+            "conflicting structural evidence must fail closed"
+        );
+    }
+
+    #[test]
+    fn test_user_pointer_bounds_reject_null_kernel_and_noncanonical_roots() {
+        assert!(user_pointer(0x1_0000));
+        assert!(user_pointer(0x0000_7fff_ffff_ffff));
+        assert!(!user_pointer(0));
+        assert!(!user_pointer(0xffff_8000_0000_0000));
+        assert!(!user_pointer(0x0000_8000_0000_0000));
+    }
+
+    #[test]
+    fn test_user_allocation_contains_header_and_payload_addresses() {
+        let allocation = allocation(0x1000, HeapBackend::Vs, 0x2000, 0x40);
+        assert!(allocation.contains(0x2000));
+        assert!(allocation.contains(0x204f));
+        assert!(!allocation.contains(0x2050));
+    }
+
+    #[test]
+    fn test_scope_lists_unsupported_heaps_explicitly() {
+        let roots = vec![
+            HeapRoot {
+                index: 0,
+                address: 1,
+                kind: HeapKind::Segment,
+                supported: true,
+                reason: None,
+            },
+            HeapRoot {
+                index: 1,
+                address: 2,
+                kind: HeapKind::Nt,
+                supported: false,
+                reason: Some("classic".into()),
+            },
+            HeapRoot {
+                index: 2,
+                address: 3,
+                kind: HeapKind::Unknown,
+                supported: false,
+                reason: Some("unknown".into()),
+            },
+            HeapRoot {
+                index: 3,
+                address: 4,
+                kind: HeapKind::Unreadable,
+                supported: false,
+                reason: Some("unreadable".into()),
+            },
+        ];
+        let scope = scope_of(&roots);
+        assert_eq!(scope.segment_heaps_walked, vec![1]);
+        assert_eq!(scope.nt_heaps_skipped, vec![2]);
+        assert_eq!(scope.unknown_heaps_skipped, vec![3]);
+        assert_eq!(scope.unreadable_heaps_skipped, vec![4]);
+    }
+
+    #[test]
+    fn test_census_key_separates_heap_backend_state_and_size_class() {
+        let left = allocation(1, HeapBackend::Lfh, 0x1000, 0x20);
+        let mut right = allocation(2, HeapBackend::Lfh, 0x2000, 0x20);
+        right.state = HeapState::ReusableFree;
+        assert_ne!(
+            (left.heap, left.backend, left.state, left.size_class),
+            (right.heap, right.backend, right.state, right.size_class)
+        );
+    }
+
+    #[test]
+    fn test_neighbourhood_requires_contiguity_and_same_allocator_identity() {
+        let previous = allocation(1, HeapBackend::Vs, 0x2000, 0x20);
+        let current = allocation(1, HeapBackend::Vs, previous.end(), 0x20);
+        let next = allocation(1, HeapBackend::Vs, current.end(), 0x20);
+        let found = neighbourhood_at(
+            &[previous.clone(), current.clone(), next.clone()],
+            current.user_address + 3,
+        )
+        .unwrap();
+        assert_eq!(found.offset, 3);
+        assert_eq!(found.previous, Some(previous));
+        assert_eq!(found.next, Some(next));
+
+        let header =
+            neighbourhood_at(std::slice::from_ref(&current), current.header_address).unwrap();
+        assert_eq!(header.offset, -0x10);
+
+        let other_heap = allocation(2, HeapBackend::Vs, current.end(), 0x20);
+        let found = neighbourhood_at(&[current.clone(), other_heap], current.user_address).unwrap();
+        assert!(found.next.is_none(), "neighbours may not cross a heap root");
+    }
+
+    #[test]
+    fn test_census_totals_and_sorts_heaviest_first() {
+        let allocations = vec![
+            allocation(1, HeapBackend::Lfh, 0x1000, 0x20),
+            allocation(1, HeapBackend::Lfh, 0x2000, 0x20),
+            allocation(2, HeapBackend::Large, 0x3000, 0x1000),
+        ];
+        let rows = census_of(&allocations);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].backend, HeapBackend::Large);
+        assert_eq!(rows[0].total_capacity, 0x1000);
+        assert_eq!(rows[1].chunks, 2);
+        assert_eq!(rows[1].total_capacity, 0x40);
+    }
+}

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -11,15 +11,15 @@ use thiserror::Error;
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
     DEBUG_STATUS_BREAK, DEBUG_STATUS_NO_DEBUGGEE,
 };
+use windows::Win32::System::SystemInformation::IMAGE_FILE_MACHINE_AMD64;
 
 use crate::allocator::LayoutProvenance;
 use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage};
-use crate::pool::layout::{LayoutKey, PoolLayout};
+use crate::pool::layout::{LayoutCache, LayoutKey, LayoutTarget, PoolLayout};
 use crate::pool::query::WalkCoverage;
 use crate::pool::snapshot::{PoolSnapshot, SnapshotError, walk_user_segment_heaps};
 use crate::pool::{DiagnosticShape, PoolBackend, PoolState, WalkStalls};
 
-const IMAGE_FILE_MACHINE_AMD64: u32 = 0x8664;
 const SEGMENT_HEAP_SIGNATURE: u32 = 0xddee_ddee;
 const NT_HEAP_SIGNATURE: u32 = 0xeeff_eeff;
 const MAX_PROCESS_HEAPS: usize = 4096;
@@ -201,8 +201,10 @@ pub enum HeapQueryError {
     NotUserTarget,
     #[error("no debuggee is loaded")]
     NoDebuggee,
-    #[error("the target is running; break in before walking heaps")]
-    TargetRunning,
+    #[error(
+        "the target is not stopped (execution status {status:#x}); break in before walking heaps"
+    )]
+    TargetRunning { status: u32 },
     #[error("heap walking supports x64 targets only (machine {machine:#x})")]
     UnsupportedArchitecture { machine: u32 },
     #[error("invalid PEB heap metadata: {0}")]
@@ -235,6 +237,19 @@ struct HeapSnapshot {
     scope: HeapScope,
     walk: HeapWalkReport,
     diagnostics: HeapDiagnosticReport,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ValidatedTarget {
+    target: u64,
+    peb: u64,
+    generation: u64,
+}
+
+struct ResolvedSchema {
+    layout: PoolLayout,
+    provenance: LayoutProvenance,
+    image: KernelImage,
 }
 
 #[derive(Default)]
@@ -272,48 +287,6 @@ fn snapshots() -> &'static SnapshotCache {
     CACHE.get_or_init(SnapshotCache::default)
 }
 
-#[derive(Default)]
-struct UserLayoutCache {
-    entries: Mutex<HashMap<LayoutKey, PoolLayout>>,
-}
-
-impl UserLayoutCache {
-    fn global() -> &'static Self {
-        static CACHE: OnceLock<UserLayoutCache> = OnceLock::new();
-        CACHE.get_or_init(UserLayoutCache::default)
-    }
-
-    fn get_or_resolve(
-        &self,
-        engine: &DebugEngine,
-        key: LayoutKey,
-    ) -> Result<PoolLayout, HeapQueryError> {
-        if let Some(layout) = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(&key)
-            .cloned()
-        {
-            return Ok(layout);
-        }
-        let layout = PoolLayout::resolve_user(engine, key)
-            .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
-        self.entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(key, layout.clone());
-        Ok(layout)
-    }
-
-    fn invalidate(&self) {
-        self.entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clear();
-    }
-}
-
 /// Drop the user-heap snapshot while retaining the image-keyed `ntdll` schema.
 pub fn invalidate_snapshot() {
     snapshots().invalidate();
@@ -322,18 +295,24 @@ pub fn invalidate_snapshot() {
 /// Drop every user-heap snapshot and resolved `ntdll` schema.
 pub fn invalidate_caches() {
     invalidate_snapshot();
-    UserLayoutCache::global().invalidate();
+    LayoutCache::global().invalidate();
 }
 
 fn read_u32(engine: &DebugEngine, address: u64) -> Result<u32, DbgEngError> {
     Ok(u32::from_le_bytes(
-        engine.read_memory(address, 4)?.try_into().unwrap(),
+        engine
+            .read_memory(address, 4)?
+            .try_into()
+            .expect("read_memory returns exactly four bytes or a ShortRead error"),
     ))
 }
 
 fn read_u64(engine: &DebugEngine, address: u64) -> Result<u64, DbgEngError> {
     Ok(u64::from_le_bytes(
-        engine.read_memory(address, 8)?.try_into().unwrap(),
+        engine
+            .read_memory(address, 8)?
+            .try_into()
+            .expect("read_memory returns exactly eight bytes or a ShortRead error"),
     ))
 }
 
@@ -366,6 +345,40 @@ fn classify_root(
             Some("root matches neither the PDB-resolved Segment nor NT heap signature".into()),
         ),
     }
+}
+
+fn read_root_signatures(
+    engine: &DebugEngine,
+    address: u64,
+    segment_offset: u64,
+    nt_offset: u64,
+) -> (Result<u32, String>, Result<u32, String>) {
+    let start_offset = segment_offset.min(nt_offset);
+    let end_offset = segment_offset.max(nt_offset).saturating_add(4);
+    let Some(start) = address.checked_add(start_offset) else {
+        let error = "heap signature address overflow".to_string();
+        return (Err(error.clone()), Err(error));
+    };
+    let size = usize::try_from(end_offset.saturating_sub(start_offset))
+        .expect("two u32 PDB fields fit in a host-sized read buffer");
+    let bytes = match engine.read_memory(start, size) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let error = error.to_string();
+            return (Err(error.clone()), Err(error));
+        }
+    };
+    let decode = |offset: u64| {
+        let relative = usize::try_from(offset - start_offset)
+            .expect("a field within the signature buffer has a host-sized offset");
+        let value = bytes
+            .get(relative..relative + 4)
+            .expect("read_memory returns the complete signature buffer or a ShortRead error")
+            .try_into()
+            .expect("a signature slice is exactly four bytes");
+        Ok(u32::from_le_bytes(value))
+    };
+    (decode(segment_offset), decode(nt_offset))
 }
 
 fn enumerate_roots(
@@ -413,7 +426,11 @@ fn enumerate_roots(
         .map_err(|error| HeapQueryError::Layout(error.to_string()))? as u64;
     let mut roots = Vec::with_capacity(count);
     for (index, entry) in bytes.chunks_exact(8).enumerate() {
-        let address = u64::from_le_bytes(entry.try_into().unwrap());
+        let address = u64::from_le_bytes(
+            entry
+                .try_into()
+                .expect("ProcessHeaps is read as a whole number of pointer-sized entries"),
+        );
         if address == 0 {
             roots.push(HeapRoot {
                 index,
@@ -434,14 +451,7 @@ fn enumerate_roots(
             });
             continue;
         }
-        let segment = address
-            .checked_add(segment_offset)
-            .ok_or_else(|| "Segment signature address overflow".into())
-            .and_then(|address| read_u32(engine, address).map_err(|error| error.to_string()));
-        let nt = address
-            .checked_add(nt_offset)
-            .ok_or_else(|| "NT signature address overflow".into())
-            .and_then(|address| read_u32(engine, address).map_err(|error| error.to_string()));
+        let (segment, nt) = read_root_signatures(engine, address, segment_offset, nt_offset);
         let (kind, reason) = classify_root(segment, nt);
         roots.push(HeapRoot {
             index,
@@ -470,7 +480,7 @@ fn scope_of(roots: &[HeapRoot]) -> HeapScope {
 fn from_pool_snapshot(
     snapshot: PoolSnapshot,
 ) -> (Vec<HeapAllocation>, HeapWalkReport, HeapDiagnosticReport) {
-    let allocations: Vec<_> = snapshot
+    let mut allocations: Vec<_> = snapshot
         .spans
         .iter()
         .map(|span| HeapAllocation {
@@ -485,6 +495,7 @@ fn from_pool_snapshot(
             size_class: span.size_class,
         })
         .collect();
+    allocations.sort_by_key(|allocation| (allocation.user_address, allocation.heap));
     let walk = HeapWalkReport {
         coverage: match (snapshot.complete, snapshot.budget_expired) {
             (true, _) => WalkCoverage::Complete,
@@ -511,18 +522,17 @@ fn from_pool_snapshot(
     (allocations, walk, diagnostics)
 }
 
-fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQueryError> {
-    let started = Instant::now();
+fn validate_target(engine: &DebugEngine) -> Result<ValidatedTarget, HeapQueryError> {
     if engine.is_kernel_target()? {
         return Err(HeapQueryError::NotUserTarget);
     }
     match engine.execution_status()? {
         DEBUG_STATUS_NO_DEBUGGEE => return Err(HeapQueryError::NoDebuggee),
         DEBUG_STATUS_BREAK => {}
-        _ => return Err(HeapQueryError::TargetRunning),
+        status => return Err(HeapQueryError::TargetRunning { status }),
     }
     let machine = engine.processor_type()?;
-    if machine != IMAGE_FILE_MACHINE_AMD64 {
+    if machine != u32::from(IMAGE_FILE_MACHINE_AMD64.0) {
         return Err(HeapQueryError::UnsupportedArchitecture { machine });
     }
     let peb = engine.current_process_peb()?;
@@ -531,6 +541,17 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
             "DbgEng returned a null PEB".into(),
         ));
     }
+    Ok(ValidatedTarget {
+        target: engine.target_identity(),
+        peb,
+        generation: crate::pool::query::generation(),
+    })
+}
+
+fn resolve_schema(
+    engine: &DebugEngine,
+    target: ValidatedTarget,
+) -> Result<ResolvedSchema, HeapQueryError> {
     let loaded_module = engine.module("ntdll")?;
     let image = KernelImage {
         base: loaded_module.base,
@@ -538,12 +559,13 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
         timestamp: loaded_module.timestamp,
         checksum: loaded_module.checksum,
     };
-    let generation = crate::pool::query::generation();
     let layout_key = LayoutKey {
         image,
-        session: generation,
+        session: target.generation,
     };
-    let layout = UserLayoutCache::global().get_or_resolve(engine, layout_key)?;
+    let layout = LayoutCache::global()
+        .get_or_resolve(engine, layout_key, LayoutTarget::User)
+        .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
     // Type lookups above force a deferred module to load. Check provenance afterwards so
     // export-only symbols fail explicitly without preventing the normal deferred-load path.
     let module = engine.module_identity("ntdll")?;
@@ -555,11 +577,25 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
     let provenance = layout
         .provenance(module)
         .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
-    let key = SnapshotKey {
-        target: engine.target_identity(),
-        peb,
+    Ok(ResolvedSchema {
+        layout,
+        provenance,
         image,
-        generation,
+    })
+}
+
+fn walk_snapshot(
+    engine: &DebugEngine,
+    walk: HeapWalk,
+    started: Instant,
+    target: ValidatedTarget,
+    schema: ResolvedSchema,
+) -> Result<HeapSnapshot, HeapQueryError> {
+    let key = SnapshotKey {
+        target: target.target,
+        peb: target.peb,
+        image: schema.image,
+        generation: target.generation,
     };
     if walk.refresh {
         snapshots().invalidate();
@@ -567,15 +603,15 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
         return Ok(snapshot);
     }
 
-    let roots = enumerate_roots(engine, &layout, peb)?;
+    let roots = enumerate_roots(engine, &schema.layout, target.peb)?;
     let scope = scope_of(&roots);
     let remaining = walk
         .budget
         .map(|budget| budget.saturating_sub(started.elapsed()));
     let pool = walk_user_segment_heaps(
         engine,
-        &layout,
-        peb,
+        &schema.layout,
+        target.peb,
         &scope.segment_heaps_walked,
         remaining,
         1_000_000,
@@ -588,7 +624,7 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
     let snapshot = HeapSnapshot {
         roots,
         allocations,
-        layout: provenance,
+        layout: schema.provenance,
         scope,
         walk: report,
         diagnostics,
@@ -597,6 +633,13 @@ fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQue
         snapshots().put(key, snapshot.clone());
     }
     Ok(snapshot)
+}
+
+fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQueryError> {
+    let started = Instant::now();
+    let target = validate_target(engine)?;
+    let schema = resolve_schema(engine, target)?;
+    walk_snapshot(engine, walk, started, target, schema)
 }
 
 fn answer<T>(snapshot: &HeapSnapshot, found: T) -> HeapAnswer<T> {
@@ -635,9 +678,16 @@ pub fn chunk_at(
 }
 
 fn neighbourhood_at(allocations: &[HeapAllocation], address: u64) -> Option<HeapNeighbourhood> {
-    let position = allocations
-        .iter()
-        .position(|allocation| allocation.contains(address))?;
+    let split = allocations.partition_point(|allocation| allocation.user_address <= address);
+    let position = split
+        .checked_sub(1)
+        .filter(|&index| allocations[index].contains(address))
+        .or_else(|| {
+            allocations
+                .get(split)
+                .filter(|allocation| allocation.contains(address))
+                .map(|_| split)
+        })?;
     let allocation = allocations[position].clone();
     let same_heap = |candidate: &HeapAllocation| {
         candidate.heap == allocation.heap

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -15,7 +15,7 @@ use windows::Win32::System::SystemInformation::IMAGE_FILE_MACHINE_AMD64;
 
 use crate::allocator::LayoutProvenance;
 use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage};
-use crate::pool::layout::{LayoutCache, LayoutKey, LayoutTarget, PoolLayout};
+use crate::pool::layout::{LayoutCache, LayoutError, LayoutKey, LayoutTarget, PoolLayout, Symbols};
 use crate::pool::query::WalkCoverage;
 use crate::pool::snapshot::{PoolSnapshot, SnapshotError, walk_user_segment_heaps};
 use crate::pool::{DiagnosticShape, PoolBackend, PoolState, WalkStalls};
@@ -215,6 +215,8 @@ pub enum HeapQueryError {
     Layout(String),
     #[error("the heap walk was interrupted on request")]
     Interrupted,
+    #[error("the heap walk ran out of its budget while resolving the ntdll allocator layout")]
+    BudgetExpired,
     #[error("walking the heap failed: {0}")]
     Walk(String),
     #[error(transparent)]
@@ -224,6 +226,7 @@ pub enum HeapQueryError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct SnapshotKey {
     target: u64,
+    process_system_id: u32,
     peb: u64,
     image: KernelImage,
     generation: u64,
@@ -242,6 +245,7 @@ struct HeapSnapshot {
 #[derive(Debug, Clone, Copy)]
 struct ValidatedTarget {
     target: u64,
+    process_system_id: u32,
     peb: u64,
     generation: u64,
 }
@@ -250,6 +254,62 @@ struct ResolvedSchema {
     layout: PoolLayout,
     provenance: LayoutProvenance,
     image: KernelImage,
+}
+
+struct BudgetedSymbols<'a> {
+    engine: &'a DebugEngine,
+    deadline: Option<Instant>,
+}
+
+impl BudgetedSymbols<'_> {
+    fn check(&self) -> Result<(), HeapQueryError> {
+        self.poll().map_err(map_layout_error)
+    }
+}
+
+impl Symbols for BudgetedSymbols<'_> {
+    fn poll(&self) -> Result<(), LayoutError> {
+        if self
+            .engine
+            .interrupted()
+            .map_err(|error| LayoutError::Poll {
+                detail: error.to_string(),
+            })?
+        {
+            return Err(LayoutError::Interrupted);
+        }
+        if self
+            .deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return Err(LayoutError::BudgetExpired);
+        }
+        Ok(())
+    }
+
+    fn symbol(&self, name: &str) -> Result<u64, DbgEngError> {
+        self.engine.symbol_offset(name)
+    }
+
+    fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError> {
+        self.engine.type_id(module, name)
+    }
+
+    fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError> {
+        self.engine.type_size(module, type_id)
+    }
+
+    fn field(&self, module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError> {
+        self.engine.field_offset(module, type_id, name)
+    }
+}
+
+fn map_layout_error(error: LayoutError) -> HeapQueryError {
+    match error {
+        LayoutError::Interrupted => HeapQueryError::Interrupted,
+        LayoutError::BudgetExpired => HeapQueryError::BudgetExpired,
+        other => HeapQueryError::Layout(other.to_string()),
+    }
 }
 
 #[derive(Default)]
@@ -615,6 +675,7 @@ fn validate_target(engine: &DebugEngine) -> Result<ValidatedTarget, HeapQueryErr
     }
     Ok(ValidatedTarget {
         target: engine.target_identity(),
+        process_system_id: engine.current_process_system_id()?,
         peb,
         generation: crate::pool::query::generation(),
     })
@@ -623,8 +684,13 @@ fn validate_target(engine: &DebugEngine) -> Result<ValidatedTarget, HeapQueryErr
 fn resolve_schema(
     engine: &DebugEngine,
     target: ValidatedTarget,
+    deadline: Option<Instant>,
 ) -> Result<ResolvedSchema, HeapQueryError> {
-    let loaded_module = engine.module("ntdll")?;
+    let symbols = BudgetedSymbols { engine, deadline };
+    symbols.check()?;
+    let loaded_module = engine.module("ntdll");
+    symbols.check()?;
+    let loaded_module = loaded_module?;
     let image = KernelImage {
         base: loaded_module.base,
         size: loaded_module.size,
@@ -636,19 +702,20 @@ fn resolve_schema(
         session: target.generation,
     };
     let layout = LayoutCache::global()
-        .get_or_resolve(engine, layout_key, LayoutTarget::User)
-        .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
+        .get_or_resolve(&symbols, layout_key, LayoutTarget::User)
+        .map_err(map_layout_error)?;
     // Type lookups above force a deferred module to load. Check provenance afterwards so
     // export-only symbols fail explicitly without preventing the normal deferred-load path.
-    let module = engine.module_identity("ntdll")?;
+    symbols.check()?;
+    let module = engine.module_identity("ntdll");
+    symbols.check()?;
+    let module = module?;
     if !module.symbols.has_type_info() || module.symbol_file.is_empty() {
         return Err(HeapQueryError::Layout(
             "DbgEng did not load private PDB type information for ntdll".into(),
         ));
     }
-    let provenance = layout
-        .provenance(module)
-        .map_err(|error| HeapQueryError::Layout(error.to_string()))?;
+    let provenance = layout.provenance(module).map_err(map_layout_error)?;
     Ok(ResolvedSchema {
         layout,
         provenance,
@@ -665,6 +732,7 @@ fn walk_snapshot(
 ) -> Result<HeapSnapshot, HeapQueryError> {
     let key = SnapshotKey {
         target: target.target,
+        process_system_id: target.process_system_id,
         peb: target.peb,
         image: schema.image,
         generation: target.generation,
@@ -723,8 +791,9 @@ fn walk_snapshot(
 
 fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQueryError> {
     let started = Instant::now();
+    let deadline = walk.budget.and_then(|budget| started.checked_add(budget));
     let target = validate_target(engine)?;
-    let schema = resolve_schema(engine, target)?;
+    let schema = resolve_schema(engine, target, deadline)?;
     walk_snapshot(engine, walk, started, target, schema)
 }
 
@@ -903,6 +972,30 @@ mod tests {
         assert!(!user_pointer(0));
         assert!(!user_pointer(0xffff_8000_0000_0000));
         assert!(!user_pointer(0x0000_8000_0000_0000));
+    }
+
+    #[test]
+    fn test_snapshot_identity_separates_current_processes() {
+        let image = KernelImage {
+            base: 0x0000_7ffb_0000_0000,
+            size: 0x20_0000,
+            timestamp: 0x1234_5678,
+            checksum: 0x9876,
+        };
+        let key = |process_system_id| SnapshotKey {
+            target: 7,
+            process_system_id,
+            peb: 0x0000_7fff_0000_1000,
+            image,
+            generation: 3,
+        };
+
+        assert_ne!(
+            key(100),
+            key(200),
+            "two current processes may share virtual addresses but never a heap snapshot"
+        );
+        assert_eq!(key(100), key(100));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod allocator;
 pub mod dbgeng;
+pub mod heap;
 pub mod pool;
 mod pool_extension;
 pub mod process;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -67,6 +67,9 @@ pub struct PoolSpan {
     pub header_address: u64,
     pub usable_address: u64,
     pub size: u64,
+    /// Exact requested size when allocator metadata validates it. Kernel pool and user LFH/VS
+    /// spans leave this unset rather than guessing from capacity.
+    pub requested_size: Option<u64>,
     pub raw_tag: u32,
     pub display_tag: String,
     pub pool_kind: PoolKind,
@@ -109,6 +112,7 @@ impl PoolSpan {
             header_address: address,
             usable_address: address,
             size,
+            requested_size: None,
             raw_tag: tag,
             display_tag: decode::display_tag(tag),
             pool_kind,

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -412,6 +412,11 @@ pub(crate) fn decode_pool_header(
     offset: usize,
     layout: PoolHeaderLayout,
 ) -> Option<PoolHeader> {
+    // User Segment Heap blocks have no kernel `_POOL_HEADER`; their shared-decoder adapter is
+    // deliberately zero-sized and must not reinterpret payload bytes as header fields or tags.
+    if layout.size == 0 {
+        return None;
+    }
     range(bytes, offset, layout.size)?;
     // PDB field offsets for the two bitfield pairs can both name the containing
     // USHORT. In that representation the second member occupies its high byte.
@@ -761,6 +766,16 @@ mod tests {
                 .pool_index,
             3
         );
+
+        let no_pool_header = PoolHeaderLayout {
+            size: 0,
+            previous_size: 0,
+            pool_index: 0,
+            block_size: 0,
+            pool_type: 0,
+            tag: 0,
+        };
+        assert_eq!(decode_pool_header(b"DATA", 0, no_pool_header), None);
     }
 
     /// The flag combinations the kernel itself dispatches on, as read out of `nt` on Server

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -528,8 +528,23 @@ pub(crate) fn decode_special_pool_header(
 }
 
 pub(crate) fn decode_rb_root(root: u64, tree_address: u64, encoded: bool) -> Option<u64> {
+    decode_rb_root_for(root, tree_address, encoded, false)
+}
+
+pub(crate) fn decode_rb_root_for(
+    root: u64,
+    tree_address: u64,
+    encoded: bool,
+    user: bool,
+) -> Option<u64> {
     let pointer = if encoded { root ^ tree_address } else { root } & !0xf;
-    (pointer == 0 || is_kernel_pointer(pointer)).then_some(pointer)
+    (pointer == 0
+        || if user {
+            is_user_pointer(pointer)
+        } else {
+            is_kernel_pointer(pointer)
+        })
+    .then_some(pointer)
 }
 
 /// Decode the 60-bit `NextEntry` field packed above the low four reserved bits
@@ -546,14 +561,47 @@ pub(crate) fn decode_large_allocation(
     virtual_address_field: u64,
     allocated_pages_field: u64,
 ) -> Option<(u64, u64)> {
+    decode_large_allocation_for(virtual_address_field, allocated_pages_field, false)
+}
+
+pub(crate) fn decode_large_allocation_for(
+    virtual_address_field: u64,
+    allocated_pages_field: u64,
+    user: bool,
+) -> Option<(u64, u64)> {
     let virtual_address = virtual_address_field & !0xffff;
     let allocated_pages = allocated_pages_field >> 12;
-    (virtual_address != 0 && is_kernel_pointer(virtual_address) && allocated_pages != 0)
+    (virtual_address != 0
+        && if user {
+            is_user_pointer(virtual_address)
+        } else {
+            is_kernel_pointer(virtual_address)
+        }
+        && allocated_pages != 0)
         .then_some((virtual_address, allocated_pages))
+}
+
+/// Recover the exact request encoded in the low sixteen bits of the large-allocation address
+/// word. Callers must pass `validated_alias` only when the selected PDB reports `UnusedBytes`
+/// at the same offset as `VirtualAddress`.
+pub(crate) fn decode_large_requested_size(
+    virtual_address_field: u64,
+    allocated_bytes: u64,
+    validated_alias: bool,
+) -> Option<u64> {
+    if !validated_alias {
+        return None;
+    }
+    let unused = virtual_address_field & 0xffff;
+    allocated_bytes.checked_sub(unused)
 }
 
 pub(crate) fn is_kernel_pointer(pointer: u64) -> bool {
     pointer == 0 || pointer >= 0xffff_8000_0000_0000
+}
+
+pub(crate) fn is_user_pointer(pointer: u64) -> bool {
+    (0x1_0000..0x0000_8000_0000_0000).contains(&pointer)
 }
 
 pub(crate) fn big_page_hash(address: u64, table_size: usize) -> Option<usize> {
@@ -891,6 +939,19 @@ mod tests {
         assert_eq!(
             decode_large_allocation(root | 0x1234, (0x2345u64 << 12) | 0xabc),
             Some((root, 0x2345))
+        );
+        assert_eq!(
+            decode_large_requested_size(root | 0x1234, 0x20_000, true),
+            Some(0x1_edcc)
+        );
+        assert_eq!(
+            decode_large_requested_size(root | 0x1234, 0x20_000, false),
+            None,
+            "without a PDB-validated alias capacity must not be presented as an exact request"
+        );
+        assert_eq!(
+            decode_large_requested_size(root | 0xffff, 0x1000, true),
+            None
         );
     }
 }

--- a/src/pool/index.rs
+++ b/src/pool/index.rs
@@ -21,6 +21,7 @@ pub(crate) struct Hole {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PoolIndex {
+    pub layout: crate::allocator::LayoutProvenance,
     pub spans: Vec<PoolSpan>,
     pub postings: HashMap<u32, Vec<usize>>,
     pub diagnostics: PoolDiagnostics,
@@ -82,6 +83,7 @@ impl PoolIndex {
             span_rows.push(row);
         }
         Self {
+            layout: snapshot.layout,
             spans: snapshot.spans,
             postings,
             diagnostics: snapshot.diagnostics,

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -4,7 +4,8 @@ use std::sync::{Mutex, OnceLock};
 use thiserror::Error;
 
 use super::decode::PoolHeaderLayout;
-use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage};
+use crate::allocator::{LayoutProvenance, VsSemanticFamily, fingerprint};
+use crate::dbgeng::{DbgEngError, DebugEngine, KernelImage, ModuleIdentity};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct SessionKey {
@@ -55,16 +56,22 @@ impl From<SessionKey> for LayoutKey {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PoolLayout {
+pub(crate) struct AllocatorSchema {
     pub key: LayoutKey,
     pub globals: HashMap<&'static str, u64>,
     pub types: HashMap<&'static str, TypeLayout>,
 }
 
+/// Kernel-facing compatibility name. User and kernel adapters both resolve the same
+/// module-scoped allocator schema; the alias keeps the mature pool decoder terminology local.
+pub(crate) type PoolLayout = AllocatorSchema;
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub(crate) enum LayoutError {
-    #[error("missing kernel pool symbols ({item}); run `.reload /f nt` and retry")]
+    #[error("missing allocator symbols ({item})")]
     Missing { item: String },
+    #[error("unsupported allocator layout {fingerprint}: {detail}")]
+    Unsupported { fingerprint: String, detail: String },
 }
 
 pub(crate) trait Symbols {
@@ -143,8 +150,8 @@ const TYPES: &[TypeSpec] = &[
         ],
     },
     // Deliberately no *required* fields. The VS free-chunk state lives inside this
-    // struct on older builds, and from Windows 26100 it moved into a separately
-    // addressed _HEAP_VS_AFFINITY_SLOT. Both shapes are resolved optionally below;
+    // struct in one schema family and moved into a separately addressed
+    // _HEAP_VS_AFFINITY_SLOT in another. Both shapes are resolved optionally below;
     // requiring either one here would refuse to walk half the world.
     TypeSpec {
         name: "_HEAP_VS_CONTEXT",
@@ -211,9 +218,8 @@ const TYPES: &[TypeSpec] = &[
 ];
 
 const OPTIONAL_TYPES: &[TypeSpec] = &[
-    // Windows 26100+: the VS free-chunk tree, subsegment list and delay-free list moved
-    // out of _HEAP_VS_CONTEXT into one of these per-affinity slots. Absent on older
-    // builds, where the same state is inline in the context.
+    // Affinity-slot family: the VS free-chunk tree, subsegment list and delay-free list live
+    // outside _HEAP_VS_CONTEXT in one of these per-affinity slots. Absent in the inline family.
     TypeSpec {
         name: "_HEAP_VS_AFFINITY_SLOT",
         fields: &[
@@ -254,6 +260,7 @@ const OPTIONAL_TYPES: &[TypeSpec] = &[
 ];
 
 const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
+    ("_SEGMENT_HEAP", "Signature", &["Signature"]),
     ("_EX_HEAP_POOL_NODE", "Lookasides", &["Lookasides"]),
     ("_RTL_RB_TREE", "Encoded", &["Encoded"]),
     (
@@ -267,17 +274,32 @@ const OPTIONAL_FIELDS: &[(&str, &str, &[&str])] = &[
         &["AffinitySlots", "AffinitizedInfoArrays"],
     ),
     ("_RTL_LOOKASIDE", "Size", &["Size", "SizeClass"]),
-    // Legacy (pre-26100) in-context VS state.
+    // Inline-family VS state.
     ("_HEAP_VS_CONTEXT", "FreeChunkTree", &["FreeChunkTree"]),
     (
         "_HEAP_VS_CONTEXT",
         "DelayFreeContext",
         &["DelayFreeContext"],
     ),
-    // 26100+: locate the affinity slots. Both are self-relative to the VS context and
+    // Affinity-slot family. Both references are self-relative to the VS context and
     // scaled by 64 bytes; the slot map holds AffinityMask + 1 entries.
     ("_HEAP_VS_CONTEXT", "SlotMapRef", &["SlotMapRef"]),
     ("_HEAP_VS_CONTEXT", "AffinityMask", &["AffinityMask"]),
+    ("_HEAP_LARGE_ALLOC_DATA", "UnusedBytes", &["UnusedBytes"]),
+];
+
+const USER_TYPES: &[TypeSpec] = &[
+    TypeSpec {
+        name: "_PEB",
+        fields: &[
+            ("NumberOfHeaps", &["NumberOfHeaps"]),
+            ("ProcessHeaps", &["ProcessHeaps"]),
+        ],
+    },
+    TypeSpec {
+        name: "_HEAP",
+        fields: &[("Signature", &["Signature"])],
+    },
 ];
 
 const GLOBALS: &[(&str, &[&str])] = &[
@@ -318,7 +340,11 @@ fn resolve_type(
     Ok(TypeLayout { size, fields })
 }
 
-impl PoolLayout {
+impl AllocatorSchema {
+    pub(crate) fn is_user(&self) -> bool {
+        !self.globals.contains_key("ExPoolState") && self.globals.contains_key("RtlpHpHeapGlobals")
+    }
+
     pub(crate) fn type_layout(&self, name: &str) -> Result<&TypeLayout, LayoutError> {
         self.types
             .get(name)
@@ -337,6 +363,19 @@ impl PoolLayout {
     }
 
     pub(crate) fn pool_header_layout(&self) -> Result<PoolHeaderLayout, LayoutError> {
+        // User Segment Heap blocks do not carry the kernel's `_POOL_HEADER`. A zero-sized
+        // adapter lets the shared LFH/VS/page-range decoder report the block geometry without
+        // inventing a tag header.
+        if self.is_user() {
+            return Ok(PoolHeaderLayout {
+                size: 0,
+                previous_size: 0,
+                pool_index: 0,
+                block_size: 0,
+                pool_type: 0,
+                tag: 0,
+            });
+        }
         Ok(PoolHeaderLayout {
             size: self.type_layout("_POOL_HEADER")?.size as usize,
             previous_size: self.field("_POOL_HEADER", "PreviousSize")?,
@@ -392,11 +431,130 @@ impl PoolLayout {
             types,
         })
     }
+
+    /// Resolve the same Segment Heap decoder schema from `ntdll` rather than `nt`.
+    pub(crate) fn resolve_user(
+        symbols: &impl Symbols,
+        key: LayoutKey,
+    ) -> Result<Self, LayoutError> {
+        let globals = [("RtlpHpHeapGlobals", "ntdll!RtlpHpHeapGlobals")]
+            .into_iter()
+            .map(|(canonical, symbol)| {
+                symbols
+                    .symbol(symbol)
+                    .map(|value| (canonical, value))
+                    .map_err(|_| LayoutError::Missing {
+                        item: canonical.into(),
+                    })
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?;
+
+        let excluded = [
+            "_EX_POOL_HEAP_MANAGER_STATE",
+            "_EX_HEAP_POOL_NODE",
+            "_POOL_HEADER",
+        ];
+        let mut types = HashMap::new();
+        for spec in TYPES.iter().filter(|spec| !excluded.contains(&spec.name)) {
+            types.insert(spec.name, resolve_type(symbols, key.image.base, spec)?);
+        }
+        for spec in USER_TYPES {
+            types.insert(spec.name, resolve_type(symbols, key.image.base, spec)?);
+        }
+        for spec in OPTIONAL_TYPES {
+            if spec.name == "_POOL_TRACKER_BIG_PAGES" {
+                continue;
+            }
+            if let Ok(layout) = resolve_type(symbols, key.image.base, spec) {
+                types.insert(spec.name, layout);
+            }
+        }
+        for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
+            let Some(layout) = types.get_mut(type_name) else {
+                continue;
+            };
+            let Ok(type_id) = symbols.type_id(key.image.base, type_name) else {
+                continue;
+            };
+            if let Some(offset) = aliases
+                .iter()
+                .find_map(|field| symbols.field(key.image.base, type_id, field).ok())
+            {
+                layout.fields.insert(canonical, offset);
+            }
+        }
+        if !types
+            .get("_SEGMENT_HEAP")
+            .is_some_and(|layout| layout.fields.contains_key("Signature"))
+        {
+            return Err(LayoutError::Missing {
+                item: "_SEGMENT_HEAP.Signature".into(),
+            });
+        }
+        Ok(Self {
+            key,
+            globals,
+            types,
+        })
+    }
+
+    pub(crate) fn provenance(
+        &self,
+        module: ModuleIdentity,
+    ) -> Result<LayoutProvenance, LayoutError> {
+        let mut facts = Vec::new();
+        for (type_name, layout) in &self.types {
+            facts.push(format!("type:{type_name}:size:{:#x}", layout.size));
+            for (field, offset) in &layout.fields {
+                facts.push(format!("field:{type_name}.{field}:{offset:#x}"));
+            }
+        }
+        facts.sort_unstable();
+        let fingerprint = fingerprint(facts.iter().map(String::as_str));
+        let inline = [
+            ("_HEAP_VS_CONTEXT", "FreeChunkTree"),
+            ("_HEAP_VS_CONTEXT", "DelayFreeContext"),
+        ]
+        .into_iter()
+        .all(|(ty, field)| self.field(ty, field).is_ok());
+        let affinity = [
+            ("_HEAP_VS_CONTEXT", "SlotMapRef"),
+            ("_HEAP_VS_CONTEXT", "AffinityMask"),
+            ("_HEAP_VS_AFFINITY_SLOT", "VsContext"),
+            ("_HEAP_VS_AFFINITY_SLOT", "FreeChunkTree"),
+            ("_HEAP_VS_AFFINITY_SLOT", "DelayFreeContext"),
+            ("_HEAP_VS_SLOT_MAP", "SlotRef"),
+        ]
+        .into_iter()
+        .all(|(ty, field)| self.field(ty, field).is_ok());
+        let semantic_family = match (inline, affinity) {
+            (true, false) => VsSemanticFamily::Inline,
+            (false, true) => VsSemanticFamily::AffinitySlots,
+            (false, false) => {
+                return Err(LayoutError::Unsupported {
+                    fingerprint,
+                    detail: "no recognized VS structural family is complete".into(),
+                });
+            }
+            (true, true) => {
+                return Err(LayoutError::Unsupported {
+                    fingerprint,
+                    detail: "both VS structural families are present and the layout is ambiguous"
+                        .into(),
+                });
+            }
+        };
+        Ok(LayoutProvenance {
+            module,
+            fingerprint,
+            semantic_family,
+        })
+    }
 }
 
 #[derive(Default)]
 pub(crate) struct LayoutCache {
-    entries: Mutex<HashMap<LayoutKey, PoolLayout>>,
+    entries: Mutex<HashMap<LayoutKey, AllocatorSchema>>,
 }
 
 impl LayoutCache {
@@ -409,12 +567,12 @@ impl LayoutCache {
         &self,
         symbols: &impl Symbols,
         key: impl Into<LayoutKey>,
-    ) -> Result<PoolLayout, LayoutError> {
+    ) -> Result<AllocatorSchema, LayoutError> {
         let key = key.into();
         if let Some(layout) = self.entries.lock().unwrap().get(&key).cloned() {
             return Ok(layout);
         }
-        let layout = PoolLayout::resolve(symbols, key)?;
+        let layout = AllocatorSchema::resolve(symbols, key)?;
         self.entries.lock().unwrap().insert(key, layout.clone());
         Ok(layout)
     }
@@ -452,9 +610,13 @@ mod tests {
         }
 
         fn type_spec(type_id: u32) -> Option<&'static TypeSpec> {
-            type_id
-                .checked_sub(1)
-                .and_then(|index| TYPES.iter().chain(OPTIONAL_TYPES).nth(index as usize))
+            type_id.checked_sub(1).and_then(|index| {
+                TYPES
+                    .iter()
+                    .chain(OPTIONAL_TYPES)
+                    .chain(USER_TYPES)
+                    .nth(index as usize)
+            })
         }
 
         fn resolve_field(&self, spec: &TypeSpec, name: &str) -> Result<u32, DbgEngError> {
@@ -495,6 +657,9 @@ mod tests {
             if self.missing_global == Some(name) {
                 return Self::error();
             }
+            if name == "ntdll!RtlpHpHeapGlobals" {
+                return Ok(0x0000_7ffb_1234_5000);
+            }
             GLOBALS
                 .iter()
                 .chain(OPTIONAL_GLOBALS)
@@ -510,6 +675,7 @@ mod tests {
             TYPES
                 .iter()
                 .chain(OPTIONAL_TYPES)
+                .chain(USER_TYPES)
                 .position(|spec| spec.name == name)
                 .map(|index| index as u32 + 1)
                 .ok_or(DbgEngError::InvalidCommand)
@@ -595,6 +761,7 @@ mod tests {
     fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {
         match result.unwrap_err() {
             LayoutError::Missing { item } => item,
+            LayoutError::Unsupported { .. } => panic!("expected a missing symbol error"),
         }
     }
 
@@ -670,6 +837,46 @@ mod tests {
                 key(),
             )),
             "_POOL_HEADER.PoolTag"
+        );
+    }
+
+    #[test]
+    fn test_user_schema_requires_ntdll_globals_peb_fields_and_segment_signature() {
+        let symbols = FakeSymbols {
+            optional_fields: true,
+            ..FakeSymbols::default()
+        };
+        let layout = PoolLayout::resolve_user(&symbols, key()).unwrap();
+        assert!(layout.is_user());
+        assert_eq!(layout.pool_header_layout().unwrap().size, 0);
+        assert!(layout.field("_PEB", "ProcessHeaps").is_ok());
+        assert!(layout.field("_SEGMENT_HEAP", "Signature").is_ok());
+
+        assert_eq!(
+            missing_item(PoolLayout::resolve_user(
+                &FakeSymbols {
+                    optional_fields: true,
+                    missing_global: Some("ntdll!RtlpHpHeapGlobals"),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )),
+            "RtlpHpHeapGlobals"
+        );
+        assert_eq!(
+            missing_item(PoolLayout::resolve_user(
+                &FakeSymbols {
+                    optional_fields: true,
+                    missing_field: Some(("_PEB", "ProcessHeaps")),
+                    ..FakeSymbols::default()
+                },
+                key(),
+            )),
+            "_PEB.ProcessHeaps"
+        );
+        assert_eq!(
+            missing_item(PoolLayout::resolve_user(&FakeSymbols::default(), key(),)),
+            "_SEGMENT_HEAP.Signature"
         );
     }
 
@@ -835,5 +1042,145 @@ mod tests {
 
             assert!(layout.field(missing_field.0, missing_field.1).is_err());
         }
+    }
+
+    fn pdb_module(timestamp: u32) -> ModuleIdentity {
+        ModuleIdentity {
+            name: "nt".into(),
+            image_name: "ntkrnlmp.exe".into(),
+            loaded_image_name: r"C:\Windows\System32\ntoskrnl.exe".into(),
+            symbol_file: r"C:\symbols\ntkrnlmp.pdb".into(),
+            symbols: crate::dbgeng::SymbolKind::Pdb,
+            base: key().image.base,
+            size: key().image.size,
+            timestamp,
+            checksum: key().image.checksum,
+        }
+    }
+
+    /// Compact structural fixture for the inline-VS family in Vergilius' public-PDB-derived
+    /// `10.0.19045.2965-x64.yml` and `10.0.22631.2428-x64.yml` in
+    /// <https://github.com/VergiliusProject/kernels-data>. Runtime selection is exclusively by
+    /// these PDB fields, never by the build labels in this comment.
+    fn inline_vs_fixture() -> PoolLayout {
+        let mut layout = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
+        let context = layout.types.get_mut("_HEAP_VS_CONTEXT").unwrap();
+        context.size = 0xc0;
+        context.fields.insert("FreeChunkTree", 0x10);
+        context.fields.insert("DelayFreeContext", 0x40);
+        layout
+    }
+
+    /// Compact structural fixture for the affinity-slot VS family in Vergilius'
+    /// `10.0.26200.6584-x64.yml` in <https://github.com/VergiliusProject/kernels-data>. The same
+    /// family is measured on the later 26100 kernel recorded in `snapshot.rs`; the earlier
+    /// `10.0.26100.1742` YAML is still inline, which is exactly why runtime selection must not use
+    /// a 26100 build threshold.
+    fn affinity_vs_fixture() -> PoolLayout {
+        let mut layout = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
+        let context = layout.types.get_mut("_HEAP_VS_CONTEXT").unwrap();
+        context.size = 0x60;
+        context.fields.insert("SlotMapRef", 0);
+        context.fields.insert("AffinityMask", 2);
+        let slot = layout.types.get_mut("_HEAP_VS_AFFINITY_SLOT").unwrap();
+        slot.size = 0x80;
+        slot.fields.insert("VsContext", 0);
+        slot.fields.insert("FreeChunkTree", 0x10);
+        slot.fields.insert("DelayFreeContext", 0x40);
+        let map = layout.types.get_mut("_HEAP_VS_SLOT_MAP").unwrap();
+        map.size = 4;
+        map.fields.insert("SlotRef", 0);
+        layout
+    }
+
+    #[test]
+    fn test_provenance_selects_validated_vs_families_without_build_thresholds() {
+        let inline = inline_vs_fixture()
+            .provenance(pdb_module(0x1111_2222))
+            .unwrap();
+        let affinity = affinity_vs_fixture()
+            .provenance(pdb_module(0x3333_4444))
+            .unwrap();
+
+        assert_eq!(inline.semantic_family, VsSemanticFamily::Inline);
+        assert_eq!(affinity.semantic_family, VsSemanticFamily::AffinitySlots);
+        assert_ne!(inline.fingerprint, affinity.fingerprint);
+        assert_eq!(inline.module.symbol_file, r"C:\symbols\ntkrnlmp.pdb");
+        let inline_fixture = inline_vs_fixture();
+        assert_eq!(
+            inline_fixture.type_layout("_HEAP_VS_CONTEXT").unwrap().size,
+            0xc0
+        );
+        assert_eq!(
+            inline_fixture.field("_HEAP_VS_CONTEXT", "DelayFreeContext"),
+            Ok(0x40)
+        );
+        let affinity_fixture = affinity_vs_fixture();
+        assert_eq!(
+            affinity_fixture
+                .type_layout("_HEAP_VS_AFFINITY_SLOT")
+                .unwrap()
+                .size,
+            0x80
+        );
+        assert_eq!(
+            affinity_fixture.field("_HEAP_VS_CONTEXT", "SlotMapRef"),
+            Ok(0)
+        );
+    }
+
+    #[test]
+    fn test_provenance_fails_closed_for_missing_or_conflicting_families() {
+        let unknown = PoolLayout::resolve(&FakeSymbols::default(), key()).unwrap();
+        assert!(
+            unknown
+                .provenance(pdb_module(0xdead_beef))
+                .unwrap_err()
+                .to_string()
+                .contains("no recognized VS structural family")
+        );
+
+        let mut conflicting = affinity_vs_fixture();
+        conflicting
+            .types
+            .get_mut("_HEAP_VS_CONTEXT")
+            .unwrap()
+            .fields
+            .insert("FreeChunkTree", 0x10);
+        conflicting
+            .types
+            .get_mut("_HEAP_VS_CONTEXT")
+            .unwrap()
+            .fields
+            .insert("DelayFreeContext", 0x40);
+        assert!(
+            conflicting
+                .provenance(pdb_module(0xdead_beef))
+                .unwrap_err()
+                .to_string()
+                .contains("layout is ambiguous")
+        );
+        let unknown_error = unknown
+            .provenance(pdb_module(0xdead_beef))
+            .unwrap_err()
+            .to_string();
+        assert!(unknown_error.contains("fnv1a64:"), "{unknown_error}");
+    }
+
+    #[test]
+    fn test_fingerprint_changes_when_a_pdb_field_offset_changes() {
+        let first = inline_vs_fixture()
+            .provenance(pdb_module(0x1111_2222))
+            .unwrap();
+        let mut changed = inline_vs_fixture();
+        changed
+            .types
+            .get_mut("_HEAP_VS_CONTEXT")
+            .unwrap()
+            .fields
+            .insert("FreeChunkTree", 0x18);
+        let changed = changed.provenance(pdb_module(0x3333_4444)).unwrap();
+
+        assert_ne!(first.fingerprint, changed.fingerprint);
     }
 }

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -556,6 +556,15 @@ pub(crate) enum LayoutTarget {
     User,
 }
 
+impl LayoutTarget {
+    fn probe_type(self) -> &'static str {
+        match self {
+            Self::Kernel => "_POOL_HEADER",
+            Self::User => "_PEB",
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct LayoutCache {
     entries: Mutex<HashMap<(LayoutTarget, LayoutKey), AllocatorSchema>>,
@@ -574,6 +583,13 @@ impl LayoutCache {
         target: LayoutTarget,
     ) -> Result<AllocatorSchema, LayoutError> {
         let key = key.into();
+        // A cached schema can be shared by multiple DebugEngine instances. Probe a required
+        // type on this engine before accepting the hit so DbgEng loads deferred symbols here,
+        // rather than trusting that the engine which populated the global cache loaded them.
+        let probe = target.probe_type();
+        symbols
+            .type_id(key.image.base, probe)
+            .map_err(|_| LayoutError::Missing { item: probe.into() })?;
         let cache_key = (target, key);
         if let Some(layout) = self.entries.lock().unwrap().get(&cache_key).cloned() {
             return Ok(layout);
@@ -605,6 +621,7 @@ mod tests {
         /// How many times a layout has actually been resolved through these symbols, so a
         /// cache hit can be told from a re-resolution rather than inferred from equal results.
         resolutions: Cell<usize>,
+        type_lookups: Cell<usize>,
         fallback_aliases: bool,
         optional_fields: bool,
         missing_global: Option<&'static str>,
@@ -681,6 +698,7 @@ mod tests {
         }
 
         fn type_id(&self, _module: u64, name: &str) -> Result<u32, DbgEngError> {
+            self.type_lookups.set(self.type_lookups.get() + 1);
             if self.missing_type == Some(name) {
                 return Self::error();
             }
@@ -795,6 +813,46 @@ mod tests {
             symbols.resolutions.get() > resolved_after_kernel,
             "one image key may not alias two module-specific resolver modes"
         );
+    }
+
+    #[test]
+    fn test_layout_cache_hit_still_probes_symbols_on_the_current_engine() {
+        let cache = LayoutCache::default();
+        cache
+            .get_or_resolve(&FakeSymbols::default(), key(), LayoutTarget::Kernel)
+            .unwrap();
+
+        let deferred = FakeSymbols {
+            missing_type: Some(LayoutTarget::Kernel.probe_type()),
+            ..FakeSymbols::default()
+        };
+        assert_eq!(
+            missing_item(cache.get_or_resolve(&deferred, key(), LayoutTarget::Kernel)),
+            "_POOL_HEADER",
+            "a cache hit must probe the current engine instead of inheriting another engine's \
+             symbol-loaded state"
+        );
+        assert_eq!(deferred.type_lookups.get(), 1);
+
+        cache
+            .get_or_resolve(
+                &FakeSymbols {
+                    optional_fields: true,
+                    ..FakeSymbols::default()
+                },
+                key(),
+                LayoutTarget::User,
+            )
+            .unwrap();
+        let deferred_user = FakeSymbols {
+            missing_type: Some(LayoutTarget::User.probe_type()),
+            ..FakeSymbols::default()
+        };
+        assert_eq!(
+            missing_item(cache.get_or_resolve(&deferred_user, key(), LayoutTarget::User)),
+            "_PEB"
+        );
+        assert_eq!(deferred_user.type_lookups.get(), 1);
     }
 
     fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -72,13 +72,46 @@ pub(crate) enum LayoutError {
     Missing { item: String },
     #[error("unsupported allocator layout {fingerprint}: {detail}")]
     Unsupported { fingerprint: String, detail: String },
+    #[error("allocator layout resolution was interrupted on request")]
+    Interrupted,
+    #[error("allocator layout resolution ran out of its walk budget")]
+    BudgetExpired,
+    #[error("polling allocator layout resolution failed: {detail}")]
+    Poll { detail: String },
 }
 
 pub(crate) trait Symbols {
+    fn poll(&self) -> Result<(), LayoutError> {
+        Ok(())
+    }
+
     fn symbol(&self, name: &str) -> Result<u64, DbgEngError>;
     fn type_id(&self, module: u64, name: &str) -> Result<u32, DbgEngError>;
     fn type_size(&self, module: u64, type_id: u32) -> Result<u32, DbgEngError>;
     fn field(&self, module: u64, type_id: u32, name: &str) -> Result<u32, DbgEngError>;
+}
+
+fn polled<T>(
+    symbols: &impl Symbols,
+    lookup: impl FnOnce() -> Result<T, DbgEngError>,
+) -> Result<Result<T, DbgEngError>, LayoutError> {
+    symbols.poll()?;
+    let result = lookup();
+    symbols.poll()?;
+    Ok(result)
+}
+
+fn first_available<T>(
+    symbols: &impl Symbols,
+    aliases: &[&str],
+    mut lookup: impl FnMut(&str) -> Result<T, DbgEngError>,
+) -> Result<Option<T>, LayoutError> {
+    for alias in aliases {
+        if let Ok(value) = polled(symbols, || lookup(alias))? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
 }
 
 impl Symbols for DebugEngine {
@@ -317,24 +350,24 @@ fn resolve_type(
     module: u64,
     spec: &TypeSpec,
 ) -> Result<TypeLayout, LayoutError> {
-    let type_id = symbols
-        .type_id(module, spec.name)
-        .map_err(|_| LayoutError::Missing {
+    let type_id = polled(symbols, || symbols.type_id(module, spec.name))?.map_err(|_| {
+        LayoutError::Missing {
             item: spec.name.into(),
-        })?;
-    let size = symbols
-        .type_size(module, type_id)
-        .map_err(|_| LayoutError::Missing {
+        }
+    })?;
+    let size = polled(symbols, || symbols.type_size(module, type_id))?.map_err(|_| {
+        LayoutError::Missing {
             item: spec.name.into(),
-        })?;
+        }
+    })?;
     let mut fields = HashMap::new();
     for &(canonical, aliases) in spec.fields {
-        let offset = aliases
-            .iter()
-            .find_map(|field| symbols.field(module, type_id, field).ok())
-            .ok_or_else(|| LayoutError::Missing {
-                item: format!("{}.{canonical}", spec.name),
-            })?;
+        let offset = first_available(symbols, aliases, |field| {
+            symbols.field(module, type_id, field)
+        })?
+        .ok_or_else(|| LayoutError::Missing {
+            item: format!("{}.{canonical}", spec.name),
+        })?;
         fields.insert(canonical, offset);
     }
     Ok(TypeLayout { size, fields })
@@ -344,21 +377,21 @@ fn apply_optional_fields(
     symbols: &impl Symbols,
     module: u64,
     types: &mut HashMap<&'static str, TypeLayout>,
-) {
+) -> Result<(), LayoutError> {
     for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
         let Some(layout) = types.get_mut(type_name) else {
             continue;
         };
-        let Ok(type_id) = symbols.type_id(module, type_name) else {
+        let Ok(type_id) = polled(symbols, || symbols.type_id(module, type_name))? else {
             continue;
         };
-        if let Some(offset) = aliases
-            .iter()
-            .find_map(|field| symbols.field(module, type_id, field).ok())
-        {
+        if let Some(offset) = first_available(symbols, aliases, |field| {
+            symbols.field(module, type_id, field)
+        })? {
             layout.fields.insert(canonical, offset);
         }
     }
+    Ok(())
 }
 
 impl AllocatorSchema {
@@ -410,16 +443,14 @@ impl AllocatorSchema {
     pub(crate) fn resolve(symbols: &impl Symbols, key: LayoutKey) -> Result<Self, LayoutError> {
         let mut globals = HashMap::new();
         for &(canonical, aliases) in GLOBALS {
-            let value = aliases
-                .iter()
-                .find_map(|name| symbols.symbol(name).ok())
+            let value = first_available(symbols, aliases, |name| symbols.symbol(name))?
                 .ok_or_else(|| LayoutError::Missing {
                     item: canonical.into(),
                 })?;
             globals.insert(canonical, value);
         }
         for &(canonical, aliases) in OPTIONAL_GLOBALS {
-            if let Some(value) = aliases.iter().find_map(|name| symbols.symbol(name).ok()) {
+            if let Some(value) = first_available(symbols, aliases, |name| symbols.symbol(name))? {
                 globals.insert(canonical, value);
             }
         }
@@ -428,11 +459,15 @@ impl AllocatorSchema {
             types.insert(spec.name, resolve_type(symbols, key.image.base, spec)?);
         }
         for spec in OPTIONAL_TYPES {
-            if let Ok(layout) = resolve_type(symbols, key.image.base, spec) {
-                types.insert(spec.name, layout);
+            match resolve_type(symbols, key.image.base, spec) {
+                Ok(layout) => {
+                    types.insert(spec.name, layout);
+                }
+                Err(LayoutError::Missing { .. }) => {}
+                Err(error) => return Err(error),
             }
         }
-        apply_optional_fields(symbols, key.image.base, &mut types);
+        apply_optional_fields(symbols, key.image.base, &mut types)?;
         Ok(Self {
             key,
             globals,
@@ -445,17 +480,14 @@ impl AllocatorSchema {
         symbols: &impl Symbols,
         key: LayoutKey,
     ) -> Result<Self, LayoutError> {
-        let globals = [("RtlpHpHeapGlobals", "ntdll!RtlpHpHeapGlobals")]
-            .into_iter()
-            .map(|(canonical, symbol)| {
-                symbols
-                    .symbol(symbol)
-                    .map(|value| (canonical, value))
-                    .map_err(|_| LayoutError::Missing {
-                        item: canonical.into(),
-                    })
-            })
-            .collect::<Result<HashMap<_, _>, _>>()?;
+        let mut globals = HashMap::new();
+        let global =
+            polled(symbols, || symbols.symbol("ntdll!RtlpHpHeapGlobals"))?.map_err(|_| {
+                LayoutError::Missing {
+                    item: "RtlpHpHeapGlobals".into(),
+                }
+            })?;
+        globals.insert("RtlpHpHeapGlobals", global);
 
         let excluded = [
             "_EX_POOL_HEAP_MANAGER_STATE",
@@ -476,11 +508,15 @@ impl AllocatorSchema {
             if spec.name == "_POOL_TRACKER_BIG_PAGES" {
                 continue;
             }
-            if let Ok(layout) = resolve_type(symbols, key.image.base, spec) {
-                types.insert(spec.name, layout);
+            match resolve_type(symbols, key.image.base, spec) {
+                Ok(layout) => {
+                    types.insert(spec.name, layout);
+                }
+                Err(LayoutError::Missing { .. }) => {}
+                Err(error) => return Err(error),
             }
         }
-        apply_optional_fields(symbols, key.image.base, &mut types);
+        apply_optional_fields(symbols, key.image.base, &mut types)?;
         if !types
             .get("_SEGMENT_HEAP")
             .is_some_and(|layout| layout.fields.contains_key("Signature"))
@@ -587,8 +623,7 @@ impl LayoutCache {
         // type on this engine before accepting the hit so DbgEng loads deferred symbols here,
         // rather than trusting that the engine which populated the global cache loaded them.
         let probe = target.probe_type();
-        symbols
-            .type_id(key.image.base, probe)
+        polled(symbols, || symbols.type_id(key.image.base, probe))?
             .map_err(|_| LayoutError::Missing { item: probe.into() })?;
         let cache_key = (target, key);
         if let Some(layout) = self.entries.lock().unwrap().get(&cache_key).cloned() {
@@ -622,6 +657,9 @@ mod tests {
         /// cache hit can be told from a re-resolution rather than inferred from equal results.
         resolutions: Cell<usize>,
         type_lookups: Cell<usize>,
+        polls: Cell<usize>,
+        budget_after_polls: Option<usize>,
+        interrupt_after_polls: Option<usize>,
         fallback_aliases: bool,
         optional_fields: bool,
         missing_global: Option<&'static str>,
@@ -681,6 +719,24 @@ mod tests {
     }
 
     impl Symbols for FakeSymbols {
+        fn poll(&self) -> Result<(), LayoutError> {
+            let polls = self.polls.get();
+            self.polls.set(polls + 1);
+            if self
+                .interrupt_after_polls
+                .is_some_and(|allowed| polls >= allowed)
+            {
+                return Err(LayoutError::Interrupted);
+            }
+            if self
+                .budget_after_polls
+                .is_some_and(|allowed| polls >= allowed)
+            {
+                return Err(LayoutError::BudgetExpired);
+            }
+            Ok(())
+        }
+
         fn symbol(&self, name: &str) -> Result<u64, DbgEngError> {
             self.resolutions.set(self.resolutions.get() + 1);
             if self.missing_global == Some(name) {
@@ -855,10 +911,61 @@ mod tests {
         assert_eq!(deferred_user.type_lookups.get(), 1);
     }
 
+    #[test]
+    fn test_layout_resolution_stops_on_budget_or_interrupt_polls() {
+        let budgeted = FakeSymbols {
+            optional_fields: true,
+            budget_after_polls: Some(6),
+            ..FakeSymbols::default()
+        };
+        assert_eq!(
+            LayoutCache::default().get_or_resolve(&budgeted, key(), LayoutTarget::User),
+            Err(LayoutError::BudgetExpired)
+        );
+        assert_eq!(budgeted.polls.get(), 7);
+
+        let interrupted = FakeSymbols {
+            optional_fields: true,
+            interrupt_after_polls: Some(4),
+            ..FakeSymbols::default()
+        };
+        assert_eq!(
+            LayoutCache::default().get_or_resolve(&interrupted, key(), LayoutTarget::User),
+            Err(LayoutError::Interrupted)
+        );
+        assert_eq!(interrupted.polls.get(), 5);
+    }
+
+    #[test]
+    fn test_cached_layout_still_checks_the_current_resolution_budget() {
+        let cache = LayoutCache::default();
+        cache
+            .get_or_resolve(
+                &FakeSymbols {
+                    optional_fields: true,
+                    ..FakeSymbols::default()
+                },
+                key(),
+                LayoutTarget::User,
+            )
+            .unwrap();
+
+        let expired = FakeSymbols {
+            budget_after_polls: Some(0),
+            ..FakeSymbols::default()
+        };
+        assert_eq!(
+            cache.get_or_resolve(&expired, key(), LayoutTarget::User),
+            Err(LayoutError::BudgetExpired),
+            "a cache hit may not bypass the caller's deadline"
+        );
+        assert_eq!(expired.type_lookups.get(), 0);
+    }
+
     fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {
         match result.unwrap_err() {
             LayoutError::Missing { item } => item,
-            LayoutError::Unsupported { .. } => panic!("expected a missing symbol error"),
+            other => panic!("expected a missing symbol error, got {other}"),
         }
     }
 

--- a/src/pool/layout.rs
+++ b/src/pool/layout.rs
@@ -340,6 +340,27 @@ fn resolve_type(
     Ok(TypeLayout { size, fields })
 }
 
+fn apply_optional_fields(
+    symbols: &impl Symbols,
+    module: u64,
+    types: &mut HashMap<&'static str, TypeLayout>,
+) {
+    for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
+        let Some(layout) = types.get_mut(type_name) else {
+            continue;
+        };
+        let Ok(type_id) = symbols.type_id(module, type_name) else {
+            continue;
+        };
+        if let Some(offset) = aliases
+            .iter()
+            .find_map(|field| symbols.field(module, type_id, field).ok())
+        {
+            layout.fields.insert(canonical, offset);
+        }
+    }
+}
+
 impl AllocatorSchema {
     pub(crate) fn is_user(&self) -> bool {
         !self.globals.contains_key("ExPoolState") && self.globals.contains_key("RtlpHpHeapGlobals")
@@ -411,20 +432,7 @@ impl AllocatorSchema {
                 types.insert(spec.name, layout);
             }
         }
-        for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
-            let Some(layout) = types.get_mut(type_name) else {
-                continue;
-            };
-            let Ok(type_id) = symbols.type_id(key.image.base, type_name) else {
-                continue;
-            };
-            if let Some(offset) = aliases
-                .iter()
-                .find_map(|field| symbols.field(key.image.base, type_id, field).ok())
-            {
-                layout.fields.insert(canonical, offset);
-            }
-        }
+        apply_optional_fields(symbols, key.image.base, &mut types);
         Ok(Self {
             key,
             globals,
@@ -461,6 +469,9 @@ impl AllocatorSchema {
         for spec in USER_TYPES {
             types.insert(spec.name, resolve_type(symbols, key.image.base, spec)?);
         }
+        // Kernel-only optional lookaside types are intentionally tolerated when `ntdll`
+        // omits them. The big-page tracker alone is skipped explicitly because interpreting
+        // it requires the kernel-only global table and dedicated discovery path.
         for spec in OPTIONAL_TYPES {
             if spec.name == "_POOL_TRACKER_BIG_PAGES" {
                 continue;
@@ -469,20 +480,7 @@ impl AllocatorSchema {
                 types.insert(spec.name, layout);
             }
         }
-        for &(type_name, canonical, aliases) in OPTIONAL_FIELDS {
-            let Some(layout) = types.get_mut(type_name) else {
-                continue;
-            };
-            let Ok(type_id) = symbols.type_id(key.image.base, type_name) else {
-                continue;
-            };
-            if let Some(offset) = aliases
-                .iter()
-                .find_map(|field| symbols.field(key.image.base, type_id, field).ok())
-            {
-                layout.fields.insert(canonical, offset);
-            }
-        }
+        apply_optional_fields(symbols, key.image.base, &mut types);
         if !types
             .get("_SEGMENT_HEAP")
             .is_some_and(|layout| layout.fields.contains_key("Signature"))
@@ -552,9 +550,15 @@ impl AllocatorSchema {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum LayoutTarget {
+    Kernel,
+    User,
+}
+
 #[derive(Default)]
 pub(crate) struct LayoutCache {
-    entries: Mutex<HashMap<LayoutKey, AllocatorSchema>>,
+    entries: Mutex<HashMap<(LayoutTarget, LayoutKey), AllocatorSchema>>,
 }
 
 impl LayoutCache {
@@ -567,13 +571,21 @@ impl LayoutCache {
         &self,
         symbols: &impl Symbols,
         key: impl Into<LayoutKey>,
+        target: LayoutTarget,
     ) -> Result<AllocatorSchema, LayoutError> {
         let key = key.into();
-        if let Some(layout) = self.entries.lock().unwrap().get(&key).cloned() {
+        let cache_key = (target, key);
+        if let Some(layout) = self.entries.lock().unwrap().get(&cache_key).cloned() {
             return Ok(layout);
         }
-        let layout = AllocatorSchema::resolve(symbols, key)?;
-        self.entries.lock().unwrap().insert(key, layout.clone());
+        let layout = match target {
+            LayoutTarget::Kernel => AllocatorSchema::resolve(symbols, key),
+            LayoutTarget::User => AllocatorSchema::resolve_user(symbols, key),
+        }?;
+        self.entries
+            .lock()
+            .unwrap()
+            .insert(cache_key, layout.clone());
         Ok(layout)
     }
 
@@ -718,11 +730,15 @@ mod tests {
         let symbols = FakeSymbols::default();
         let cache = LayoutCache::default();
         let resolve = |key: LayoutKey| {
-            let layout = cache.get_or_resolve(&symbols, key).unwrap();
+            let layout = cache
+                .get_or_resolve(&symbols, key, LayoutTarget::Kernel)
+                .unwrap();
             (symbols.resolutions.get(), layout.key.image)
         };
         let through_an_engine = |key: SessionKey| {
-            let layout = cache.get_or_resolve(&symbols, key).unwrap();
+            let layout = cache
+                .get_or_resolve(&symbols, key, LayoutTarget::Kernel)
+                .unwrap();
             (symbols.resolutions.get(), layout.key.image)
         };
 
@@ -756,6 +772,29 @@ mod tests {
             "a second build at one base must not be served the first build's layout"
         );
         assert_eq!(resolved, other_build);
+    }
+
+    #[test]
+    fn test_layout_cache_keeps_kernel_and_user_resolvers_separate() {
+        let symbols = FakeSymbols {
+            optional_fields: true,
+            ..FakeSymbols::default()
+        };
+        let cache = LayoutCache::default();
+        let kernel = cache
+            .get_or_resolve(&symbols, key(), LayoutTarget::Kernel)
+            .unwrap();
+        let resolved_after_kernel = symbols.resolutions.get();
+        let user = cache
+            .get_or_resolve(&symbols, key(), LayoutTarget::User)
+            .unwrap();
+
+        assert!(!kernel.is_user());
+        assert!(user.is_user());
+        assert!(
+            symbols.resolutions.get() > resolved_after_kernel,
+            "one image key may not alias two module-specific resolver modes"
+        );
     }
 
     fn missing_item(result: Result<PoolLayout, LayoutError>) -> String {

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -21,7 +21,7 @@ use windows::Win32::System::Diagnostics::Debug::Extensions::{
 
 use super::decode::parse_tag;
 use super::index::{PoolIndex, SnapshotCache};
-use super::layout::{LayoutCache, SessionKey};
+use super::layout::{LayoutCache, LayoutTarget, SessionKey};
 use super::snapshot::{SnapshotError, SnapshotWalker, WalkStalls};
 use super::{PoolBackend, PoolDiagnostics, PoolSpan, PoolState};
 use crate::dbgeng::{DbgEngError, DebugEngine};
@@ -366,7 +366,7 @@ pub(crate) fn prepare_index(
     // kernels load at one address share a layout, which is not a leak but wrong data reported
     // confidently.
     let layout = LayoutCache::global()
-        .get_or_resolve(engine, key)
+        .get_or_resolve(engine, key, LayoutTarget::Kernel)
         .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
     let module = engine.module_identity("nt")?;
     if !module.symbols.has_type_info() || module.symbol_file.is_empty() {

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -12,6 +12,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use std::time::Instant;
 
 use thiserror::Error;
 use windows::Win32::System::Diagnostics::Debug::Extensions::{
@@ -58,6 +59,22 @@ pub(crate) fn invalidate_session() {
     LayoutCache::global().invalidate();
 }
 
+/// Invalidate every cached allocator snapshot and schema for a programmatic host.
+///
+/// WinDbg extensions receive session notifications and do this automatically. A host that
+/// resumes or replaces a target through the API knows about that transition directly and calls
+/// this at the same boundary.
+pub fn invalidate_allocator_caches() {
+    invalidate_session();
+    crate::heap::invalidate_caches();
+}
+
+/// Invalidate target-memory snapshots after execution while retaining immutable PDB layouts.
+pub fn invalidate_allocator_snapshots() {
+    snapshots().invalidate();
+    crate::heap::invalidate_snapshot();
+}
+
 /// Why a pool query could not be answered.
 ///
 /// These are deliberately distinct variants rather than one string: a caller needs to
@@ -80,7 +97,7 @@ pub enum PoolQueryError {
     #[error("tag must contain 1..4 ASCII bytes")]
     InvalidTag,
 
-    #[error("resolving pool layout failed: {0}")]
+    #[error("resolving pool layout failed ({0}); run `.reload /f nt` and retry")]
     Layout(String),
 
     /// The walk was stopped on request (Ctrl+C / `SetInterrupt`) and its snapshot discarded.
@@ -207,6 +224,7 @@ pub struct PoolTagSummary {
 /// reached almost none of the pool" — those look identical without the walk's own diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoolSnapshotReport {
+    pub layout: crate::allocator::LayoutProvenance,
     pub total_chunks: usize,
     pub allocated_chunks: usize,
     /// How much of the pool the walk actually covered, and — when it fell short — what stopped
@@ -284,6 +302,7 @@ pub fn snapshot_report(
 
 fn report_of(index: &PoolIndex) -> PoolSnapshotReport {
     PoolSnapshotReport {
+        layout: index.layout.clone(),
         total_chunks: index.spans.len(),
         allocated_chunks: index
             .spans
@@ -312,6 +331,7 @@ pub(crate) fn prepare_index(
     engine: &DebugEngine,
     walk: PoolWalk,
 ) -> Result<PoolIndex, PoolQueryError> {
+    let started = Instant::now();
     if !engine.is_kernel_target()? {
         return Err(PoolQueryError::NotKernelTarget);
     }
@@ -348,17 +368,31 @@ pub(crate) fn prepare_index(
     let layout = LayoutCache::global()
         .get_or_resolve(engine, key)
         .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
+    let module = engine.module_identity("nt")?;
+    if !module.symbols.has_type_info() || module.symbol_file.is_empty() {
+        return Err(PoolQueryError::Layout(
+            "DbgEng did not load private PDB type information for nt".into(),
+        ));
+    }
+    let provenance = layout
+        .provenance(module)
+        .map_err(|error| PoolQueryError::Layout(error.to_string()))?;
+    let remaining = walk
+        .budget
+        .map(|budget| budget.saturating_sub(started.elapsed()));
 
     // Keyed on the whole `SessionKey`: a programmatic host receives no session
     // notifications, so the generation alone would let a snapshot outlive its target.
     snapshots()
         .get_or_refresh(key, walk.refresh, || {
-            SnapshotWalker {
+            let mut snapshot = SnapshotWalker {
                 memory: engine,
                 layout: &layout,
                 traversal_limit: 1_000_000,
             }
-            .walk(walk.budget)
+            .walk(remaining)?;
+            snapshot.layout = provenance;
+            Ok(snapshot)
         })
         // Mapped from the walk's own error type rather than from a string it was flattened
         // into: an interrupt is the one stop here that is not a failure, and a `to_string()`
@@ -658,6 +692,7 @@ mod tests {
             header_address: chunk + VS_HEADER,
             usable_address: chunk + VS_HEADER + POOL_HEADER,
             size: chunk_size - VS_HEADER - POOL_HEADER,
+            requested_size: None,
             raw_tag,
             display_tag: crate::pool::decode::display_tag(raw_tag),
             pool_kind: PoolKind::NonPagedNx,
@@ -698,6 +733,7 @@ mod tests {
             header_address: slot,
             usable_address: slot + POOL_HEADER,
             size: unit - POOL_HEADER,
+            requested_size: None,
             raw_tag,
             display_tag: crate::pool::decode::display_tag(raw_tag),
             pool_kind: PoolKind::NonPagedNx,

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -408,6 +408,7 @@ mod tests {
         spans[3].subsegment = Some(2);
         spans[4].subsegment = Some(2);
         let index = PoolIndex::build(PoolSnapshot {
+            layout: Default::default(),
             spans,
             complete: true,
             budget_expired: false,
@@ -501,6 +502,7 @@ mod tests {
             many.push(value);
         }
         let many_index = PoolIndex::build(PoolSnapshot {
+            layout: Default::default(),
             spans: many,
             complete: true,
             budget_expired: false,

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -6,8 +6,8 @@ use thiserror::Error;
 
 use super::decode::{
     PAGE_SIZE, PoolHeaderLayout, SpecialPoolHeader, adjust_page_end_header, big_page_probe,
-    decode_descriptor_at, decode_large_allocation, decode_lfh_subsegment, decode_pool_header,
-    decode_rb_root, decode_slist_header_next, decode_special_pool_header, decode_vs_chunk,
+    decode_descriptor_at, decode_large_requested_size, decode_lfh_subsegment, decode_pool_header,
+    decode_rb_root_for, decode_slist_header_next, decode_special_pool_header, decode_vs_chunk,
     descriptor_backend, lfh_bitmap_state, read_u16, read_u32, read_u64,
     valid_descriptor_tree_signature, valid_page_segment_signature, valid_vs_signature,
 };
@@ -96,6 +96,7 @@ fn missing_layout(item: impl Into<String>) -> SnapshotError {
 pub(crate) struct PoolRegion {
     pub address: u64,
     pub size: usize,
+    pub requested_size: Option<u64>,
     pub pool_kind: PoolKind,
     pub numa_node: u16,
     pub heap: HeapIdentity,
@@ -358,7 +359,12 @@ fn tree_nodes(
     } else {
         false
     };
-    let Some(root) = decode_rb_root(root_value, tree_address, encoded) else {
+    let decoded_root = if layout.is_user() {
+        decode_rb_root_for(root_value, tree_address, encoded, true)
+    } else {
+        super::decode::decode_rb_root(root_value, tree_address, encoded)
+    };
+    let Some(root) = decoded_root else {
         diagnostics.push(format!("rejecting corrupt {label} root {root_value:#x}"));
         return Ok(Vec::new());
     };
@@ -607,9 +613,9 @@ struct VsRoot {
 /// Resolves where a VS context keeps its free-chunk state. Both shapes are supported,
 /// because a debugger host does not get to choose which build it is pointed at:
 ///
-/// * **pre-26100** — `FreeChunkTree`/`DelayFreeContext` are inline in `_HEAP_VS_CONTEXT`,
+/// * **inline family** — `FreeChunkTree`/`DelayFreeContext` are in `_HEAP_VS_CONTEXT`,
 ///   so there is exactly one root: the context itself.
-/// * **26100+** — they moved into `_HEAP_VS_AFFINITY_SLOT`s reached through a slot map.
+/// * **affinity-slot family** — they live in `_HEAP_VS_AFFINITY_SLOT`s reached through a slot map.
 ///   `SlotMapRef` and each `SlotRef` are offsets *from the context*, scaled by 64 bytes,
 ///   and the map holds `AffinityMask + 1` entries. Entries routinely share a slot, so the
 ///   result is deduplicated.
@@ -758,8 +764,8 @@ fn discover_vs_evidence(
         .map_or(0, |value| value.size as u64);
     if let Ok(list_offset) = layout.field("_HEAP_VS_DELAY_FREE_CONTEXT", "ListHead") {
         for root in &roots {
-            // Pre-26100 the delay-free list sits beside the tree in the context; from
-            // 26100 it is per-slot. Either way it is a known offset from `root.base`.
+            // In the inline family the delay-free list sits beside the tree in the context;
+            // in the affinity family it is per-slot. Either way it is known from `root.base`.
             let Some(delay_offset) = root.delay_offset else {
                 continue;
             };
@@ -1204,6 +1210,7 @@ fn discover_segment_context(
             discovery.regions.push(PoolRegion {
                 address: region_address,
                 size: region_size,
+                requested_size: None,
                 pool_kind,
                 numa_node,
                 heap: identity,
@@ -1280,7 +1287,13 @@ fn discover_large_allocations(
         };
         let Some((virtual_address, pages)) = read_u64(&allocation, virtual_offset)
             .zip(read_u64(&allocation, pages_offset))
-            .and_then(|(virtual_address, pages)| decode_large_allocation(virtual_address, pages))
+            .and_then(|(virtual_address, pages)| {
+                if layout.is_user() {
+                    super::decode::decode_large_allocation_for(virtual_address, pages, true)
+                } else {
+                    super::decode::decode_large_allocation(virtual_address, pages)
+                }
+            })
         else {
             continue;
         };
@@ -1291,14 +1304,26 @@ fn discover_large_allocations(
             continue;
         }
         let bytes = pages.saturating_mul(PAGE_SIZE);
-        let (tag, tracked_size) = match lookup_big_page_target(
-            memory,
-            layout,
-            virtual_address,
-            &mut discovery.diagnostics,
-        )? {
-            Some(value) => value,
-            None => (0, bytes),
+        // In the validated x64 layout `UnusedBytes` aliases the low 16 bits of the
+        // `VirtualAddress` word. Only recover an exact request when the PDB confirms that
+        // alias and the encoded value fits inside the allocation.
+        let validated_unused_bytes = layout
+            .field("_HEAP_LARGE_ALLOC_DATA", "UnusedBytes")
+            .is_ok_and(|offset| offset == virtual_offset);
+        let requested_size = read_u64(&allocation, virtual_offset)
+            .and_then(|word| decode_large_requested_size(word, bytes, validated_unused_bytes));
+        let (tag, tracked_size) = if layout.is_user() {
+            (0, bytes)
+        } else {
+            match lookup_big_page_target(
+                memory,
+                layout,
+                virtual_address,
+                &mut discovery.diagnostics,
+            )? {
+                Some(value) => value,
+                None => (0, bytes),
+            }
         };
         let size = tracked_size.min(bytes).min(usize::MAX as u64) as usize;
         let Ok(pool_header) = layout.pool_header_layout() else {
@@ -1307,6 +1332,7 @@ fn discover_large_allocations(
         discovery.regions.push(PoolRegion {
             address: virtual_address,
             size,
+            requested_size: layout.is_user().then_some(requested_size).flatten(),
             pool_kind,
             numa_node,
             heap: identity,
@@ -1581,6 +1607,7 @@ impl FromIterator<String> for PoolDiagnostics {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PoolSnapshot {
+    pub layout: crate::allocator::LayoutProvenance,
     pub spans: Vec<PoolSpan>,
     pub diagnostics: PoolDiagnostics,
     pub complete: bool,
@@ -2085,6 +2112,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             header_address: header,
             usable_address: usable,
             size,
+            requested_size: region.requested_size,
             raw_tag: tag,
             display_tag: super::decode::display_tag(tag),
             pool_kind: region.pool_kind,
@@ -2327,11 +2355,16 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
                 break;
             }
             let candidate = header_address + region.vs_header_size as u64;
-            let Some(physical_header) =
-                adjust_page_end_header(candidate, region.pool_header.size as u64)
-            else {
-                snapshot.complete = false;
-                break;
+            let physical_header = if region.pool_header.size == 0 {
+                candidate
+            } else {
+                let Some(header) =
+                    adjust_page_end_header(candidate, region.pool_header.size as u64)
+                else {
+                    snapshot.complete = false;
+                    break;
+                };
+                header
             };
             let pool_offset = physical_header.saturating_sub(base) as usize;
             let tag = decode_pool_header(bytes, pool_offset, region.pool_header)
@@ -2348,9 +2381,14 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             let overhead = physical_header
                 .saturating_sub(header_address)
                 .saturating_add(region.pool_header.size as u64);
+            let span_header = if region.pool_header.size == 0 {
+                header_address
+            } else {
+                physical_header
+            };
             let mut span = self.base_span(
                 region,
-                physical_header,
+                span_header,
                 physical_header + region.pool_header.size as u64,
                 (chunk_size as u64).saturating_sub(overhead),
                 tag,
@@ -2449,6 +2487,114 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     }
 }
 
+/// Walk user-mode Segment Heap roots through the same region discovery and backend decoders
+/// used for kernel pool heaps.
+///
+/// The adapter supplies user addresses and a zero-sized pool header through `layout`; everything
+/// below the root enumeration—page segments, descriptors, LFH bitmaps, VS chains, free-state
+/// evidence, large allocations, diagnostics, caps, and deadlines—is shared.
+pub(crate) fn walk_user_segment_heaps<M: PoolMemory>(
+    memory: &M,
+    layout: &PoolLayout,
+    peb: u64,
+    heaps: &[u64],
+    budget: Option<Duration>,
+    traversal_limit: usize,
+) -> Result<PoolSnapshot, SnapshotError> {
+    let (discovery_deadline, walk_deadline) = budget_deadlines(Instant::now(), budget);
+    let discovery_clock = Budgeted::new(memory, discovery_deadline);
+    let globals_address = *layout
+        .globals
+        .get("RtlpHpHeapGlobals")
+        .ok_or_else(|| missing_layout("RtlpHpHeapGlobals"))?;
+    let heap_key = scalar(
+        &discovery_clock,
+        globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "HeapKey")? as u64,
+        8,
+    )?;
+    let lfh_key = scalar(
+        &discovery_clock,
+        globals_address + layout.field("_RTLP_HP_HEAP_GLOBALS", "LfhKey")? as u64,
+        8,
+    )?;
+
+    let mut discovery = Discovery::default();
+    let mut expired = false;
+    for &heap in heaps {
+        let identity = HeapIdentity {
+            pool_state: peb,
+            heap,
+            special: false,
+        };
+        match discover_heap_regions(
+            &discovery_clock,
+            layout,
+            heap,
+            0,
+            PoolKind::NonPagedNx,
+            identity,
+            None,
+            heap_key,
+            lfh_key,
+            traversal_limit,
+            &mut discovery,
+        ) {
+            Ok(()) => {}
+            Err(SnapshotError::BudgetExpired) => {
+                expired = true;
+                break;
+            }
+            Err(error) if error.halts_walk() => return Err(error),
+            Err(error) => discovery
+                .diagnostics
+                .push(format!("cannot fully discover heap {heap:#x}: {error}")),
+        }
+    }
+
+    let mut snapshot = PoolSnapshot {
+        complete: discovery.diagnostics.is_empty(),
+        diagnostics: PoolDiagnostics::from_iter(std::mem::take(&mut discovery.diagnostics)),
+        ..PoolSnapshot::default()
+    };
+    let walk_clock = Budgeted::new(memory, walk_deadline);
+    let walker = SnapshotWalker {
+        memory: &walk_clock,
+        layout,
+        traversal_limit,
+    };
+    let discovered = discovery.regions.len();
+    let mut walked = 0usize;
+    for region in discovery.regions {
+        let outcome = if region.backend == PoolBackend::Large {
+            walker.walk_large(&region, &mut snapshot);
+            Ok(())
+        } else {
+            walker.walk_region(&region, &mut snapshot)
+        };
+        match outcome {
+            Ok(()) => walked += 1,
+            Err(SnapshotError::BudgetExpired) => {
+                expired = true;
+                break;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    if expired {
+        snapshot.complete = false;
+        snapshot.budget_expired = true;
+        snapshot.diagnostics.push(format!(
+            "the walk ran out of its {:?} budget: {walked} of {discovered} discovered regions \
+             were walked; what is missing is unknown, not absent",
+            budget.unwrap_or_default()
+        ));
+    }
+    snapshot
+        .spans
+        .sort_by_key(|span| (span.heap, span.usable_address));
+    Ok(snapshot)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{cell::Cell, collections::HashMap};
@@ -2461,6 +2607,7 @@ mod tests {
         PoolRegion {
             address,
             size: 0x1000,
+            requested_size: None,
             pool_kind: PoolKind::NonPagedNx,
             numa_node: 0,
             heap: HeapIdentity {
@@ -2528,7 +2675,7 @@ mod tests {
         );
     }
 
-    // ---- VS roots: legacy in-context shape vs 26100 affinity slots ------------------
+    // ---- VS roots: inline context vs affinity slots ----------------------------------
 
     /// Memory backed by one contiguous buffer. Anything outside it fails to read, the way
     /// an unmapped page does.
@@ -2587,7 +2734,7 @@ mod tests {
     const VS_CONTEXT: u64 = 0x1000;
 
     /// A layout carrying only what `vs_roots` consults. `affinity` picks the shape: with
-    /// it, the 26100 slot types exist and `_HEAP_VS_CONTEXT` has no `FreeChunkTree`;
+    /// it, the affinity-slot types exist and `_HEAP_VS_CONTEXT` has no `FreeChunkTree`;
     /// without it, the legacy in-context fields are present instead.
     fn vs_layout(affinity: bool) -> PoolLayout {
         let mut types = HashMap::new();
@@ -2656,7 +2803,7 @@ mod tests {
         );
     }
 
-    /// Pre-26100: the tree is inline in the context, so there is exactly one root and no
+    /// Inline family: the tree is in the context, so there is exactly one root and no
     /// slot map is consulted at all.
     #[test]
     fn test_vs_roots_reads_the_legacy_in_context_shape() {
@@ -2670,7 +2817,7 @@ mod tests {
         assert!(diagnostics.is_empty());
     }
 
-    /// 26100: `slot = VsContext + (SlotRef << 6)`, and entries routinely share a slot.
+    /// Affinity family: `slot = VsContext + (SlotRef << 6)`, and entries routinely share a slot.
     #[test]
     fn test_vs_roots_walks_the_affinity_slots_and_dedups_them() {
         let memory = affinity_fixture();
@@ -2904,6 +3051,7 @@ mod tests {
         PoolRegion {
             address,
             size: pages * PAGE_SIZE as usize,
+            requested_size: None,
             pool_kind: PoolKind::SpecialNonPagedNx,
             numa_node: 0,
             heap: HeapIdentity {
@@ -2933,6 +3081,7 @@ mod tests {
         PoolRegion {
             address: VS_BASE,
             size,
+            requested_size: None,
             pool_kind: PoolKind::NonPagedNx,
             numa_node: 0,
             heap: HeapIdentity {

--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -1821,7 +1821,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
 
         let discovery_clock = Budgeted::new(self.memory, discovery_deadline);
         let mut discovery = Discovery::default();
-        let mut expired = match discover_pool_regions(
+        let expired = match discover_pool_regions(
             &discovery_clock,
             self.layout,
             self.traversal_limit,
@@ -1846,15 +1846,27 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             layout: self.layout,
             traversal_limit: self.traversal_limit,
         };
-        let discovered = discovery.regions.len();
+        walker.walk_discovered_regions(discovery.regions, budget, expired, &mut snapshot)?;
+        Ok(snapshot)
+    }
+
+    /// Walk every discovered region and record how much of the discovery was covered.
+    fn walk_discovered_regions(
+        &self,
+        regions: Vec<PoolRegion>,
+        budget: Option<Duration>,
+        mut expired: bool,
+        snapshot: &mut PoolSnapshot,
+    ) -> Result<(), SnapshotError> {
+        let discovered = regions.len();
         let mut walked = 0usize;
-        for region in discovery.regions {
+        for region in regions {
             let outcome = if region.backend == PoolBackend::Large {
                 // No reads of its own: the span comes from metadata discovery already did.
-                walker.walk_large(&region, &mut snapshot);
+                self.walk_large(&region, snapshot);
                 Ok(())
             } else {
-                walker.walk_region(&region, &mut snapshot)
+                self.walk_region(&region, snapshot)
             };
             match outcome {
                 // Counted only when the region was walked *through*. A region abandoned
@@ -1885,7 +1897,7 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
         snapshot
             .spans
             .sort_by_key(|span| (span.heap, span.usable_address));
-        Ok(snapshot)
+        Ok(())
     }
 
     /// Reads one region and decodes its chunks, stopping if the walk's time runs out.
@@ -2562,36 +2574,7 @@ pub(crate) fn walk_user_segment_heaps<M: PoolMemory>(
         layout,
         traversal_limit,
     };
-    let discovered = discovery.regions.len();
-    let mut walked = 0usize;
-    for region in discovery.regions {
-        let outcome = if region.backend == PoolBackend::Large {
-            walker.walk_large(&region, &mut snapshot);
-            Ok(())
-        } else {
-            walker.walk_region(&region, &mut snapshot)
-        };
-        match outcome {
-            Ok(()) => walked += 1,
-            Err(SnapshotError::BudgetExpired) => {
-                expired = true;
-                break;
-            }
-            Err(error) => return Err(error),
-        }
-    }
-    if expired {
-        snapshot.complete = false;
-        snapshot.budget_expired = true;
-        snapshot.diagnostics.push(format!(
-            "the walk ran out of its {:?} budget: {walked} of {discovered} discovered regions \
-             were walked; what is missing is unknown, not absent",
-            budget.unwrap_or_default()
-        ));
-    }
-    snapshot
-        .spans
-        .sort_by_key(|span| (span.heap, span.usable_address));
+    walker.walk_discovered_regions(discovery.regions, budget, expired, &mut snapshot)?;
     Ok(snapshot)
 }
 
@@ -2672,6 +2655,58 @@ mod tests {
         assert!(
             snapshot.complete,
             "a straddling slot is expected layout and must not mark the snapshot incomplete"
+        );
+    }
+
+    #[test]
+    fn test_user_regions_never_report_payload_bytes_as_pool_tags() {
+        let no_pool_header = PoolHeaderLayout {
+            size: 0,
+            previous_size: 0,
+            pool_index: 0,
+            block_size: 0,
+            pool_type: 0,
+            tag: 0,
+        };
+        let memory = FlatMemory::new(0x1000, 0x1000);
+        let layout = vs_layout(false);
+        let walker = SnapshotWalker {
+            memory: &memory,
+            layout: &layout,
+            traversal_limit: 1000,
+        };
+        let mut snapshot = PoolSnapshot {
+            complete: true,
+            ..PoolSnapshot::default()
+        };
+
+        let mut lfh = lfh_region(0x1000, 0x20);
+        lfh.size = 0x20;
+        lfh.pool_header = no_pool_header;
+        let mut lfh_bytes = vec![0; 0x20];
+        lfh_bytes[..4].copy_from_slice(b"LFH!");
+        walker.walk_lfh(&lfh, lfh.address, &lfh_bytes, &mut snapshot);
+
+        let mut vs = vs_region(0x40);
+        vs.pool_header = no_pool_header;
+        let mut vs_bytes = vs_extent(&[(0x40, 0)]);
+        vs_bytes[0x10..0x14].copy_from_slice(b"VS!!");
+        walker.walk_vs(&vs, vs.address, &vs_bytes, &mut snapshot);
+
+        let mut page = lfh_region(0x3000, 0x20);
+        page.size = 0x20;
+        page.backend = PoolBackend::Segment;
+        page.pool_header = no_pool_header;
+        page.states = vec![PoolState::Allocated];
+        let mut page_bytes = vec![0; 0x20];
+        page_bytes[..4].copy_from_slice(b"PAGE");
+        walker.walk_page_ranges(&page, page.address, &page_bytes, &mut snapshot);
+
+        assert_eq!(snapshot.spans.len(), 3);
+        assert!(
+            snapshot.spans.iter().all(|span| span.raw_tag == 0),
+            "user payload bytes must not be decoded as kernel pool tags: {:?}",
+            snapshot.spans
         );
     }
 

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -164,6 +164,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
         // keeping how much of the pool the walk covered, which is a property of the walk and
         // not of the filter applied to its result.
         let snapshot = crate::pool::PoolSnapshot {
+            layout: filtered.layout,
             complete: filtered.complete,
             budget_expired: filtered.budget_expired,
             stalls: filtered.stalls,
@@ -255,7 +256,7 @@ pub unsafe extern "system" fn DebugExtensionNotify(notify: u32, _argument: u64) 
 }
 
 fn invalidate_session() {
-    query::invalidate_session();
+    query::invalidate_allocator_caches();
 }
 
 #[unsafe(no_mangle)]

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -249,7 +249,9 @@ pub unsafe extern "system" fn DebugExtensionUninitialize() {
 pub unsafe extern "system" fn DebugExtensionNotify(notify: u32, _argument: u64) {
     let _ = catch_unwind(AssertUnwindSafe(|| match notify {
         DEBUG_NOTIFY_SESSION_ACTIVE | DEBUG_NOTIFY_SESSION_INACTIVE => invalidate_session(),
-        DEBUG_NOTIFY_SESSION_INACCESSIBLE => query::snapshots().invalidate(),
+        // Target memory can change while the session is inaccessible. Layouts describe the
+        // loaded PDBs and remain valid, but both allocator snapshots must be discarded.
+        DEBUG_NOTIFY_SESSION_INACCESSIBLE => query::invalidate_allocator_snapshots(),
         DEBUG_NOTIFY_SESSION_ACCESSIBLE => {}
         _ => {}
     }));


### PR DESCRIPTION
## Summary

- resolve allocator layouts from the exact loaded `nt` or `ntdll` PDB and fail closed on unknown structural families
- share Segment Heap decoding across kernel pool and user heap adapters, including LFH, VS, backend, and large allocations
- add typed user-heap list, allocation, neighbourhood, census, diagnostics, provenance, coverage, deadline, interrupt, and cache APIs
- add compact inline/affinity fixtures and an opt-in live/dump user-heap smoke helper

## Why

Build-number heuristics and nearest-layout fallbacks are unsafe for allocator inspection. The walk now validates the target module's PDB structure, records a stable layout fingerprint, and reports incomplete coverage explicitly.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets` (passes with one pre-existing `process.rs` warning)
- `cargo test -q` (111 passed, 6 ignored)
- `cargo check --example user_heap_smoke`

The opt-in live helper reaches the expected exact-private-PDB prerequisite on this machine; full live/dump assertions require the matching `ntdll` PDB. KDNET smoke remains environment-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows user-mode Segment Heap inspection, including heap roots, live allocations, allocation neighbourhoods, censuses and diagnostics.
  - Added support for validating heap layouts across supported Windows versions and reporting layout provenance.
  - Added requested allocation-size reporting where reliable metadata is available.
  - Added controls for refreshing snapshots and invalidating cached heap information.
  - Added an opt-in Windows smoke test covering heap inspection and memory-dump validation.

- **Bug Fixes**
  - Improved pointer validation and decoding for user-mode heap allocations.
  - Added clearer diagnostics for unsupported, invalid or insufficiently symbolised targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->