### PR TITLE
Run Miri where one run per change is enough

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,28 +1,52 @@
 # Miri: Rust undefined behavior detector
 # Runs tests under the Miri interpreter to catch UB, invalid memory access,
 # and unsafe code issues that normal test runs cannot detect.
+#
+# **Not on pull requests**, since 2026-08-22. It is the longest job in this repo by a wide margin —
+# a median of 9 minutes against `ci.yml`'s 1 and `coverage.yml`'s 4 — and running it on the PR *and*
+# on the merge meant paying that twice for every change. It has never failed: 92 successes and 6
+# runs cancelled by the rule below, across the last hundred. So it moves to where one run per change
+# is enough, and stops being the thing a PR waits on.
+#
+# A **path filter** was the first proposal and was measured rather than adopted. Skipping Miri for
+# changes that cannot affect it does not work in this crate: filtering to the obviously-unsafe
+# modules would have to exclude `dbgeng.rs` (23 tests Miri executes) and `pool/**` (81, decoding raw
+# kernel structures out of byte slices), which is the most UB-prone code here; and a filter that
+# keeps everything Miri's run could depend on — `src/**`, `Cargo.*`, `build.rs` — would have skipped
+# 2 of the last 30 merged pull requests. Nearly every change here touches `src/`.
+#
+# What this costs: a UB regression is found on `main` rather than on the branch. That is a small
+# difference in a repo where `main` is not protected and the author merges their own work, and
+# `workflow_dispatch` runs it against a branch when a change is one Miri would have something to say
+# about.
 
 name: Miri
 
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+
+  # The toolchain is the other thing that can turn this red, and it moves on its own: Miri ships
+  # with nightly, and a nightly that tightens a rule finds the same code newly wrong. A weekly run
+  # separates "the code changed" from "the checker changed", which a push-only schedule cannot.
+  schedule:
+    - cron: "0 6 * * 1"
 
   workflow_dispatch:
 
 concurrency:
-  # A superseded push or PR update should cancel its predecessor. Without this every push to a
-  # PR left its predecessor running to completion — five pushes to one PR meant five concurrent
-  # Miri runs, which back when a run took ~28 minutes was most of an hour of runner time nobody
-  # would read. The run is far shorter now, but the reasoning does not depend on the duration.
+  # A superseded push should cancel its predecessor: two merges landing minutes apart otherwise
+  # leave the first still checking code nobody has any more. The rule was written for pull
+  # requests, where five pushes to one PR meant five concurrent Miri runs — most of an hour of
+  # runner time nobody would read, back when a run took ~28 minutes — and it outlives them because
+  # the shape is the same and the reasoning never depended on the duration.
   #
-  # Manual dispatches are deliberately excluded. A dispatch shares `github.ref` with the
-  # branch's own run, so a shared group would have the two cancel each other, and a repeat
-  # dispatch would kill the run someone had just asked for. Keying dispatches by run id gives
-  # each one a group of its own: never cancelled, never cancelling.
-  group: miri-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  # Manual dispatches and scheduled runs are deliberately excluded. Both share `github.ref` with
+  # the branch's own run — `main`, in the scheduled case — so a shared group would have them cancel
+  # each other: a Monday run would kill the merge that happened to land beside it, or be killed by
+  # it, and a repeat dispatch would kill the run someone had just asked for. Keying them by run id
+  # gives each one a group of its own: never cancelled, never cancelling.
+  group: miri-${{ github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.run_id || 'auto' }}
   cancel-in-progress: true
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ The crate is Windows-only in practice: most modules use the `windows` crate dire
 - `cargo fmt --all`: apply Rust formatting.
 - `cargo nextest run --verbose`: preferred test runner and CI path.
 - `cargo test`: standard fallback test runner.
-- `cargo miri test --verbose`: nightly/Miri check used by CI for unsafe-code issues.
+- `cargo miri test --verbose`: nightly/Miri check for unsafe-code issues. CI runs it on merges to `main`, weekly, and on demand — **not on pull requests** (see `.github/workflows/miri.yml`), so run it yourself when a change touches unsafe code.
 - `cargo run --example kdtest -- "<kd connection>"`: run the kernel-debugging smoke test.
 
 Local builds use `ml64` for x86_64 or `armasm64` for ARM64 when available. Without assemblers, `build.rs` enables the shellcode fallback path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ When touching this module, mind the `owns_session` invariant, the stdout-isolati
 Three workflows run on **Windows runners only**:
 - **ci.yml**: fmt check → build → `cargo nextest run` on both `windows-latest` (x64) and `windows-11-arm` (ARM64) with stable Rust
 - **coverage.yml**: grcov + LLVM instrumentation → Codecov upload
-- **miri.yml**: `cargo miri nextest run` on nightly with `MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks"`, plus a `cargo miri test --doc` step for the doctests nextest cannot run
+- **miri.yml**: `cargo miri nextest run` on nightly with `MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks"`, plus a `cargo miri test --doc` step for the doctests nextest cannot run. **It does not run on pull requests** — it is the longest job here by a wide margin (9 minutes median against ci.yml's 1) and had never failed in a hundred runs, so it runs on the merge to `main`, weekly for toolchain drift, and on `workflow_dispatch` for a branch worth checking before it lands. A green PR therefore says nothing about Miri; run it by hand when a change is one Miri would have something to say about. The workflow's own header records why a path filter was measured and rejected
 
 CI installs MASM/ARMASM tooling via `glslang/setup-masm@v1.4` in all three workflows, so assemblers are always available there. Local builds without assemblers silently activate `shellcode_fallback`.
 


### PR DESCRIPTION
Miri is the longest job in this repo by a wide margin, and it ran **twice per change** — once on the
pull request, once on the merge.

| workflow | median | max |
| --- | ---: | ---: |
| `ci.yml` | 1m | 6m |
| `coverage.yml` | 4m | 7m |
| **`miri.yml`** | **9m** | 10m |

Across the last hundred runs it has **never failed**: 92 successes, 6 cancelled by the concurrency
rule, 2 in flight.

## What changes

`push: main` + a weekly schedule + `workflow_dispatch`; no `pull_request`. That halves the runs and
takes the longest job off the PR critical path entirely.

It is **not** deleted, because zero failures is weaker evidence than it looks — equally consistent
with "the unsafe code is careful" and with "the check keeps it careful", and you cannot tell which
from outside. What tips it is the asymmetry: this crate is raw pointer work, UB in it is invisible
to native tests by construction, and the downstream failure is a bugchecked research VM that gets
blamed on the target rather than on the library. Miri is the only thing in this pipeline that can
see it.

The weekly run is not redundant with the push: Miri ships with nightly, and a nightly that tightens
a rule finds the same code newly wrong. The schedule separates *the code changed* from *the checker
changed*, which a push-only trigger cannot.

## A path filter was measured and rejected

It was the first proposal — skip Miri for changes that cannot affect it — and the numbers do not
support it:

| filter | would skip | why not |
| --- | ---: | --- |
| obviously-unsafe modules only | ~50% of PRs | has to exclude `dbgeng.rs` (23 tests Miri executes) and `pool/**` (81, decoding raw kernel structures out of byte slices) — the most UB-prone code here |
| everything Miri's run could depend on (`src/**`, `Cargo.*`, `build.rs`) | **2 of the last 30 merged PRs** | correct, and not worth the machinery |

Nearly every change here touches `src/`. The workflow header carries those numbers so the idea is
not re-proposed by reflex.

## What it costs, said where it will be met

- **A UB regression is found on `main`, not on the branch.** Small in a repo where `main` is not
  protected and the author merges their own work — and `workflow_dispatch` runs it against a branch
  when a change is one Miri would have something to say about.
- **A green PR now says nothing about Miri.** `CLAUDE.md` and `AGENTS.md` say so, and say to
  dispatch it by hand for unsafe-code changes.

The concurrency rationale is rewritten rather than left describing pull requests it no longer sees,
and scheduled runs join dispatches in getting a group of their own — otherwise a Monday run and a
merge landing beside it would cancel each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
