### PR TITLE
Say why a VS chunk chain is lost, and stop claiming it cannot be

### DIFF
--- a/src/pool/snapshot.rs
+++ b/src/pool/snapshot.rs
@@ -2413,11 +2413,20 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
     /// than the subsegment, so the walk was decoding a page that holds no chunks. See
     /// [`discover_segment_context`], which now sizes the region from the subsegment.
     ///
-    /// The chain is what crosses the hole. A decommitted range is always the *interior* of a
-    /// free chunk — the allocator has to keep its own headers readable — so the chunk before a
-    /// hole records a size that reaches past it and the next header lands in the next committed
-    /// extent, at an address this walk already knows. `expected` carries that address between
-    /// extents. `None` means the walk lost it, and a walk that has lost it does not guess again.
+    /// The chain is what crosses the hole. The chunk before one records a size that reaches past
+    /// it and so names the header on the far side, at an address this walk already knows.
+    /// `expected` carries that address between extents. `None` means the walk lost it, and a walk
+    /// that has lost it does not guess again.
+    ///
+    /// It can lose it, and the reason is worth knowing before reading `unplaced_bytes` as damage.
+    /// A *decommitted* range is the interior of a free chunk — the allocator has to keep its own
+    /// headers reachable — so the chain crosses those. But a hole here is not only decommitted
+    /// memory: on paged pool it is also memory that is committed and **paged out**, and nothing
+    /// stops a chunk header being in it. Every unreadable header on a live 26100 walk was exactly
+    /// that — `!pte` on each named address gave a pagefile PTE, `Protect: 4 - ReadWrite`, not a
+    /// zero one — and a KD link cannot fault a page in. So those bytes are unreachable from a
+    /// live target rather than absent from the pool, and the walk reports them instead of
+    /// inventing chunks in them.
     ///
     /// A refused header costs more than itself: the walk no longer knows where the next one
     /// starts, so it advances sixteen bytes and tries again, and every header after it in the
@@ -2442,10 +2451,22 @@ impl<'a, M: PoolMemory> SnapshotWalker<'a, M> {
             // these bytes can be placed. Sized and not merely counted, because what this costs
             // is coverage — and the alternative, decoding from a guess, costs correctness.
             snapshot.unplaced_bytes = snapshot.unplaced_bytes.saturating_add(bytes.len() as u64);
-            snapshot.diagnostics.push(format!(
-                "VS extent at {base:#x} does not begin on a chunk boundary; {:#x} bytes not decoded",
-                bytes.len()
-            ));
+            // Two causes, kept as two shapes so a walk says which — `PoolDiagnostics` folds
+            // numbers but not words, so this is the only way the split survives to a live run.
+            snapshot.diagnostics.push(match expected {
+                Some(next) => format!(
+                    "VS extent at {base:#x} does not begin on a chunk boundary: the chunk chain \
+                     names {next:#x}, {:#x} bytes back inside unreadable memory; {:#x} bytes not \
+                     decoded",
+                    base - next,
+                    bytes.len()
+                ),
+                None => format!(
+                    "VS extent at {base:#x} cannot be placed: the chain was already lost earlier \
+                     in this region; {:#x} bytes not decoded",
+                    bytes.len()
+                ),
+            });
             snapshot.complete = false;
             return None;
         };


### PR DESCRIPTION
Rebased onto `main` now that #108 has merged. Diagnostic wording and documentation only,
no behaviour change.

## What `unplaced_bytes` actually is

It has been exactly **290,816 bytes over 19 extents on four consecutive live walks** —
the same extents at the same addresses each time. Too stable to be damage, and until now
unexplained.

Splitting the diagnostic by cause gives 13 extents whose chain named a header it could
not read, and 6 more in those same regions that were already lost behind them. Carrying
how far back the named header is put it *inside* the hole rather than before it:

```
VS extent at 0xffffdf080c20d000 ... the chain named 0xffffdf080c20ce00, 0x200 bytes back
                                    previous extent ended 0xffffdf080c20c000
```

which contradicts the reason I gave in `walk_vs` for believing the chain always crosses a
hole: that a decommitted range is the interior of a free chunk, so the allocator has to
keep its own headers reachable.

That is true of decommitted memory. **A hole is not only decommitted memory.** `!pte` on
each named address:

```
VA ffffdf080c20ce00 ... PTE contains 00007DDE00000084
not valid   PageFile: 0   Offset: 7dde   Protect: 4 - ReadWrite
```

A pagefile PTE, not a zero one — paged pool that is committed and **paged out**. The
header is really there; a KD link simply cannot fault a page in. So `unplaced_bytes` is
not a walker defect and not corruption: it is memory unreachable from a live target,
which is why the figure is identical run to run on an idle VM and why the same walk over
a dump carrying paged memory would not lose it.

## Why nothing is being recovered here

The obvious next step would be to re-anchor from `reusable_chunks`/`cached_chunks` — the
free-tree and delay-free chunk addresses the walk already collects are *validated* chunk
boundaries, so resuming from one inside an unplaced extent would not be a guess. I have
not done it, and I do not think it is worth it: 290,816 bytes is roughly 0.3% of a walk
that reaches 446k chunks, the recovery would be partial (only where a free chunk happens
to start in the extent), and it adds a second way for the chain to be wrong in exchange.
Worth revisiting only if this figure ever grows.

## Verification

`cargo test` (125 pass), `cargo clippy --all-targets` clean, re-run after the rebase. The
wording was read off four live runs; the last one produced the samples quoted above.
