### PR TITLE
Let a pool tag be named by its bytes, not only by how it prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ The primary command is:
 !win_kexp.poolmap ffff800012345678
 ```
 
-`-tag` accepts one through four ASCII bytes. Internally the tag remains the exact
-four-byte raw little-endian value; printable display text is only a rendering. The
-tag map retains nearby unrelated allocations and holes. `-paged` and `-nonpaged`
+`-tag` accepts one through four ASCII bytes, or the **raw form** — `0x` and the four
+bytes as hex, in memory order, so it reads in the same direction as the printed tag
+(`Tgsm` is `0x5467736d`). Internally the tag remains the exact four-byte raw
+little-endian value; printable display text is only a rendering, and a lossy one: every
+byte that does not print becomes `.`, and so does a literal `.`. A tag shown with a `.`
+in it therefore names no particular tag, and passing that rendering to `-tag` asks about
+literal `.` bytes rather than about what was displayed — which is why output prints the
+raw form instead wherever the rendering would be ambiguous. Query that. The two forms
+cannot be confused: the raw form is exactly ten characters and a printed tag is at most
+four, so `0x2e` is still the four-byte tag `0x2e`. The tag map retains nearby unrelated
+allocations and holes. `-paged` and `-nonpaged`
 filter exact pool identities and cannot be combined. An address query prints detail
 for the allocation or hole containing that address. `-refresh` discards a complete
 cached snapshot and walks again.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -18,7 +18,9 @@ pub mod query;
 /// [`query::find_tag`] has a round trip that silently breaks on any tag `display_tag` cannot
 /// render — so a consumer showing tags to a human should show [`raw_tag_hex`] wherever
 /// [`display_is_ambiguous`] holds, and `parse_tag` takes either form back.
-pub use decode::{display_is_ambiguous, parse_tag, raw_tag_hex, tag_label};
+pub use decode::{
+    display_is_ambiguous, display_round_trips, parse_raw_tag, parse_tag, raw_tag_hex, tag_label,
+};
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
 pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics, WalkStalls};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -12,6 +12,13 @@ pub(crate) mod snapshot;
 
 pub mod query;
 
+/// The two forms a pool tag takes, and the question of which one identifies it.
+///
+/// A caller that renders [`PoolSpan::display_tag`] and hands the result back to
+/// [`query::find_tag`] has a round trip that silently breaks on any tag `display_tag` cannot
+/// render — so a consumer showing tags to a human should show [`raw_tag_hex`] wherever
+/// [`display_is_ambiguous`] holds, and `parse_tag` takes either form back.
+pub use decode::{display_is_ambiguous, parse_tag, raw_tag_hex};
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
 pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics, WalkStalls};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -18,7 +18,7 @@ pub mod query;
 /// [`query::find_tag`] has a round trip that silently breaks on any tag `display_tag` cannot
 /// render — so a consumer showing tags to a human should show [`raw_tag_hex`] wherever
 /// [`display_is_ambiguous`] holds, and `parse_tag` takes either form back.
-pub use decode::{display_is_ambiguous, parse_tag, raw_tag_hex};
+pub use decode::{display_is_ambiguous, parse_tag, raw_tag_hex, tag_label};
 pub(crate) use index::PoolIndex;
 pub(crate) use snapshot::PoolSnapshot;
 pub use snapshot::{DIAGNOSTIC_EXAMPLES, DiagnosticShape, PoolDiagnostics, WalkStalls};

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -683,6 +683,21 @@ pub fn raw_tag_hex(tag: u32) -> String {
     format!("0x{a:02x}{b:02x}{c:02x}{d:02x}")
 }
 
+/// How a tag should be shown to someone who might hand it back.
+///
+/// [`display_tag`] where it identifies the tag, [`raw_tag_hex`] where it does not. Every place
+/// that prints a tag for a human should go through this rather than reaching for `display_tag`:
+/// printing a rendering that cannot be queried is what made `....` an unusable answer, and having
+/// one rule here is what stops the extension's output and a programmatic host's from disagreeing
+/// about the same chunk.
+pub fn tag_label(tag: u32) -> String {
+    if display_is_ambiguous(tag) {
+        raw_tag_hex(tag)
+    } else {
+        display_tag(tag)
+    }
+}
+
 /// A tag from either form: the four displayed bytes, or [`raw_tag_hex`]'s `0x` + 8 hex digits.
 ///
 /// The two cannot collide, which is what makes accepting both safe rather than a guess: the raw
@@ -969,6 +984,20 @@ mod tests {
         assert!(display_is_ambiguous(dots), "a literal `.` is ambiguous too");
         assert!(!display_is_ambiguous(u32::from_le_bytes(*b"Tgsm")));
         assert!(!display_is_ambiguous(u32::from_le_bytes(*b"Ntf ")));
+
+        // What every output site shows: the printed form where it identifies the tag, the raw
+        // bytes where it does not — and never two different tags under one label.
+        assert_eq!(tag_label(u32::from_le_bytes(*b"Tgsm")), "Tgsm");
+        assert_eq!(tag_label(u32::from_le_bytes(*b"Ntf ")), "Ntf ");
+        assert_eq!(tag_label(binary), "0x000180ff");
+        assert_eq!(tag_label(dots), "0x2e2e2e2e");
+        assert_ne!(tag_label(binary), tag_label(dots));
+        // And whatever it shows can be handed straight back.
+        assert_eq!(parse_tag(&tag_label(binary)), Some(binary));
+        assert_eq!(
+            parse_tag(&tag_label(u32::from_le_bytes(*b"Tgsm"))),
+            Some(u32::from_le_bytes(*b"Tgsm"))
+        );
 
         // A displayed tag is at most 4 characters and the raw form is exactly 10, so the two
         // can never collide -- `0x2e` stays the four-byte tag it has always been.

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -683,19 +683,59 @@ pub fn raw_tag_hex(tag: u32) -> String {
     format!("0x{a:02x}{b:02x}{c:02x}{d:02x}")
 }
 
+/// Whether [`display_tag`]'s rendering can be handed back and name the same tag again.
+///
+/// Two separate ways it cannot, and collapsing them would get the reason wrong:
+///
+/// * it does not identify the tag at all — [`display_is_ambiguous`];
+/// * it identifies it but cannot survive the trip. `!win_kexp.poolmap` splits its arguments on
+///   whitespace, so a tag with a leading or embedded space — raw bytes `A BC` — comes back as the
+///   tag `A` with `BC` left over as a stray argument, and an all-space tag comes back as no
+///   argument at all. Only a nonempty run of non-space bytes followed by nothing but spaces
+///   survives, which is exactly the shape [`parse_tag`] rebuilds when it pads a short tag out to
+///   four bytes: `Ntf ` round-trips, `A BC` does not.
+pub fn display_round_trips(tag: u32) -> bool {
+    if display_is_ambiguous(tag) {
+        return false;
+    }
+    let bytes = tag.to_le_bytes();
+    let leading = bytes.iter().take_while(|&&byte| byte != b' ').count();
+    leading > 0 && bytes[leading..].iter().all(|&byte| byte == b' ')
+}
+
 /// How a tag should be shown to someone who might hand it back.
 ///
-/// [`display_tag`] where it identifies the tag, [`raw_tag_hex`] where it does not. Every place
-/// that prints a tag for a human should go through this rather than reaching for `display_tag`:
-/// printing a rendering that cannot be queried is what made `....` an unusable answer, and having
-/// one rule here is what stops the extension's output and a programmatic host's from disagreeing
-/// about the same chunk.
+/// [`display_tag`] where that survives the round trip, [`raw_tag_hex`] where it does not. Every
+/// place that prints a tag for a human should go through this rather than reaching for
+/// `display_tag`: printing a rendering that cannot be queried is what made `....` an unusable
+/// answer, and having one rule here is what stops the extension's output and a programmatic
+/// host's from disagreeing about the same chunk.
 pub fn tag_label(tag: u32) -> String {
-    if display_is_ambiguous(tag) {
-        raw_tag_hex(tag)
-    } else {
+    if display_round_trips(tag) {
         display_tag(tag)
+    } else {
+        raw_tag_hex(tag)
     }
+}
+
+/// The **raw form alone**: `0x` and exactly eight hex digits, the four bytes in memory order.
+///
+/// Public because a caller that treats the two forms differently — explaining that a *rendering*
+/// found nothing, say — has to ask exactly the question [`parse_tag`] asks, and a `0x` prefix is
+/// not that question. `0x2e` is four printable bytes and a perfectly ordinary tag; so is `0x..`,
+/// which is *ambiguous* and needs that explaining rather than being waved through as raw. Sharing
+/// this predicate is what keeps the two from disagreeing about which inputs are which.
+pub fn parse_raw_tag(text: &str) -> Option<u32> {
+    let digits = text
+        .strip_prefix("0x")
+        .or_else(|| text.strip_prefix("0X"))
+        .filter(|digits| digits.len() == 8 && digits.bytes().all(|b| b.is_ascii_hexdigit()))?;
+    let mut raw = [0u8; 4];
+    for (byte, pair) in raw.iter_mut().zip(digits.as_bytes().chunks_exact(2)) {
+        // Each pair is two verified hex digits, so this cannot fail.
+        *byte = u8::from_str_radix(std::str::from_utf8(pair).ok()?, 16).ok()?;
+    }
+    Some(u32::from_le_bytes(raw))
 }
 
 /// A tag from either form: the four displayed bytes, or [`raw_tag_hex`]'s `0x` + 8 hex digits.
@@ -708,17 +748,8 @@ pub fn tag_label(tag: u32) -> String {
 /// because this parser only ever accepted ASCII: before it, a tag with a byte outside ASCII could
 /// not be named at all, so the pool's heaviest tag could be one no query could ask for.
 pub fn parse_tag(text: &str) -> Option<u32> {
-    if let Some(digits) = text
-        .strip_prefix("0x")
-        .or_else(|| text.strip_prefix("0X"))
-        .filter(|digits| digits.len() == 8 && digits.bytes().all(|b| b.is_ascii_hexdigit()))
-    {
-        let mut raw = [0u8; 4];
-        for (byte, pair) in raw.iter_mut().zip(digits.as_bytes().chunks_exact(2)) {
-            // Each pair is two verified hex digits, so this cannot fail.
-            *byte = u8::from_str_radix(std::str::from_utf8(pair).ok()?, 16).ok()?;
-        }
-        return Some(u32::from_le_bytes(raw));
+    if let Some(raw) = parse_raw_tag(text) {
+        return Some(raw);
     }
     let bytes = text.as_bytes();
     if bytes.is_empty() || bytes.len() > 4 || !bytes.iter().all(u8::is_ascii) {
@@ -998,7 +1029,61 @@ mod tests {
             parse_tag(&tag_label(u32::from_le_bytes(*b"Tgsm"))),
             Some(u32::from_le_bytes(*b"Tgsm"))
         );
+    }
 
+    /// A rendering can identify a tag and still not survive being handed back.
+    ///
+    /// The extension splits its arguments on whitespace, so a space that is not trailing padding
+    /// breaks the round trip even though nothing about the rendering is ambiguous. These labels
+    /// have to be the raw form for a different reason than `....` does.
+    #[test]
+    fn test_a_space_that_is_not_padding_costs_the_printed_form() {
+        let trailing = u32::from_le_bytes(*b"Ntf ");
+        let embedded = u32::from_le_bytes(*b"A BC");
+        let leading = u32::from_le_bytes(*b" ABC");
+        let blank = u32::from_le_bytes(*b"    ");
+
+        // None of these is ambiguous -- each rendering names exactly one tag.
+        for tag in [trailing, embedded, leading, blank] {
+            assert!(!display_is_ambiguous(tag), "{}", display_tag(tag));
+        }
+
+        // Padding is the shape `parse_tag` rebuilds, so it alone survives.
+        assert!(display_round_trips(trailing));
+        assert_eq!(tag_label(trailing), "Ntf ");
+        assert_eq!(parse_tag("Ntf"), Some(trailing), "the split drops padding");
+
+        for tag in [embedded, leading, blank] {
+            assert!(
+                !display_round_trips(tag),
+                "`{}` cannot come back through a whitespace split",
+                display_tag(tag)
+            );
+            assert_eq!(tag_label(tag), raw_tag_hex(tag));
+            assert_eq!(parse_tag(&tag_label(tag)), Some(tag));
+        }
+    }
+
+    /// A `0x` prefix is not the raw form, and the difference decides who gets an explanation.
+    #[test]
+    fn test_only_the_complete_raw_form_counts_as_raw() {
+        assert_eq!(parse_raw_tag("0x000180ff"), Some(0xff80_0100));
+        assert_eq!(parse_raw_tag("0X000180FF"), Some(0xff80_0100));
+
+        // Ordinary four-byte tags that merely start with `0x`. The second is ambiguous, and a
+        // caller treating a `0x` prefix as proof of rawness would skip explaining it.
+        assert_eq!(parse_raw_tag("0x2e"), None);
+        assert_eq!(parse_raw_tag("0x.."), None);
+        assert_eq!(parse_tag("0x.."), Some(u32::from_le_bytes(*b"0x..")));
+        assert!(display_is_ambiguous(u32::from_le_bytes(*b"0x..")));
+
+        assert_eq!(parse_raw_tag("0x5467736"), None, "nine characters");
+        assert_eq!(parse_raw_tag("0xzzzzzzzz"), None, "not hex");
+        assert_eq!(parse_raw_tag("5467736d"), None, "no prefix");
+    }
+
+    #[test]
+    fn test_the_two_tag_forms_cannot_collide() {
         // A displayed tag is at most 4 characters and the raw form is exactly 10, so the two
         // can never collide -- `0x2e` stays the four-byte tag it has always been.
         assert_eq!(parse_tag("0x2e"), Some(u32::from_le_bytes(*b"0x2e")));

--- a/src/pool/decode.rs
+++ b/src/pool/decode.rs
@@ -661,7 +661,50 @@ pub(crate) fn display_tag(tag: u32) -> String {
         .collect()
 }
 
-pub(crate) fn parse_tag(text: &str) -> Option<u32> {
+/// Whether [`display_tag`]'s rendering of `tag` identifies it.
+///
+/// It does not whenever a `.` appears, and that is not only the unprintable case: `.` is itself
+/// `ascii_graphic`, so a tag whose bytes really are `.` renders identically to one nothing can
+/// print. A caller holding `....` cannot tell which of 2^32 tags it came from, so the rendering
+/// is a label and [`raw_tag_hex`] is the identifier.
+pub fn display_is_ambiguous(tag: u32) -> bool {
+    tag.to_le_bytes()
+        .iter()
+        .any(|&byte| byte == b'.' || !(byte.is_ascii_graphic() || byte == b' '))
+}
+
+/// The tag's four bytes as hex, **in memory order**: `0x` then two digits per byte.
+///
+/// Memory order rather than the `u32`'s numeric order, so this reads in the same direction as
+/// [`display_tag`] and as the debugger's own output — `Tgsm` is `0x5467736d`, not `0x6d736754`.
+/// The two forms are the same fact, and `parse_tag` takes either.
+pub fn raw_tag_hex(tag: u32) -> String {
+    let [a, b, c, d] = tag.to_le_bytes();
+    format!("0x{a:02x}{b:02x}{c:02x}{d:02x}")
+}
+
+/// A tag from either form: the four displayed bytes, or [`raw_tag_hex`]'s `0x` + 8 hex digits.
+///
+/// The two cannot collide, which is what makes accepting both safe rather than a guess: the raw
+/// form is exactly 10 characters and a displayed tag is at most 4, so a string that parses as one
+/// can never be the other. `"0x2e"` stays the literal four-byte tag it has always been.
+///
+/// The raw form exists because the displayed one is lossy (see [`display_is_ambiguous`]) and
+/// because this parser only ever accepted ASCII: before it, a tag with a byte outside ASCII could
+/// not be named at all, so the pool's heaviest tag could be one no query could ask for.
+pub fn parse_tag(text: &str) -> Option<u32> {
+    if let Some(digits) = text
+        .strip_prefix("0x")
+        .or_else(|| text.strip_prefix("0X"))
+        .filter(|digits| digits.len() == 8 && digits.bytes().all(|b| b.is_ascii_hexdigit()))
+    {
+        let mut raw = [0u8; 4];
+        for (byte, pair) in raw.iter_mut().zip(digits.as_bytes().chunks_exact(2)) {
+            // Each pair is two verified hex digits, so this cannot fail.
+            *byte = u8::from_str_radix(std::str::from_utf8(pair).ok()?, 16).ok()?;
+        }
+        return Some(u32::from_le_bytes(raw));
+    }
     let bytes = text.as_bytes();
     if bytes.is_empty() || bytes.len() > 4 || !bytes.iter().all(u8::is_ascii) {
         return None;
@@ -899,6 +942,49 @@ mod tests {
             context,
             heap_key
         ));
+    }
+
+    /// Every tag can be named, and naming it is what `display_tag` alone cannot do.
+    ///
+    /// The round trip is the whole point: a census renders a tag, a caller hands the rendering
+    /// back, and the query must find the same tag. Over the displayed form that holds only while
+    /// every byte is printable, so the raw form has to hold over all 2^32 — checked here on the
+    /// byte patterns that break the displayed one, plus an exhaustive sweep of one byte position.
+    #[test]
+    fn test_raw_tag_round_trips_where_the_displayed_one_cannot() {
+        // Memory order, so the hex reads in the same direction as the rendering.
+        assert_eq!(raw_tag_hex(u32::from_le_bytes(*b"Tgsm")), "0x5467736d");
+        assert_eq!(parse_tag("0x5467736d"), Some(u32::from_le_bytes(*b"Tgsm")));
+        assert_eq!(parse_tag("0X5467736D"), Some(u32::from_le_bytes(*b"Tgsm")));
+
+        // The collision the raw form exists for: an unprintable tag and a literal `....` render
+        // identically, and `parse_tag` on that rendering silently returns the *other* one.
+        let binary = u32::from_le_bytes([0x00, 0x01, 0x80, 0xff]);
+        let dots = u32::from_le_bytes(*b"....");
+        assert_eq!(display_tag(binary), display_tag(dots));
+        assert_ne!(binary, dots);
+        assert_eq!(parse_tag(&display_tag(binary)), Some(dots));
+        assert_eq!(parse_tag(&raw_tag_hex(binary)), Some(binary));
+        assert!(display_is_ambiguous(binary));
+        assert!(display_is_ambiguous(dots), "a literal `.` is ambiguous too");
+        assert!(!display_is_ambiguous(u32::from_le_bytes(*b"Tgsm")));
+        assert!(!display_is_ambiguous(u32::from_le_bytes(*b"Ntf ")));
+
+        // A displayed tag is at most 4 characters and the raw form is exactly 10, so the two
+        // can never collide -- `0x2e` stays the four-byte tag it has always been.
+        assert_eq!(parse_tag("0x2e"), Some(u32::from_le_bytes(*b"0x2e")));
+        assert_eq!(parse_tag("0x5467736"), None, "9 characters is neither form");
+        assert_eq!(parse_tag("0xzzzzzzzz"), None, "not hex digits");
+        assert_eq!(parse_tag(""), None);
+
+        for byte in 0..=u8::MAX {
+            let tag = u32::from_le_bytes([b'A', byte, b'C', b'D']);
+            assert_eq!(
+                parse_tag(&raw_tag_hex(tag)),
+                Some(tag),
+                "raw form must round-trip byte {byte:#04x}"
+            );
+        }
     }
 
     #[test]

--- a/src/pool/query.rs
+++ b/src/pool/query.rs
@@ -94,7 +94,9 @@ pub enum PoolQueryError {
     #[error("pool walking supports x64 targets only (machine {machine:#x})")]
     UnsupportedArchitecture { machine: u32 },
 
-    #[error("tag must contain 1..4 ASCII bytes")]
+    #[error(
+        "tag must be 1..4 ASCII bytes (\"Tgsm\") or the raw form 0x + 8 hex digits (\"0x5467736d\")"
+    )]
     InvalidTag,
 
     #[error("resolving pool layout failed ({0}); run `.reload /f nt` and retry")]
@@ -407,7 +409,13 @@ pub(crate) fn prepare_index(
         })
 }
 
-/// Every *allocated* chunk carrying `tag` (1..4 ASCII bytes, e.g. `"Tgsm"`).
+/// Every *allocated* chunk carrying `tag`, named either way [`crate::pool::parse_tag`] accepts:
+/// 1..4 ASCII bytes (`"Tgsm"`), or the raw form `0x` + 8 hex digits (`"0x5467736d"`).
+///
+/// Prefer the raw form for anything read back out of a [`PoolSpan`], because the displayed one
+/// is lossy — a tag with an unprintable byte renders as `.` and so does a literal `.`, and
+/// feeding *that* rendering back here finds a different tag rather than failing. See
+/// [`crate::pool::display_is_ambiguous`].
 ///
 /// Only allocated chunks are indexed by tag: a freed chunk's tag is not reliably
 /// preserved by the allocator, so returning "freed chunks with this tag" would be
@@ -639,6 +647,38 @@ mod tests {
         let found = collect_tag(&index, u32::from_le_bytes(*b"Tgsm"), None);
         assert_eq!(found.len(), 2);
         assert!(found.iter().all(|span| span.display_tag == "Tgsm"));
+    }
+
+    /// A tag nothing can print is still a tag, and only the raw form can ask for it.
+    ///
+    /// Both allocations below render `....`, so the rendering cannot be the key: handed back as
+    /// a tag it parses as four literal `.` bytes and finds the *other* allocation — an answer,
+    /// not an error, which is what made this worth a test rather than a doc note.
+    #[test]
+    fn test_a_binary_tag_is_found_by_its_bytes_not_by_its_rendering() {
+        let binary = [0x00u8, 0x01, 0x80, 0xff];
+        let index = index_of(vec![
+            allocation(0x1000, 0x68, &binary, PoolKind::NonPagedNx, 1),
+            allocation(0x2000, 0x40, b"....", PoolKind::NonPagedNx, 1),
+        ]);
+        assert_eq!(
+            crate::pool::decode::display_tag(u32::from_le_bytes(binary)),
+            crate::pool::decode::display_tag(u32::from_le_bytes(*b"....")),
+            "the premise: these two are indistinguishable once rendered"
+        );
+
+        // The rendering finds the literal dots, and says nothing about the tag above it.
+        let rendered = parse_tag("....").expect("four ASCII bytes parse");
+        let by_rendering = collect_tag(&index, rendered, None);
+        assert_eq!(by_rendering.len(), 1);
+        assert_eq!(by_rendering[0].usable_address, 0x2000);
+
+        // The raw form finds the one that has no other name.
+        let raw = parse_tag(&crate::pool::raw_tag_hex(u32::from_le_bytes(binary)))
+            .expect("the raw form parses");
+        let by_bytes = collect_tag(&index, raw, None);
+        assert_eq!(by_bytes.len(), 1);
+        assert_eq!(by_bytes[0].usable_address, 0x1000);
     }
 
     #[test]

--- a/src/pool/render.rs
+++ b/src/pool/render.rs
@@ -269,9 +269,9 @@ pub(crate) fn render_advice(index: &PoolIndex, tag: u32, dml: bool) -> String {
             kind_name(span.pool_kind),
             backend_name(span.backend),
             if dml {
-                escape_dml(&span.display_tag)
+                escape_dml(&crate::pool::tag_label(span.raw_tag))
             } else {
-                span.display_tag.clone()
+                crate::pool::tag_label(span.raw_tag)
             },
             span.usable_address,
             span.size,

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -52,16 +52,15 @@ fn parse_args(args: &str) -> Result<PoolCommand, String> {
         match tokens[index] {
             "-tag" => {
                 index += 1;
-                let text = tokens
-                    .get(index)
-                    .ok_or_else(|| "-tag requires 1..4 ASCII bytes".to_string())?;
+                let text = tokens.get(index).ok_or_else(|| {
+                    "-tag requires 1..4 ASCII bytes or 0x+8 hex digits".to_string()
+                })?;
                 if tag.is_some() {
                     return Err("-tag may be specified only once".into());
                 }
-                tag = Some(
-                    parse_tag(text)
-                        .ok_or_else(|| "tag must contain 1..4 ASCII bytes".to_string())?,
-                );
+                tag = Some(parse_tag(text).ok_or_else(|| {
+                    "tag must be 1..4 ASCII bytes or 0x+8 hex digits".to_string()
+                })?);
             }
             "-paged" => {
                 if filter.replace(PoolFilter::Paged).is_some() {

--- a/src/pool_extension.rs
+++ b/src/pool_extension.rs
@@ -30,7 +30,7 @@ struct PoolCommand {
 }
 
 fn usage() -> &'static str {
-    "Usage: !win_kexp.poolmap -tag <1..4 ASCII bytes> [-paged|-nonpaged] [-refresh]\n       !win_kexp.poolmap <address> [-refresh]\n"
+    "Usage: !win_kexp.poolmap -tag <1..4 ASCII bytes | 0x + 8 hex digits> [-paged|-nonpaged] [-refresh]\n       !win_kexp.poolmap <address> [-refresh]\n\n       A tag whose bytes do not all print is shown as its raw form (e.g. 0x000180ff);\n       pass that back to -tag. A rendering containing `.` names literal `.` bytes.\n"
 }
 
 fn parse_address(text: &str) -> Option<u64> {
@@ -143,7 +143,7 @@ fn command_poolmap(engine: &DebugEngine, args: &str) -> Result<(), String> {
                     },
                     span.usable_address,
                     span.size,
-                    span.display_tag,
+                    crate::pool::tag_label(span.raw_tag),
                     span.pool_kind,
                     span.backend
                 )


### PR DESCRIPTION
## The bug

`display_tag` maps every unprintable byte to `.` — and a literal `.` to the same thing — so its rendering does not identify a tag. That lossy label was being used as a key:

- a caller reading a tag out of a census and handing it back to `find_tag` gets a **different tag rather than an error**, because `....` is four valid ASCII bytes and parses cleanly;
- a tag with a byte outside ASCII could not be named at all, so the pool's heaviest tag could be one no query could ask for.

On the live kernel this was found against, the two heaviest tags by bytes are both binary and both rendered `....` — so the largest pool consumer was the one thing the API could not be asked about.

## The change

The raw form: `0x` plus the four bytes as hex, **in memory order**, so it reads in the same direction as the rendering and as the debugger's own output (`Tgsm` is `0x5467736d`, not `0x6d736754`).

- `parse_tag` accepts either form. They cannot collide — the raw form is exactly 10 characters and a displayed tag is at most 4 — so `0x2e` still means the four-byte tag it always did.
- `raw_tag_hex` renders it, and `display_is_ambiguous` is the question a consumer has to ask before showing a tag to someone who may hand it back.
- All three are re-exported from `pool`. `raw_tag` was already on `PoolSpan` and `PoolTagSummary`; this makes it usable.

## Tests

- `test_raw_tag_round_trips_where_the_displayed_one_cannot` — pins the collision (a binary tag and a literal `....` render identically, and the rendering resolves to the *wrong* one), and sweeps all 256 values of one byte position through the round trip.
- `test_a_binary_tag_is_found_by_its_bytes_not_by_its_rendering` — end to end through `collect_tag`: the rendering finds the literal dots, the raw form finds the tag that has no other name.

131 tests pass; clippy clean apart from the pre-existing `process.rs` warning.

Consumed by the companion windbg-mcp PR, which surfaces `raw_tag` on `pool_census`/`pool_chunk` and accepts it on `pool_find_tag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)