### PR TITLE
feat(dbgeng): expose the whole register description, not one flag of it

### DIFF
--- a/examples/register_description.rs
+++ b/examples/register_description.rs
@@ -13,6 +13,9 @@
 use win_kexp::dbgeng::DebugEngine;
 
 /// `DEBUG_VALUE_*`, so the `Type` column reads as something.
+///
+/// Note `FLOAT82` at 8, which is easy to leave out and shifts every label above it by one — this
+/// table did, and printed `VECTOR64` as `vector128`.
 fn kind(value: u32) -> &'static str {
     match value {
         1 => "int8",
@@ -22,9 +25,10 @@ fn kind(value: u32) -> &'static str {
         5 => "float32",
         6 => "float64",
         7 => "float80",
-        8 => "float128",
-        9 => "vector64",
-        10 => "vector128",
+        8 => "float82",
+        9 => "float128",
+        10 => "vector64",
+        11 => "vector128",
         other => Box::leak(format!("type{other}").into_boxed_str()),
     }
 }
@@ -87,18 +91,23 @@ fn main() {
         .iter()
         .filter(|d| d.flags & SUB_REGISTER != 0)
         .count();
-    let unflagged_with_master = descriptions
+    // **Not `subreg_master != 0`.** Index 0 is a real register — `rax` on x64, `x0` on ARM64 — and
+    // it is precisely the master the interesting rows would name if they named one, so a test that
+    // treats 0 as "unset" throws away the case it was written to find. What says "the engine filled
+    // nothing in here" is the whole sub-register group being zero.
+    let unflagged_carrying_anything = descriptions
         .iter()
-        .enumerate()
-        .filter(|(index, d)| {
+        .filter(|d| {
             d.flags & SUB_REGISTER == 0
-                && d.subreg_master as usize != *index
-                && d.subreg_master != 0
+                && (d.subreg_master != 0
+                    || d.subreg_length != 0
+                    || d.subreg_shift != 0
+                    || d.subreg_mask != 0)
         })
         .count();
     println!(
-        "\nflagged as sub-registers: {flagged}\nunflagged but naming another master: \
-         {unflagged_with_master}"
+        "\nflagged as sub-registers: {flagged}\nunflagged, with any sub-register field set: \
+         {unflagged_carrying_anything}"
     );
     for name in ["xmm0/0", "w0", "eax"] {
         if let Some(d) = descriptions.iter().find(|d| d.name == name) {

--- a/examples/register_description.rs
+++ b/examples/register_description.rs
@@ -1,0 +1,119 @@
+//! Scratch experiment (not part of the public API): what `DEBUG_REGISTER_DESCRIPTION` actually
+//! says about the registers a caller would want to leave out of a default listing.
+//!
+//! The question it exists to answer. A host filtering "the registers" from "views of them" reaches
+//! for `DEBUG_REGISTER_SUB_REGISTER`, and that flag is clear for two sets of registers that are
+//! views by every other measure: `xmm0/0`…`xmm15/3` on x64 (four int64 pieces of each 128-bit
+//! vector register) and `w0`–`w30` on ARM64 (the 32-bit halves of `x0`–`x30`). Is there anything
+//! else in the description that identifies them — a `SubregMaster` populated even where the flag
+//! is clear, a narrower `SubregLength`, a distinguishing `Type`?
+//!
+//! Run: cargo run --example register_description -- <dump path>
+
+use win_kexp::dbgeng::DebugEngine;
+
+/// `DEBUG_VALUE_*`, so the `Type` column reads as something.
+fn kind(value: u32) -> &'static str {
+    match value {
+        1 => "int8",
+        2 => "int16",
+        3 => "int32",
+        4 => "int64",
+        5 => "float32",
+        6 => "float64",
+        7 => "float80",
+        8 => "float128",
+        9 => "vector64",
+        10 => "vector128",
+        other => Box::leak(format!("type{other}").into_boxed_str()),
+    }
+}
+
+const SUB_REGISTER: u32 = 0x1;
+
+fn main() {
+    let Some(path) = std::env::args().nth(1) else {
+        eprintln!("usage: cargo run --example register_description -- <dump path>");
+        std::process::exit(2);
+    };
+
+    let e = DebugEngine::new();
+    if let Err(why) = e.open_dump(&path) {
+        eprintln!("could not open {path}: {why}");
+        std::process::exit(1);
+    }
+    // `open_dump` commits the session; the engine has no current process or thread until it has
+    // been pumped, and `GetNumberRegisters` answers `0x8000FFFF` until it does.
+    if let Err(why) = e.wait_for_event(60_000) {
+        eprintln!("the dump never settled: {why}");
+        std::process::exit(1);
+    }
+
+    let descriptions = match e.register_descriptions() {
+        Ok(descriptions) => descriptions,
+        Err(why) => {
+            eprintln!("could not describe the registers: {why}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("{} registers\n", descriptions.len());
+    println!(
+        "{:<12} {:>9} {:>7} {:>7} {:>12} {:>7} {:>7}",
+        "name", "kind", "flags", "sub?", "master", "length", "shift"
+    );
+    for description in &descriptions {
+        let flagged = description.flags & SUB_REGISTER != 0;
+        let master = descriptions
+            .get(description.subreg_master as usize)
+            .map(|master| master.name.as_str())
+            .unwrap_or("-");
+        println!(
+            "{:<12} {:>9} {:>#7x} {:>7} {:>12} {:>7} {:>7}",
+            description.name,
+            kind(description.kind),
+            description.flags,
+            if flagged { "yes" } else { "" },
+            // Printed for every register, flagged or not: whether it is *meaningful* where the
+            // flag is clear is the whole question.
+            format!("{}({})", master, description.subreg_master),
+            description.subreg_length,
+            description.subreg_shift,
+        );
+    }
+
+    // The summary that answers the question without reading two hundred rows.
+    let flagged = descriptions
+        .iter()
+        .filter(|d| d.flags & SUB_REGISTER != 0)
+        .count();
+    let unflagged_with_master = descriptions
+        .iter()
+        .enumerate()
+        .filter(|(index, d)| {
+            d.flags & SUB_REGISTER == 0
+                && d.subreg_master as usize != *index
+                && d.subreg_master != 0
+        })
+        .count();
+    println!(
+        "\nflagged as sub-registers: {flagged}\nunflagged but naming another master: \
+         {unflagged_with_master}"
+    );
+    for name in ["xmm0/0", "w0", "eax"] {
+        if let Some(d) = descriptions.iter().find(|d| d.name == name) {
+            let master = descriptions
+                .get(d.subreg_master as usize)
+                .map(|m| m.name.as_str())
+                .unwrap_or("-");
+            println!(
+                "  {name}: flags={:#x} kind={} master={master}({}) length={} shift={}",
+                d.flags,
+                kind(d.kind),
+                d.subreg_master,
+                d.subreg_length,
+                d.subreg_shift
+            );
+        }
+    }
+}

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -342,7 +342,8 @@ pub struct RegisterDescription {
     /// meaningful only when [`Self::flags`] says the register is a sub-register**, which is
     /// exactly the limitation a caller needs to be able to check rather than assume.
     pub subreg_master: u32,
-    /// How many bytes of the master this register covers, under the same condition.
+    /// How many **bits** of the master this register covers, under the same condition — the unit
+    /// is the engine's, and it is the one a reader assumes wrongly: `eax` reports 32.
     pub subreg_length: u32,
     pub subreg_mask: u64,
     pub subreg_shift: u32,

--- a/src/dbgeng.rs
+++ b/src/dbgeng.rs
@@ -322,6 +322,32 @@ impl RegisterValue {
     }
 }
 
+/// What the engine says a register **is**, as distinct from what it currently holds.
+///
+/// [`DebugEngine::register_values`] reports one field of this — [`Register::subregister`], the
+/// `DEBUG_REGISTER_SUB_REGISTER` flag — because that is the one a caller filtering "real
+/// registers" from "views of them" reaches for. This is the whole of
+/// `DEBUG_REGISTER_DESCRIPTION`, for a caller who has found that flag insufficient and needs to
+/// see what else the engine offers: it is clear for `xmm0/0`…`xmm0/3` on x64 and for `w0`–`w30`
+/// on ARM64, both of which are pieces of wider registers by every other measure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisterDescription {
+    /// The engine's own name for it, lowercase.
+    pub name: String,
+    /// The `DEBUG_VALUE_*` type the engine reports this register's value as.
+    pub kind: u32,
+    /// `DEBUG_REGISTER_SUB_REGISTER`, and whatever else this engine sets.
+    pub flags: u32,
+    /// The index of the register this one is a piece of. **The engine documents this as
+    /// meaningful only when [`Self::flags`] says the register is a sub-register**, which is
+    /// exactly the limitation a caller needs to be able to check rather than assume.
+    pub subreg_master: u32,
+    /// How many bytes of the master this register covers, under the same condition.
+    pub subreg_length: u32,
+    pub subreg_mask: u64,
+    pub subreg_shift: u32,
+}
+
 /// One register of the target's context, as [`DebugEngine::register_values`] reports it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Register {
@@ -2171,6 +2197,51 @@ impl DebugEngine {
                 name,
                 value,
                 subregister: description.Flags & DEBUG_REGISTER_SUB_REGISTER != 0,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Every register's **description**, without reading a value for any of them.
+    ///
+    /// The same enumeration [`Self::register_values`] performs, minus the per-register `GetValue`
+    /// — so it is cheap, and it answers a different question: not "what is in this register" but
+    /// "what does the engine say this register is". A caller that wants to know whether `w0` is a
+    /// view of `x0`, or whether `xmm0/0` is a piece of `xmm0`, has to be able to look at
+    /// `SubregMaster` and decide for itself, because the flag beside it does not say so on either
+    /// architecture.
+    ///
+    /// Indexes are positions in this list, which is the engine's own register order — so
+    /// [`RegisterDescription::subreg_master`] indexes the same `Vec` it came from.
+    pub fn register_descriptions(&self) -> Result<Vec<RegisterDescription>, DbgEngError> {
+        let registers: IDebugRegisters =
+            self.client.cast().map_err(|source| DbgEngError::Context {
+                operation: "obtaining the register interface".into(),
+                source,
+            })?;
+        let count =
+            unsafe { registers.GetNumberRegisters() }.map_err(|source| DbgEngError::Context {
+                operation: "counting the target's registers".into(),
+                source,
+            })?;
+        let mut out = Vec::with_capacity(count as usize);
+        for index in 0..count {
+            let mut description = DEBUG_REGISTER_DESCRIPTION::default();
+            let name = read_engine_string(|buffer, size| unsafe {
+                registers.GetDescription(index, buffer, size, Some(&mut description))
+            })
+            .map_err(|source| DbgEngError::Context {
+                operation: format!("describing register {index}"),
+                source,
+            })?;
+            out.push(RegisterDescription {
+                name,
+                kind: description.Type,
+                flags: description.Flags,
+                subreg_master: description.SubregMaster,
+                subreg_length: description.SubregLength,
+                subreg_mask: description.SubregMask,
+                subreg_shift: description.SubregShift,
             });
         }
         Ok(out)


### PR DESCRIPTION
## The question

A host filtering "the registers" from "views of them" reaches for `DEBUG_REGISTER_SUB_REGISTER`,
which `register_values` reports as `Register::subregister`. That flag is clear for two sets of
registers that are views by every other measure:

- **x64** — `xmm0/0` … `xmm15/3`, four 32-bit pieces of each 128-bit vector register (64 rows).
- **ARM64** — `w0`–`w30`, the 32-bit halves of `x0`–`x28`/`fp`/`lr` (31 rows).

Consumers cannot work around that with what the crate exposes today, because the rest of
`DEBUG_REGISTER_DESCRIPTION` is read and discarded.

## What this adds

`register_descriptions()` returns the whole description — `Type`, `Flags`, `SubregMaster`,
`SubregLength`, `SubregMask`, `SubregShift` — so a caller can decide for itself. The value read is
deliberately skipped: this asks what a register *is*, not what it holds, and one `GetValue` per
register is the expensive half of `register_values`.

`examples/register_description.rs` prints it for a dump, so the question has a measured answer
rather than a guess.

## What the answer turned out to be

Asked of this engine build, on both architectures:

| | x64 | ARM64 |
| --- | --- | --- |
| unflagged `int32` rows | `efl`, `mxcsr`, **and all 64 `xmm` slices** | `cpsr`, `spsr`, `fpsr`, `fpcr`, `bcr*`, **and all 31 `w` views** |
| `SubregMaster` where the flag is clear | `0`, every row | `0`, every row |
| where the flag *is* set | master and length populated (`eax`: master `rax`, length 32) | the same, for nine `cpsr` bits |

So `Type` puts a view in the same bucket as a register that is simply narrow — `xmm0/0` beside
`efl`, `w0` beside `cpsr` — and the master field says nothing the flag has not already said. There
is no derived rule to be had from the description.

**That is a finding about this DbgEng rather than a permanent one**, which is the argument for
landing the accessor and the example together rather than deleting both once the question was
answered: the next engine build can be checked in one command instead of re-derived from scratch. If
you would rather not carry API nothing consumes yet, say so and I will close this — the finding is
recorded downstream either way (`windbg-mcp` FOLLOWUPS item 35).

## Verification

On an ARM64 Windows 11 guest: `cargo build`, `cargo test` (**134 passed, 6 ignored**, plus doctests),
`cargo fmt --all --check` clean. `cargo clippy --all-targets -- -D warnings` reports the same four
errors on this branch as on `main` — the pre-existing ARM64-only lints in `shellcode.rs` and
`process.rs` that the x64 CI never reaches — and none of its own. The example was run against both
of `windbg-mcp`'s checked-in kernel dumps, which is where the table above comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
