### PR TITLE
fix: scope heap diagnostics before aggregation

### DIFF
--- a/src/heap.rs
+++ b/src/heap.rs
@@ -209,6 +209,8 @@ pub enum HeapQueryError {
     UnsupportedArchitecture { machine: u32 },
     #[error("invalid PEB heap metadata: {0}")]
     InvalidPeb(String),
+    #[error("heap selector {heap:#x} is not a supported Segment Heap root in the current PEB")]
+    UnsupportedHeap { heap: u64 },
     #[error(
         "missing or unsupported ntdll allocator layout ({0}); run `.reload /f ntdll.dll` and retry"
     )]
@@ -611,14 +613,24 @@ fn scope_of(roots: &[HeapRoot]) -> HeapScope {
     scope
 }
 
-fn scope_for(roots: &[HeapRoot], heap: Option<u64>) -> HeapScope {
+fn scope_for(
+    roots: &[HeapRoot],
+    heap: Option<u64>,
+    enumeration_complete: bool,
+) -> Result<HeapScope, HeapQueryError> {
     let mut scope = scope_of(roots);
     if let Some(heap) = heap {
+        let selected = roots.iter().find(|root| root.address == heap);
+        if selected.is_some_and(|root| root.kind != HeapKind::Segment)
+            || (selected.is_none() && enumeration_complete)
+        {
+            return Err(HeapQueryError::UnsupportedHeap { heap });
+        }
         // Diagnostic shapes deliberately generalise addresses. Narrow the roots handed to the
         // walker so complaints from another heap never enter this snapshot's aggregation.
         scope.segment_heaps_walked.retain(|root| *root == heap);
     }
-    scope
+    Ok(scope)
 }
 
 fn from_pool_snapshot(
@@ -766,7 +778,7 @@ fn walk_snapshot(
         total,
         budget_expired,
     } = enumerate_roots(engine, &schema.layout, target.peb, deadline)?;
-    let mut scope = scope_for(&roots, heap);
+    let mut scope = scope_for(&roots, heap, !budget_expired)?;
     let pool = if budget_expired {
         // These roots were identified but no allocator region was walked after the deadline.
         scope.segment_heaps_walked.clear();
@@ -1120,9 +1132,43 @@ mod tests {
                 reason: None,
             },
         ];
-        let scope = scope_for(&roots, Some(0x20000));
+        let scope = scope_for(&roots, Some(0x20000), true).unwrap();
 
         assert_eq!(scope.segment_heaps_walked, vec![0x20000]);
+    }
+
+    #[test]
+    fn test_scoped_diagnostics_reject_unsupported_or_missing_heap() {
+        let roots = vec![
+            HeapRoot {
+                index: 0,
+                address: 0x10000,
+                kind: HeapKind::Nt,
+                supported: false,
+                reason: Some("classic".into()),
+            },
+            HeapRoot {
+                index: 1,
+                address: 0x20000,
+                kind: HeapKind::Unreadable,
+                supported: false,
+                reason: Some("unreadable".into()),
+            },
+        ];
+
+        for heap in [0x10000, 0x20000, 0x30000] {
+            assert!(matches!(
+                scope_for(&roots, Some(heap), true),
+                Err(HeapQueryError::UnsupportedHeap { heap: rejected }) if rejected == heap
+            ));
+        }
+    }
+
+    #[test]
+    fn test_scoped_diagnostics_leave_unseen_heap_unknown_when_enumeration_expires() {
+        let scope = scope_for(&[], Some(0x30000), false).unwrap();
+
+        assert!(scope.segment_heaps_walked.is_empty());
     }
 
     #[test]

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -230,6 +230,8 @@ struct SnapshotKey {
     peb: u64,
     image: KernelImage,
     generation: u64,
+    /// A scoped diagnostic walk is a different snapshot from the all-heaps walk.
+    heap: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -609,6 +611,16 @@ fn scope_of(roots: &[HeapRoot]) -> HeapScope {
     scope
 }
 
+fn scope_for(roots: &[HeapRoot], heap: Option<u64>) -> HeapScope {
+    let mut scope = scope_of(roots);
+    if let Some(heap) = heap {
+        // Diagnostic shapes deliberately generalise addresses. Narrow the roots handed to the
+        // walker so complaints from another heap never enter this snapshot's aggregation.
+        scope.segment_heaps_walked.retain(|root| *root == heap);
+    }
+    scope
+}
+
 fn from_pool_snapshot(
     snapshot: PoolSnapshot,
 ) -> (Vec<HeapAllocation>, HeapWalkReport, HeapDiagnosticReport) {
@@ -729,6 +741,7 @@ fn walk_snapshot(
     started: Instant,
     target: ValidatedTarget,
     schema: ResolvedSchema,
+    heap: Option<u64>,
 ) -> Result<HeapSnapshot, HeapQueryError> {
     let key = SnapshotKey {
         target: target.target,
@@ -736,6 +749,7 @@ fn walk_snapshot(
         peb: target.peb,
         image: schema.image,
         generation: target.generation,
+        heap,
     };
     if walk.refresh {
         snapshots().invalidate();
@@ -752,7 +766,7 @@ fn walk_snapshot(
         total,
         budget_expired,
     } = enumerate_roots(engine, &schema.layout, target.peb, deadline)?;
-    let mut scope = scope_of(&roots);
+    let mut scope = scope_for(&roots, heap);
     let pool = if budget_expired {
         // These roots were identified but no allocator region was walked after the deadline.
         scope.segment_heaps_walked.clear();
@@ -790,11 +804,19 @@ fn walk_snapshot(
 }
 
 fn prepare(engine: &DebugEngine, walk: HeapWalk) -> Result<HeapSnapshot, HeapQueryError> {
+    prepare_for_heap(engine, None, walk)
+}
+
+fn prepare_for_heap(
+    engine: &DebugEngine,
+    heap: Option<u64>,
+    walk: HeapWalk,
+) -> Result<HeapSnapshot, HeapQueryError> {
     let started = Instant::now();
     let deadline = walk.budget.and_then(|budget| started.checked_add(budget));
     let target = validate_target(engine)?;
     let schema = resolve_schema(engine, target, deadline)?;
-    walk_snapshot(engine, walk, started, target, schema)
+    walk_snapshot(engine, walk, started, target, schema, heap)
 }
 
 fn answer<T>(snapshot: &HeapSnapshot, found: T) -> HeapAnswer<T> {
@@ -921,6 +943,19 @@ pub fn diagnostics(
     Ok(answer(&snapshot, snapshot.diagnostics.clone()))
 }
 
+/// Reports diagnostics from one Segment Heap root.
+///
+/// The heap is selected before walking and before diagnostic shapes generalise addresses, so
+/// category totals and examples both describe only this root. Use [`diagnostics`] for all roots.
+pub fn diagnostics_for_heap(
+    engine: &DebugEngine,
+    heap: u64,
+    walk: impl Into<HeapWalk>,
+) -> Result<HeapAnswer<HeapDiagnosticReport>, HeapQueryError> {
+    let snapshot = prepare_for_heap(engine, Some(heap), walk.into())?;
+    Ok(answer(&snapshot, snapshot.diagnostics.clone()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -982,20 +1017,42 @@ mod tests {
             timestamp: 0x1234_5678,
             checksum: 0x9876,
         };
-        let key = |process_system_id| SnapshotKey {
+        let key = |process_system_id, heap| SnapshotKey {
             target: 7,
             process_system_id,
             peb: 0x0000_7fff_0000_1000,
             image,
             generation: 3,
+            heap,
         };
 
         assert_ne!(
-            key(100),
-            key(200),
+            key(100, None),
+            key(200, None),
             "two current processes may share virtual addresses but never a heap snapshot"
         );
-        assert_eq!(key(100), key(100));
+        assert_eq!(key(100, None), key(100, None));
+    }
+
+    #[test]
+    fn test_snapshot_identity_separates_scoped_diagnostic_walks() {
+        let image = KernelImage {
+            base: 0x0000_7ffb_0000_0000,
+            size: 0x20_0000,
+            timestamp: 0x1234_5678,
+            checksum: 0x9876,
+        };
+        let key = |heap| SnapshotKey {
+            target: 7,
+            process_system_id: 100,
+            peb: 0x0000_7fff_0000_1000,
+            image,
+            generation: 3,
+            heap,
+        };
+
+        assert_ne!(key(None), key(Some(0x10000)));
+        assert_ne!(key(Some(0x10000)), key(Some(0x20000)));
     }
 
     #[test]
@@ -1043,6 +1100,29 @@ mod tests {
         assert_eq!(scope.nt_heaps_skipped, vec![2]);
         assert_eq!(scope.unknown_heaps_skipped, vec![3]);
         assert_eq!(scope.unreadable_heaps_skipped, vec![4]);
+    }
+
+    #[test]
+    fn test_scoped_diagnostics_select_one_heap_before_the_walk() {
+        let roots = vec![
+            HeapRoot {
+                index: 0,
+                address: 0x10000,
+                kind: HeapKind::Segment,
+                supported: true,
+                reason: None,
+            },
+            HeapRoot {
+                index: 1,
+                address: 0x20000,
+                kind: HeapKind::Segment,
+                supported: true,
+                reason: None,
+            },
+        ];
+        let scope = scope_for(&roots, Some(0x20000));
+
+        assert_eq!(scope.segment_heaps_walked, vec![0x20000]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a `diagnostics_for_heap` query that selects one Segment Heap root before walking
- keep scoped snapshots isolated from all-heaps and other-root cache entries
- report category totals and examples from only the selected heap

## Root cause

Diagnostic category shapes intentionally generalize addresses. Filtering already-aggregated shapes by a heap address therefore removed category totals and left only incidental sampled examples.

## Validation

- `cargo fmt --all -- --check`
- `cargo test` (118 passed, 6 ignored; doctests passed)
- `cargo nextest run --verbose` (118 passed, 6 skipped)
- `cargo clippy --all-targets -- -A clippy::collapsible-if -D warnings`

Plain `cargo clippy --all-targets -- -D warnings` remains blocked by the pre-existing `clippy::collapsible-if` finding in `src/process.rs:33`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heap-specific diagnostics, allowing reports to focus on a selected Segment Heap.
  * Heap snapshots and diagnostic walks can now be scoped to a particular heap, reducing unrelated results.
  * Improved snapshot identification distinguishes between overall and heap-specific analysis.
* **Bug Fixes**
  * Improved accuracy when selecting and analysing an individual heap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->