### PR TITLE
ci: let Dependabot raise the cargo bumps its default strategy hides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    reviewers:
+    # Cargo.lock is gitignored (library convention), so Dependabot can only edit
+    # the requirement in Cargo.toml. The default `auto` strategy resolves to
+    # `widen` for libraries, which is a no-op whenever the existing caret range
+    # already admits the new release -- so patch bumps never raise a PR.
+    # `increase` moves the floor to match each new release instead.
+    versioning-strategy: increase
+    assignees:
       - "glslang"
     labels:
       - "dependencies"
@@ -23,7 +29,7 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
-    reviewers:
+    assignees:
       - "glslang"
     labels:
       - "dependencies"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: microsoft/setup-msbuild@v3
-      - uses: glslang/setup-masm@v1
+      - uses: glslang/setup-masm@v1.4
 
       - name: Install Rust
         run: rustup update stable && rustup default stable

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: microsoft/setup-msbuild@v3
-      - uses: glslang/setup-masm@v1.2
+      - uses: glslang/setup-masm@v1.4
         with:
           vs-architecture: x64
       - name: Install nightly Rust with Miri


### PR DESCRIPTION
Dependabot has not opened a cargo PR since 2025-09-08. It is not broken — the default strategy is a no-op for this repo, and two dependency floors have drifted behind as a result.

## Why cargo updates went quiet

`Cargo.lock` is gitignored (`.gitignore:11`, the standard library convention), so Dependabot's only lever is the requirement in `Cargo.toml`. The default `versioning-strategy: auto` resolves to `widen` for libraries — *"widen the allowed version requirements to include both the new and old versions"* — which changes nothing when the existing caret range already admits the new release. No edit, no PR.

The history matches exactly: the last three `chore(deps)` PRs (windows 0.61.3→0.62.0, windows-core 0.61.2→0.62.0, windows-strings 0.4.2→0.5.0) all crossed a caret boundary. Nothing has crossed one since.

Current drift, all of it inside the declared ranges:

| Crate | `Cargo.toml` | Latest |
|---|---|---|
| goblin | `0.10.5` | **0.10.7** |
| thiserror | `2.0.18` | **2.0.20** |

Everything else (byte-strings, hex, windows, windows-core, windows-strings) is genuinely at latest.

Build impact is nil — without a lockfile Cargo already resolves the newest in-range, so `cargo tree` reports 0.10.7 and 2.0.20 today. Only the floors are stale.

`versioning-strategy: increase` moves the floor to match each new release. The two floors above are deliberately left alone here, so the next Monday run doubles as a live check that the fix works.

## Also in this PR

**`setup-masm` pins normalized to `@v1.4`.** `coverage.yml` floated on `@v1` and `miri.yml` was pinned at `@v1.2` — added 2026-04-24, after v1.3 had already shipped, and never bumped since. Verified `action.yml` at v1.4 still exposes `vs-architecture` with the same semantics, so miri.yml's `with:` block is unaffected.

**`reviewers` → `assignees`.** `reviewers` is removed on github.com (the docs source gates the section behind `dependabot-reviewers-deprecation`), so it was silently assigning nobody. `assignees` is supported by every ecosystem.

## Not addressed here

- **Dependabot security updates are disabled** on the repo (`dependabot_security_updates: {status: "disabled"}`). That's a repo setting rather than config. No open alerts today, so no current exposure.
- **The `setup-masm` gap is treated, not explained.** Normalizing the pins fixes the symptom, but why Dependabot never raised a PR for `@v1.2` against an available v1.3 is still unknown. If it recurs after v1.5 ships, the job log at `/network/updates` is where the cause would show.

## Verification

- Both YAML files parse; the dependabot config resolves as intended (cargo: `increase`; both entries: `assignees: [glslang]`, no `reviewers`).
- `versioning-strategy` support for `cargo` confirmed against GitHub's options reference.
- No Rust source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)